### PR TITLE
[codex] harden superpowers-evals security controls

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Security-sensitive eval harness changes require maintainer review.
+* @arittr

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,3 +41,10 @@ Risk notes:
 
 ## Human review
 - [ ] A maintainer has reviewed the complete proposed diff before merge
+
+## Parent submodule follow-up
+<!-- After this PR merges to main, open a follow-up PR against
+     obra/superpowers targeting dev that bumps the evals submodule pointer
+     to the merged superpowers-evals commit. -->
+
+- [ ] If this PR merges to `main`, a parent `superpowers` submodule bump PR into `dev` will be opened

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+<!--
+BEFORE SUBMITTING: This repo is the Drill eval harness for superpowers.
+It runs agent CLIs in permissive modes and can handle sensitive transcripts.
+Low-evidence, speculative, or bundled PRs will be closed.
+-->
+
+## What problem are you trying to solve?
+<!-- Describe the specific failure, security gap, eval gap, or user-observed behavior.
+     "Hardening" or "improving" is not enough on its own. What broke, leaked,
+     became unsafe, or produced an unreliable eval signal? -->
+
+## What does this PR change?
+<!-- 1-3 sentences. Keep this to the actual files/behavior changed. -->
+
+## Relationship to superpowers
+<!-- Explain how this supports the parent superpowers repo.
+     If this changes skill behavior, harness loading, or eval methodology,
+     describe the expected before/after signal and why it belongs in Drill. -->
+
+## Security and eval-lab checklist
+- [ ] This PR does not commit API keys, `.env` files, session logs, `results/`, or other run artifacts
+- [ ] This PR does not cause CI to run live agent evals, call model APIs, or require `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`
+- [ ] If this touches dangerous-mode backend flags, shell execution, environment inheritance, or log collection, the risk is explained below
+- [ ] If this adds or changes a scenario, setup helper, or assertion command, I considered how untrusted input could affect shell execution
+
+Risk notes:
+<!-- Required for changes touching backends, setup helpers, assertions, session launch, logs, or verifier input. Otherwise write "N/A". -->
+
+## Existing work
+- [ ] I searched for related open and closed PRs/issues/tickets
+- Related work: <!-- links or "none found" -->
+
+## Tests
+<!-- Paste exact commands and outcomes. At minimum, explain whether these ran:
+     uv run ruff check
+     uv run ty check
+     uv run pytest
+
+     Live `drill run ...` sweeps are not required for every PR and must stay out
+     of public CI because they require credentials and permissive agent CLIs. -->
+
+## Human review
+- [ ] A maintainer has reviewed the complete proposed diff before merge

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,49 @@
+name: test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        run: |
+          set -euo pipefail
+          git init "$GITHUB_WORKSPACE/repo"
+          cd "$GITHUB_WORKSPACE/repo"
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git fetch --depth=1 origin "${GITHUB_SHA}"
+          git checkout --detach FETCH_HEAD
+
+      - name: Install uv
+        working-directory: ${{ github.workspace }}/repo
+        run: |
+          set -euo pipefail
+          python3 -m pip install --user uv==0.11.6
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Sync dependencies
+        working-directory: ${{ github.workspace }}/repo
+        run: uv sync --extra dev --locked
+
+      - name: Ruff
+        working-directory: ${{ github.workspace }}/repo
+        run: uv run ruff check
+
+      - name: Type check
+        working-directory: ${{ github.workspace }}/repo
+        run: uv run ty check
+
+      - name: Pytest
+        working-directory: ${{ github.workspace }}/repo
+        run: uv run pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: local
+    hooks:
+      - id: ruff-check
+        name: ruff check
+        entry: uv run ruff check
+        language: system
+        pass_filenames: false
+      - id: ty-check
+        name: ty check
+        entry: uv run ty check
+        language: system
+        pass_filenames: false
+      - id: pytest
+        name: pytest
+        entry: uv run pytest
+        language: system
+        pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# Drill
+
+Superpowers skill compliance benchmark. Python 3.11+, managed with uv.
+
+## Commands
+
+- **install**: `uv sync --extra dev`
+- **test**: `uv run pytest`
+- **test single**: `uv run pytest tests/test_engine.py -x -q`
+- **lint**: `uv run ruff check`
+- **format**: `uv run ruff format`
+- **typecheck**: `uv run ty check`
+- **run scenario**: `uv run drill run <scenario> -b <backend>`
+- **sweep**: `uv run drill run <scenario> --models Codex-opus-4-6,Codex-opus-4-7 --n 10`
+- **compare**: `uv run drill compare <scenario>`
+- **list**: `uv run drill list`
+
+## Architecture
+
+- `drill/engine.py` — Tmux session orchestration. Creates workdir, runs setup helpers, drives actor/agent turns, collects results.
+- `drill/actor.py` — Sonnet 4.6 LLM simulating a user. Reads turn intents from scenario YAML and generates realistic prompts.
+- `drill/verifier.py` — Sonnet 4.6 LLM evaluating session transcript + filesystem against semantic criteria.
+- `drill/assertions.py` — Deterministic post-session checks. Runs shell commands from `verify.assertions` in the results dir.
+- `drill/sweep.py` — Multi-backend, N-repetition orchestrator. Wraps Engine with try/except per run, writes run-group.json manifest.
+- `drill/compare.py` — Loads results, computes pass rates and Wilson CIs, formats comparison tables.
+- `drill/stats.py` — Wilson score confidence interval for pass rate estimation at small N.
+- `scenarios/*.yaml` — Scenario definitions (setup, turns, limits, verify).
+- `setup_helpers/*.py` — Repo fixture creators. Each creates a git repo with specific conditions.
+- `backends/*.yaml` — Per-backend CLI config (args, env, idle patterns, shutdown commands).
+- `bin/` — Assertion helper scripts: `tool-called`, `tool-not-called`, `tool-count`, `tool-before`, `tool-arg-match`. Run against `tool_calls.jsonl` in results dir.
+
+## Conventions
+
+- Setup helpers take `workdir: Path` and mutate the filesystem. Register in `setup_helpers/__init__.py`.
+- Scenarios use `user_posture: naive` (no skill names) or `spec-aware` (can name skills).
+- Verify criteria are semantic (LLM-evaluated). Verify assertions are deterministic (exit code 0 = pass).
+- Assertions run in the results dir with `$DRILL_WORKDIR` pointing to the scenario workdir and `bin/` on PATH.
+- Backend YAMLs are fully self-contained — no override/alias system.
+
+## Required env
+
+```
+ANTHROPIC_API_KEY=sk-...
+```
+
+`SUPERPOWERS_ROOT` defaults to the parent of `evals/` (the superpowers repo root). Override only if running drill against a different superpowers checkout.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,16 @@ Superpowers skill compliance benchmark. Python 3.11+, managed with uv.
 - Assertions run in the results dir with `$DRILL_WORKDIR` pointing to the scenario workdir and `bin/` on PATH.
 - Backend YAMLs are fully self-contained — no override/alias system.
 
+## Parent Superpowers Submodule
+
+`superpowers-evals` is consumed by `superpowers` as the `evals` submodule.
+After any PR merges to `main` here, open a follow-up PR against the parent
+`superpowers` repo targeting `dev` that bumps the `evals` submodule pointer
+to the merged `superpowers-evals` commit.
+
+Do not treat a `superpowers-evals` merge as fully propagated until that parent
+submodule bump PR exists.
+
 ## Required env
 
 ```

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ uv sync --extra dev
 
 Optional git hooks:
 ```bash
-uv --project evals run pre-commit install
-uv --project evals run pre-commit run --all-files
+uv run pre-commit install
+uv run pre-commit run --all-files
 ```
 
 Required environment:

--- a/README.md
+++ b/README.md
@@ -218,5 +218,15 @@ This repo inherits the quality bar of `superpowers`.
   input.
 - Changes to behavior-shaping eval methodology need evidence, not just prose.
 
+## Parent Submodule Bump
+
+`superpowers-evals` is consumed by `superpowers` as the `evals` submodule.
+After any PR merges to `main` in this repository, open a follow-up PR against
+the parent `superpowers` repo targeting `dev` that bumps the `evals` submodule
+pointer to the merged `superpowers-evals` commit.
+
+Do not treat a `superpowers-evals` merge as fully propagated until that parent
+submodule bump PR exists.
+
 Security reporting details live in [SECURITY.md](SECURITY.md). The broader
 design is documented in [docs/design.md](docs/design.md).

--- a/README.md
+++ b/README.md
@@ -1,114 +1,222 @@
 # Drill
 
-Superpowers skill compliance benchmark. Drives AI coding agents through
-tmux sessions and evaluates whether they follow superpowers workflows
-correctly.
+Drill is the behavioral eval harness for
+[superpowers](https://github.com/obra/superpowers). It drives real coding-agent
+CLIs through tmux sessions and checks whether they invoke and follow
+superpowers skills correctly.
 
-## How it works
+This is not a generic benchmark suite. Drill is an eval lab for workflow
+compliance: skill triggering, worktree behavior, subagent coordination,
+verification reflexes, review quality, and cost-shaping patterns.
 
-1. **Setup** — a helper creates a git repo with specific conditions (worktree state, plan files, code fixtures)
-2. **Actor** — a Sonnet 4.6 LLM plays the user, following turn intents from the scenario YAML
-3. **Agent** — the backend under test (Claude Code, Codex, Gemini CLI) runs in a real tmux session
-4. **Verifier** — a Sonnet 4.6 LLM evaluates the session transcript + filesystem against criteria
-5. **Assertions** — deterministic checks (tool-called, tool-count, shell commands) run post-session
+## Safety Model
+
+Drill has two very different execution modes:
+
+- **Static/unit checks** are safe for public CI. These run `ruff`, `ty`, and
+  `pytest`. They do not call model APIs and do not launch agent CLIs.
+- **Live evals** are trusted-maintainer operations. They can launch Claude
+  Code, Codex CLI, or Gemini CLI in permissive modes and may collect raw
+  transcripts, tool calls, filesystem state, and local session logs.
+
+Public CI must stay on the static/unit side of that line. Do not add API keys,
+live `drill run ...` sweeps, or dangerous-mode agent launches to public CI.
+
+## Live Eval Risk
+
+Live evals intentionally run the backend under test with broad execution power:
+
+- Claude backends use `--dangerously-skip-permissions`
+- Codex uses `--dangerously-bypass-approvals-and-sandbox`
+- Gemini uses `--yolo`
+
+Those subprocesses can currently inherit the parent shell environment and may
+use the caller's normal home-directory config/log locations. In practice, that
+means a live eval can see exported credentials, local agent configuration, and
+other process environment state unless the runner starts it from a deliberately
+clean shell.
+
+Until per-run environment isolation is implemented, run live evals only from a
+trusted local environment:
+
+- Export only the API key needed for the selected backend.
+- Avoid running with broad production or personal secrets in the environment.
+- Treat `results/`, raw session logs, and verifier inputs as sensitive.
+- Do not commit or paste raw run artifacts without checking them first.
+
+## How Drill Works
+
+1. **Setup** creates a temporary git repo with scenario-specific conditions.
+2. **Actor** uses Sonnet to simulate a realistic user from the scenario turns.
+3. **Agent** runs the backend under test in a tmux session.
+4. **Collection** captures terminal output, filesystem state, and tool calls.
+5. **Verifier** uses Sonnet to judge the transcript against semantic criteria.
+6. **Assertions** run deterministic post-session checks against result artifacts.
+
+Results are written under `results/<scenario>/<backend>/<timestamp>/`, which is
+gitignored because those artifacts can contain sensitive transcripts.
 
 ## Setup
+
+Install Python dependencies:
 
 ```bash
 uv sync --extra dev
 ```
 
-Optional git hooks:
+Optional local hooks:
+
 ```bash
 uv run pre-commit install
 uv run pre-commit run --all-files
 ```
 
-Required environment:
+## Safe Checks
+
+These are the checks expected in CI and on routine PRs:
+
 ```bash
-export ANTHROPIC_API_KEY=sk-...
+uv run ruff check
+uv run ty check
+uv run pytest
 ```
 
-`SUPERPOWERS_ROOT` defaults to the parent of `evals/` (the superpowers repo root) and only needs to be set if you're running drill against a different superpowers checkout.
+## Live Eval Prerequisites
 
-## Usage
+Live evals require the relevant backend CLI and credentials.
+
+| Backend family | CLI | Required environment |
+| --- | --- | --- |
+| Claude | `claude` | `ANTHROPIC_API_KEY`, `SUPERPOWERS_ROOT` |
+| Codex | `codex` | `OPENAI_API_KEY` |
+| Gemini | `gemini` | local Gemini CLI auth/config |
+
+`SUPERPOWERS_ROOT` defaults to the parent directory of this checkout. That is
+correct when Drill is checked out as `superpowers/evals`. In a standalone
+`superpowers-evals` clone, set it explicitly:
 
 ```bash
-# Run a single scenario on a single backend
+export SUPERPOWERS_ROOT=/path/to/superpowers
+```
+
+Use a different `SUPERPOWERS_ROOT` when running RED/GREEN comparisons against
+modified superpowers skill text.
+
+## Running Live Evals
+
+Run one scenario on one backend:
+
+```bash
 uv run drill run worktree-creation-from-main -b claude
+```
 
-# Run with N repetitions
+Run repeated trials:
+
+```bash
 uv run drill run spec-writing-blind-spot -b claude-opus-4-6 --n 5
+```
 
-# Sweep across multiple backends
-uv run drill run spec-writing-blind-spot --models claude-opus-4-6,claude-opus-4-7 --n 10
+Sweep across backend variants:
 
-# Compare results
+```bash
+uv run drill run spec-writing-blind-spot \
+  --models claude-opus-4-6,claude-opus-4-7 \
+  --n 10
+```
+
+Compare results:
+
+```bash
 uv run drill compare spec-writing-blind-spot
+```
 
-# List available scenarios
+List scenarios:
+
+```bash
 uv run drill list
 ```
 
-## Scenarios
-
-| Category | Scenarios | Tests |
-|----------|-----------|-------|
-| Worktree | 11 scenarios | Worktree creation, detection, consent, detached HEAD, and native-tool pressure |
-| Skill triggering | 6 scenarios | Auto-invocation for core Superpowers skills |
-| SDD workflow | 5 scenarios | Explicit invocation, mid-conversation invocation, real-project execution, and YAGNI enforcement |
-| Review/spec/verification | 6 scenarios | Code review, spec review, architectural targeting, design blind spots, and verification reflexes |
-| Tool mapping | 3 scenarios | Codex and Gemini subagent tool-name mapping |
-| Cost baselines | 4 scenarios | Token cost, tool-result bloat, duplicated artifacts, and disproportionate review fanout |
-
 ## Backends
 
-| Backend | CLI | Model |
-|---------|-----|-------|
-| `claude` | Claude Code | opus-4-7 (default) |
+Backend configs live in `backends/*.yaml`. They are intentionally
+self-contained: command args, required env vars, hooks, idle detection,
+terminal size, shutdown behavior, and log locations all live in the backend
+file.
+
+Current backend families:
+
+| Backend | CLI | Model / variant |
+| --- | --- | --- |
+| `claude` | Claude Code | opus default |
 | `claude-opus-4-6` | Claude Code | opus-4-6 |
 | `claude-opus-4-7` | Claude Code | opus-4-7 |
-| `claude-opus-4-6-1m` | Claude Code | opus-4-6 (1M context) |
-| `claude-opus-4-7-1m` | Claude Code | opus-4-7 (1M context) |
-| `codex` | Codex CLI | — |
+| `claude-opus-4-6-1m` | Claude Code | opus-4-6, 1M context |
+| `claude-opus-4-7-1m` | Claude Code | opus-4-7, 1M context |
+| `codex` | Codex CLI | local configured model |
 | `gemini` | Gemini CLI | auto-gemini-3 |
 | `gemini-2-5-flash` | Gemini CLI | gemini-2.5-flash |
 
-## Project structure
+## Scenarios
 
+Scenario files live in `scenarios/*.yaml`. They define setup helpers, user turn
+intents, limits, verifier criteria, and deterministic assertions.
+
+| Category | Current coverage |
+| --- | --- |
+| Worktree | creation, detection, consent, detached HEAD, native-tool pressure |
+| Skill triggering | core superpowers skill auto-invocation |
+| SDD workflow | explicit invocation, mid-conversation invocation, real projects, YAGNI |
+| Review/spec/verification | code review, spec review, targeting, blind spots, verification reflexes |
+| Tool mapping | Codex and Gemini subagent/tool-name mapping |
+| Cost baselines | token cost, tool-result bloat, duplicated artifacts, review fanout |
+
+## Writing a Scenario
+
+1. Add a setup helper in `setup_helpers/` if the scenario needs a custom repo
+   fixture.
+2. Register the helper in `setup_helpers/__init__.py`.
+3. Add `scenarios/<scenario>.yaml` with setup, turns, limits, and verify
+   sections.
+4. Run the scenario locally against at least one backend.
+
+Setup helpers take `workdir: Path` and mutate the temporary scenario repo.
+Assertions run in the results directory with `$DRILL_WORKDIR` pointing to the
+scenario workdir and `bin/` on `PATH`.
+
+## Project Map
+
+```text
+drill/              core engine and CLI
+  actor.py          user-simulator LLM
+  assertions.py     deterministic post-session assertions
+  backend.py        backend config loader and command builder
+  cli.py            `drill run`, `drill compare`, `drill list`
+  engine.py         tmux orchestration and run lifecycle
+  normalizer.py     backend log normalization
+  session.py        tmux session wrapper
+  sweep.py          multi-backend, repeated-run orchestration
+  verifier.py       LLM verifier
+backends/           backend YAML configs
+bin/                assertion helper scripts
+docs/               design notes and manual testing protocols
+fixtures/           static repo fixtures
+prompts/            actor/verifier prompts
+scenarios/          scenario YAML files
+setup_helpers/      scenario fixture builders
+tests/              pytest suite
 ```
-drill/              # Core engine
-  cli.py            # Click CLI (run, compare, list)
-  engine.py         # Tmux session orchestration
-  actor.py          # User-simulator LLM
-  verifier.py       # Criteria evaluator LLM
-  assertions.py     # Deterministic post-session assertions
-  compare.py        # Result loading and cross-backend comparison
-  sweep.py          # Multi-backend N-rep orchestrator
-  stats.py          # Wilson score confidence intervals
-scenarios/          # YAML scenario definitions
-setup_helpers/      # Repo fixture creators
-backends/           # Per-backend YAML configs
-bin/                # Assertion helper scripts (tool-called, tool-count, etc.)
-prompts/            # Actor and verifier system prompts
-fixtures/           # Static template repos
-tests/              # pytest suite (174 tests)
-docs/               # Design spec and manual testing guide
-```
 
-## Tests
+## Contribution Rules
 
-```bash
-uv run pytest
-uv run ruff check
-uv run ty check
-```
+This repo inherits the quality bar of `superpowers`.
 
-## Writing a new scenario
+- One problem per PR.
+- Do not commit generated run artifacts or secrets.
+- Do not add live evals to public CI.
+- Use the PR template and explain the security/eval-lab risk for changes that
+  touch backends, shell execution, setup helpers, assertions, logs, or verifier
+  input.
+- Changes to behavior-shaping eval methodology need evidence, not just prose.
 
-1. Create a setup helper in `setup_helpers/` if you need a custom fixture
-2. Register it in `setup_helpers/__init__.py`
-3. Create `scenarios/your-scenario.yaml` with setup, turns, limits, and verify sections
-4. Run it: `uv run drill run your-scenario -b claude`
-
-See [docs/design.md](docs/design.md) for the full design spec.
+Security reporting details live in [SECURITY.md](SECURITY.md). The broader
+design is documented in [docs/design.md](docs/design.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+Drill is a security-sensitive eval harness. It can launch real agent CLIs in
+permissive modes, collect transcripts, read local session logs, and send run
+artifacts to an LLM verifier.
+
+## Reporting a Vulnerability
+
+Do not file public issues or pull requests containing exploitable details,
+tokens, session logs with secrets, or private filesystem paths.
+
+Report security issues privately through GitHub private vulnerability reporting
+when available. If that is not available, contact a Prime Radiant maintainer
+privately and share only the minimum detail needed to reproduce the issue.
+
+## Sensitive Data
+
+Never commit:
+
+- `.env` files or API keys
+- `results/` output
+- raw `session.log`, `tool_calls.jsonl`, `filesystem.json`, `verdict.json`, or
+  `meta.json` from real runs
+- local agent config directories such as `.claude/`, `.codex/`, or `.gemini/`
+
+If a real run prints or captures a secret, rotate the secret before sharing any
+artifact derived from that run.
+
+## CI Boundary
+
+Public CI must run only static/unit checks. Live `drill run ...` evals require
+credentials and permissive agent CLIs, so they belong in trusted local or
+maintainer-controlled environments only.

--- a/drill/session.py
+++ b/drill/session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 import subprocess
 import time
 
@@ -29,8 +30,8 @@ class TmuxSession:
         )
 
     def launch(self, command: list[str], cwd: str) -> None:
-        cmd_str = " ".join(command)
-        self.send_keys(f"cd {cwd} && {cmd_str}")
+        cmd_str = shlex.join(command)
+        self.send_keys(f"cd {shlex.quote(cwd)} && {cmd_str}")
 
     def send_keys(self, text: str) -> None:
         if text:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -78,6 +78,21 @@ class TestTmuxSession:
         finally:
             session.kill()
 
+    def test_launch_shell_quotes_cwd_and_command_args(self):
+        session = TmuxSession(name="drill-test-launch-quoting")
+
+        with patch.object(session, "send_keys") as send_keys:
+            session.launch(
+                ["python3", "-c", "print('hello; rm -rf nope')"],
+                cwd="/tmp/drill path/with spaces",
+            )
+
+        expected = (
+            "cd '/tmp/drill path/with spaces' && python3 -c "
+            "'print('\"'\"'hello; rm -rf nope'\"'\"')'"
+        )
+        send_keys.assert_called_once_with(expected)
+
     def test_send_special_key(self, tmp_path):
         session = TmuxSession(name="drill-test-special", cols=80, rows=24)
         proof_file = tmp_path / "after-ctrl-c"


### PR DESCRIPTION
## What problem are you trying to solve?

`superpowers-evals` is now a public subdependency of `superpowers` and runs Drill, an eval harness that can launch real agent CLIs in permissive modes and handle sensitive transcripts. It needed repo-level guardrails comparable to the parent repo plus a concrete command-launch hardening fix.

## What does this PR change?

Adds governance/security surfaces (`AGENTS.md`, PR template, CODEOWNERS, SECURITY.md, pre-commit config, safe CI workflow), fixes README pre-commit commands for the standalone checkout, and quotes tmux-launched backend commands with `shlex`.

## Relationship to superpowers

This supports `superpowers` by making its Drill eval harness safer to maintain as a public dependency. It does not change skill behavior or eval methodology.

## Security and eval-lab checklist

- [x] This PR does not commit API keys, `.env` files, session logs, `results/`, or other run artifacts
- [x] This PR does not cause CI to run live agent evals, call model APIs, or require `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`
- [x] If this touches dangerous-mode backend flags, shell execution, environment inheritance, or log collection, the risk is explained below
- [x] If this adds or changes a scenario, setup helper, or assertion command, I considered how untrusted input could affect shell execution

Risk notes:

This touches shell execution in `TmuxSession.launch()`. Before this change, the tmux launch command concatenated `cwd` and argv with spaces, so paths or args containing shell metacharacters could be interpreted by the shell. The fix uses `shlex.quote()` for cwd and `shlex.join()` for argv, with regression coverage.

## Existing work

- [x] I searched for related open and closed PRs/issues/tickets
- Related work: Linear PRI-1591

## Tests

- `uv run ruff check` - passed
- `uv run ty check` - passed
- `uv run pytest` - 175 passed
- `uv run pre-commit run --all-files` - passed
- `.github/workflows/test.yml` parsed with PyYAML
- `pip-audit --no-deps --disable-pip --skip-editable` over exported pinned deps - no known vulnerabilities found

Live `drill run ...` was intentionally not run for this PR because public CI and this guardrail pass should not invoke model APIs or dangerous-mode agent CLIs.

## Human review

- [ ] A maintainer has reviewed the complete proposed diff before merge


## Parent submodule follow-up

After this PR merges to `main`, open a follow-up PR against `obra/superpowers` targeting `dev` that bumps the `evals` submodule pointer to the merged `superpowers-evals` commit.
