### PR TITLE
Add Pi backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Drill has two very different execution modes:
 - **Static/unit checks** are safe for public CI. These run `ruff`, `ty`, and
   `pytest`. They do not call model APIs and do not launch agent CLIs.
 - **Live evals** are trusted-maintainer operations. They can launch Claude
-  Code, Codex CLI, or Gemini CLI in permissive modes and may collect raw
+  Code, Codex CLI, Gemini CLI, or Pi in permissive modes and may collect raw
   transcripts, tool calls, filesystem state, and local session logs.
 
 Public CI must stay on the static/unit side of that line. Do not add API keys,
@@ -29,6 +29,7 @@ Live evals intentionally run the backend under test with broad execution power:
 - Claude backends use `--dangerously-skip-permissions`
 - Codex uses `--dangerously-bypass-approvals-and-sandbox`
 - Gemini uses `--yolo`
+- Pi loads the local Superpowers package with `-e ${SUPERPOWERS_ROOT}`
 
 Those subprocesses can currently inherit the parent shell environment and may
 use the caller's normal home-directory config/log locations. In practice, that
@@ -90,6 +91,7 @@ Live evals require the relevant backend CLI and credentials.
 | Claude | `claude` | `ANTHROPIC_API_KEY`, `SUPERPOWERS_ROOT` |
 | Codex | `codex` | `OPENAI_API_KEY` |
 | Gemini | `gemini` | local Gemini CLI auth/config |
+| Pi | `pi` | `SUPERPOWERS_ROOT` |
 
 `SUPERPOWERS_ROOT` defaults to the parent directory of this checkout. That is
 correct when Drill is checked out as `superpowers/evals`. In a standalone
@@ -122,6 +124,12 @@ Sweep across backend variants:
 uv run drill run spec-writing-blind-spot \
   --models claude-opus-4-6,claude-opus-4-7 \
   --n 10
+```
+
+Run against Pi, loading the local Superpowers package from `SUPERPOWERS_ROOT`:
+
+```bash
+uv run drill run triggering-writing-plans -b pi
 ```
 
 Compare results:

--- a/backends/pi.yaml
+++ b/backends/pi.yaml
@@ -1,0 +1,23 @@
+name: pi
+cli: pi
+args:
+  - "-e"
+  - "${SUPERPOWERS_ROOT}"
+required_env:
+  - SUPERPOWERS_ROOT
+hooks:
+  pre_run: []
+  post_run: []
+shutdown: "/quit"
+idle:
+  quiescence_seconds: 5
+  ready_pattern: "."
+busy_pattern: "esc to cancel|Thinking\\.\\.\\.|\\(esc to cancel[^)]*\\)|[⠇⠏⠋⠙⠹⠸⠼⠴⠦⠧⠶⠾⠽⠻⠿]"
+max_busy_seconds: 1800
+startup_timeout: 60
+turn_timeout: 300
+terminal:
+  cols: 200
+  rows: 50
+session_logs:
+  pattern: "~/.pi/agent/sessions/**/*.jsonl"

--- a/drill/backend.py
+++ b/drill/backend.py
@@ -71,7 +71,7 @@ class Backend:
     @property
     def family(self) -> str:
         """Normalize backend name to a family for log-dir / normalizer dispatch."""
-        for fam in ("claude", "codex", "gemini"):
+        for fam in ("claude", "codex", "gemini", "pi"):
             if self.name == fam or self.name.startswith(f"{fam}-"):
                 return fam
         return "other"

--- a/drill/engine.py
+++ b/drill/engine.py
@@ -21,6 +21,7 @@ from drill.normalizer import (
     NORMALIZERS,
     collect_new_logs,
     filter_codex_logs_by_cwd,
+    filter_pi_logs_by_cwd,
     snapshot_log_dir,
 )
 from drill.session import TmuxSession
@@ -357,6 +358,11 @@ class Engine:
             # Project name is the workdir basename, lowercased
             project = workdir.resolve().name.lower()
             return Path.home() / ".gemini" / "tmp" / project
+        elif self.backend.family == "pi":
+            # Pi stores sessions under ~/.pi/agent/sessions/<encoded-cwd>/.
+            # Filter by the session header cwd because multiple evals may run
+            # concurrently under the same tree.
+            return Path.home() / ".pi" / "agent" / "sessions"
         pattern = self.backend.session_logs.get("pattern", "")
         if not pattern:
             return None
@@ -373,6 +379,8 @@ class Engine:
         new_files = collect_new_logs(log_dir, snapshot)
         if self.backend.family == "codex":
             new_files = filter_codex_logs_by_cwd(new_files, str(workdir.resolve()))
+        elif self.backend.family == "pi":
+            new_files = filter_pi_logs_by_cwd(new_files, str(workdir.resolve()))
         return new_files
 
     def _normalize_tool_calls(self, new_files: list[Path]) -> list[dict[str, Any]]:

--- a/drill/normalizer.py
+++ b/drill/normalizer.py
@@ -74,6 +74,23 @@ def filter_codex_logs_by_cwd(paths: list[Path], target_cwd: str) -> list[Path]:
     return matched
 
 
+def filter_pi_logs_by_cwd(paths: list[Path], target_cwd: str) -> list[Path]:
+    """Drop Pi sessions whose header cwd doesn't match target_cwd."""
+    matched: list[Path] = []
+    for path in paths:
+        try:
+            with path.open() as f:
+                first_line = f.readline()
+            entry = json.loads(first_line)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if entry.get("type") != "session":
+            continue
+        if entry.get("cwd") == target_cwd:
+            matched.append(path)
+    return matched
+
+
 def normalize_claude_logs(raw_content: str) -> list[dict[str, Any]]:
     """Normalize Claude Code session logs.
 
@@ -155,6 +172,56 @@ def normalize_codex_logs(raw_content: str) -> list[dict[str, Any]]:
     return results
 
 
+# Reverse mapping: Pi tool names -> Claude Code canonical names
+PI_TOOL_MAP: dict[str, str] = {
+    "read": "Read",
+    "write": "Write",
+    "edit": "Edit",
+    "bash": "Bash",
+    "grep": "Grep",
+    "find": "Glob",
+    "ls": "Glob",
+}
+
+
+PI_NATIVE_TOOLS = (set(PI_TOOL_MAP.values()) - {"Bash"}) | {
+    "subagent",
+    "todo",
+    "manage_todo_list",
+}
+
+
+def normalize_pi_logs(raw_content: str) -> list[dict[str, Any]]:
+    """Normalize Pi JSONL session logs.
+
+    Pi session files are JSONL entries. Assistant messages contain tool calls as
+    content blocks: {"type": "toolCall", "name": "read", "arguments": {...}}.
+    """
+    results: list[dict[str, Any]] = []
+    for line in raw_content.strip().split("\n"):
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if entry.get("type") != "message":
+            continue
+        message = entry.get("message", {})
+        if message.get("role") != "assistant":
+            continue
+        for block in message.get("content", []):
+            if block.get("type") != "toolCall":
+                continue
+            name = block.get("name", "")
+            canonical = PI_TOOL_MAP.get(name, name)
+            source = "native" if canonical in PI_NATIVE_TOOLS else "shell"
+            results.append(
+                {"tool": canonical, "args": block.get("arguments", {}), "source": source}
+            )
+    return results
+
+
 # Reverse mapping: Gemini tool names → Claude Code canonical names
 GEMINI_TOOL_MAP: dict[str, str] = {
     "run_shell_command": "Bash",
@@ -225,4 +292,5 @@ NORMALIZERS: dict[str, Callable[[str], list[dict[str, Any]]]] = {
     "claude": normalize_claude_logs,
     "codex": normalize_codex_logs,
     "gemini": normalize_gemini_logs,
+    "pi": normalize_pi_logs,
 }

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -44,6 +44,12 @@ class TestLoadBackend:
         assert flash_backend.family == "gemini"
         assert flash_backend.model == "gemini-2.5-flash"
 
+    def test_loads_pi_backend(self, backends_dir):
+        backend = load_backend("pi", backends_dir)
+        assert backend.name == "pi"
+        assert backend.cli == "pi"
+        assert backend.family == "pi"
+
 
 class TestBackendBuildCommand:
     def test_claude_build_command(self, backends_dir, monkeypatch):
@@ -59,6 +65,12 @@ class TestBackendBuildCommand:
         backend = load_backend("codex", backends_dir)
         cmd = backend.build_command("/tmp/workdir")
         assert cmd[0] == "codex"
+
+    def test_pi_build_command_loads_local_superpowers_package(self, backends_dir, monkeypatch):
+        monkeypatch.setenv("SUPERPOWERS_ROOT", "/tmp/superpowers")
+        backend = load_backend("pi", backends_dir)
+        cmd = backend.build_command("/tmp/workdir")
+        assert cmd == ["pi", "-e", "/tmp/superpowers"]
 
 
 class TestBackendEnvValidation:
@@ -124,6 +136,21 @@ class TestBackendFamily:
     def test_codex_backend_family(self, backends_dir):
         backend = load_backend("codex", backends_dir)
         assert backend.family == "codex"
+
+    def test_pi_backend_family(self):
+        backend = Backend(
+            name="pi",
+            cli="pi",
+            args=[],
+            required_env=[],
+            hooks={"pre_run": [], "post_run": []},
+            shutdown="/quit",
+            idle={},
+            startup_timeout=30,
+            terminal={},
+            session_logs={},
+        )
+        assert backend.family == "pi"
 
     def test_variant_name_preserves_family(self):
         backend = Backend(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -4,7 +4,7 @@ import json
 import subprocess
 from pathlib import Path
 
-from drill.engine import RunResult, ScenarioConfig, VerifyConfig, snapshot_filesystem
+from drill.engine import Engine, RunResult, ScenarioConfig, VerifyConfig, snapshot_filesystem
 
 
 class TestVerifyConfig:
@@ -136,6 +136,40 @@ class TestEngineAssertionIntegration:
         result.save_verdict(tmp_path)
         assert (tmp_path / "verdict.json").exists()
         assert (tmp_path / "meta.json").exists()
+
+
+class TestEnginePiBackend:
+    def test_resolves_pi_session_log_root(self, tmp_path: Path) -> None:
+        scenario = tmp_path / "scenario.yaml"
+        scenario.write_text("scenario: test-pi\n")
+        backends = tmp_path / "backends"
+        backends.mkdir()
+        (backends / "pi.yaml").write_text(
+            """
+name: pi
+cli: pi
+args: []
+required_env: []
+hooks:
+  pre_run: []
+  post_run: []
+shutdown: /quit
+idle: {}
+startup_timeout: 1
+terminal: {}
+session_logs:
+  pattern: ~/.pi/agent/sessions/**/*.jsonl
+"""
+        )
+        engine = Engine(
+            scenario_path=scenario,
+            backend_name="pi",
+            backends_dir=backends,
+            fixtures_dir=tmp_path,
+            results_dir=tmp_path,
+        )
+
+        assert engine._resolve_log_dir(tmp_path) == Path.home() / ".pi" / "agent" / "sessions"
 
 
 class TestEngineRunParams:

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -3,9 +3,11 @@ import json
 from drill.normalizer import (
     collect_new_logs,
     filter_codex_logs_by_cwd,
+    filter_pi_logs_by_cwd,
     normalize_claude_logs,
     normalize_codex_logs,
     normalize_gemini_logs,
+    normalize_pi_logs,
     snapshot_log_dir,
 )
 
@@ -135,6 +137,56 @@ class TestNormalizeCodexLogs:
         assert normalized[0]["source"] == "shell"
         assert normalized[1]["tool"] == "Edit"
         assert normalized[1]["source"] == "native"
+
+
+class TestNormalizePiLogs:
+    def test_filter_by_cwd_keeps_matching_session_headers(self, tmp_path):
+        target = "/tmp/drill-target"
+        match = tmp_path / "match.jsonl"
+        match.write_text(json.dumps({"type": "session", "cwd": target}) + "\n")
+        other = tmp_path / "other.jsonl"
+        other.write_text(json.dumps({"type": "session", "cwd": "/tmp/other"}) + "\n")
+        malformed = tmp_path / "malformed.jsonl"
+        malformed.write_text("not json\n")
+
+        assert filter_pi_logs_by_cwd([match, other, malformed], target) == [match]
+
+    def test_normalizes_assistant_tool_calls_from_session_entries(self):
+        lines = [
+            json.dumps({"type": "session", "cwd": "/tmp/project"}),
+            json.dumps(
+                {
+                    "type": "message",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "text", "text": "I will inspect this."},
+                            {
+                                "type": "toolCall",
+                                "name": "read",
+                                "arguments": {"path": "README.md"},
+                            },
+                            {
+                                "type": "toolCall",
+                                "name": "bash",
+                                "arguments": {"command": "git status"},
+                            },
+                            {
+                                "type": "toolCall",
+                                "name": "subagent",
+                                "arguments": {"agent": "reviewer"},
+                            },
+                        ],
+                    },
+                }
+            ),
+        ]
+
+        assert normalize_pi_logs("\n".join(lines)) == [
+            {"tool": "Read", "args": {"path": "README.md"}, "source": "native"},
+            {"tool": "Bash", "args": {"command": "git status"}, "source": "shell"},
+            {"tool": "subagent", "args": {"agent": "reviewer"}, "source": "native"},
+        ]
 
 
 class TestNormalizeGeminiLogs:


### PR DESCRIPTION
## What problem are you trying to solve?

The parent `obra/superpowers#1499` adds first-class Pi package support, but the eval harness had no Pi backend for running or attributing Drill sessions. Without that backend, the parent integration could test its package extension locally, but Drill could not launch Pi with the local Superpowers package or normalize Pi session logs into the common tool-call schema.

## What does this PR change?

Adds a `pi` backend config, teaches Drill to classify Pi as its own backend family, resolves Pi session logs under `~/.pi/agent/sessions`, filters Pi logs by the session header `cwd`, and normalizes Pi `toolCall` content blocks to the shared tool-call schema. It also documents Pi live-eval usage and adds unit coverage for backend loading, command construction, log filtering, log normalization, and log-root resolution.

## Relationship to superpowers

This supports `obra/superpowers#1499`, which adds the Pi extension and points the parent `evals` submodule at this commit. Before this change, the parent PR had to carry these eval/drill edits inline; after the eval harness split, they belong in `superpowers-evals` and the parent PR should only bump the submodule pointer.

## Security and eval-lab checklist
- [x] This PR does not commit API keys, `.env` files, session logs, `results/`, or other run artifacts
- [x] This PR does not cause CI to run live agent evals, call model APIs, or require `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`
- [x] If this touches dangerous-mode backend flags, shell execution, environment inheritance, or log collection, the risk is explained below
- [x] If this adds or changes a scenario, setup helper, or assertion command, I considered how untrusted input could affect shell execution

Risk notes:

This adds a live backend config and log collection support. It does not add CI live runs or new shell assertion commands. The Pi backend launches `pi -e ${SUPERPOWERS_ROOT}` for trusted local eval use, and log attribution filters candidate Pi session files by the session header `cwd` so concurrent runs under the shared Pi session tree do not get mixed together. Raw Pi session logs and Drill results should still be treated as sensitive local artifacts.

## Existing work
- [x] I searched for related open and closed PRs/issues/tickets
- Related work: `obra/superpowers#1499`, `PRI-1599`

No existing `prime-radiant-inc/superpowers-evals` PRs or issues for Pi backend support were found.

## Tests

```bash
uv run ruff check
# All checks passed!

uv run ty check
# All checks passed!

uv run pytest
# 181 passed in 6.88s
```

I did not run a live `drill run ... -b pi` sweep in this pass; live runs require a trusted local Pi environment and should stay out of public CI.

## Human review
- [ ] A maintainer has reviewed the complete proposed diff before merge

## Parent submodule follow-up

- [x] If this PR merges to `main`, a parent `superpowers` submodule bump PR into `dev` will be opened

Parent follow-up: `obra/superpowers#1499` now references this PR and points its `evals` submodule at this branch commit.
