### PR TITLE
[codex] add Codex native hook Drill coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Live evals require the relevant backend CLI and credentials.
 | Backend family | CLI | Required environment |
 | --- | --- | --- |
 | Claude | `claude` | `ANTHROPIC_API_KEY`, `SUPERPOWERS_ROOT` |
-| Codex | `codex` | `OPENAI_API_KEY` |
+| Codex | `codex` | `OPENAI_API_KEY`, `SUPERPOWERS_ROOT` |
 | Gemini | `gemini` | local Gemini CLI auth/config |
 | Pi | `pi` | `SUPERPOWERS_ROOT` |
 
@@ -136,7 +136,7 @@ Verify Codex native plugin hooks bootstrap Superpowers from an isolated
 `CODEX_HOME`:
 
 ```bash
-uv run drill run codex-native-hooks-bootstrap -b codex-plugin-hooks
+uv run drill run codex-native-hooks-bootstrap -b codex
 ```
 
 Compare results:
@@ -167,8 +167,8 @@ Current backend families:
 | `claude-opus-4-7` | Claude Code | opus-4-7 |
 | `claude-opus-4-6-1m` | Claude Code | opus-4-6, 1M context |
 | `claude-opus-4-7-1m` | Claude Code | opus-4-7, 1M context |
-| `codex` | Codex CLI | local configured model |
-| `codex-plugin-hooks` | Codex CLI with native plugin hooks in isolated `CODEX_HOME` | local configured model |
+| `codex` | Codex CLI with native plugin hooks in isolated `CODEX_HOME` | local configured model |
+| `codex-no-hooks` | Codex CLI with legacy `.agents` symlink setup | local configured model |
 | `gemini` | Gemini CLI | auto-gemini-3 |
 | `gemini-2-5-flash` | Gemini CLI | gemini-2.5-flash |
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,13 @@ Run against Pi, loading the local Superpowers package from `SUPERPOWERS_ROOT`:
 uv run drill run triggering-writing-plans -b pi
 ```
 
+Verify Codex native plugin hooks bootstrap Superpowers from an isolated
+`CODEX_HOME`:
+
+```bash
+uv run drill run codex-native-hooks-bootstrap -b codex-plugin-hooks
+```
+
 Compare results:
 
 ```bash
@@ -161,6 +168,7 @@ Current backend families:
 | `claude-opus-4-6-1m` | Claude Code | opus-4-6, 1M context |
 | `claude-opus-4-7-1m` | Claude Code | opus-4-7, 1M context |
 | `codex` | Codex CLI | local configured model |
+| `codex-plugin-hooks` | Codex CLI with native plugin hooks in isolated `CODEX_HOME` | local configured model |
 | `gemini` | Gemini CLI | auto-gemini-3 |
 | `gemini-2-5-flash` | Gemini CLI | gemini-2.5-flash |
 
@@ -177,6 +185,7 @@ intents, limits, verifier criteria, and deterministic assertions.
 | Review/spec/verification | code review, spec review, targeting, blind spots, verification reflexes |
 | Tool mapping | Codex and Gemini subagent/tool-name mapping |
 | Cost baselines | token cost, tool-result bloat, duplicated artifacts, review fanout |
+| Harness bootstrap | Codex native plugin hook startup behavior |
 
 ## Writing a Scenario
 

--- a/backends/codex-no-hooks.yaml
+++ b/backends/codex-no-hooks.yaml
@@ -1,15 +1,13 @@
-name: codex-plugin-hooks
-cli: env
+name: codex-no-hooks
+cli: codex
 args:
-  - "CODEX_HOME=${DRILL_CODEX_HOME}"
-  - codex
   - "--dangerously-bypass-approvals-and-sandbox"
 required_env:
   - OPENAI_API_KEY
   - SUPERPOWERS_ROOT
 hooks:
   pre_run:
-    - install_codex_superpowers_plugin_hooks
+    - symlink_superpowers
   post_run: []
 shutdown: "<<KEY:ctrl-d>>"
 idle:

--- a/backends/codex-plugin-hooks.yaml
+++ b/backends/codex-plugin-hooks.yaml
@@ -1,0 +1,23 @@
+name: codex-plugin-hooks
+cli: env
+args:
+  - "CODEX_HOME=${DRILL_CODEX_HOME}"
+  - codex
+  - "--dangerously-bypass-approvals-and-sandbox"
+required_env:
+  - OPENAI_API_KEY
+  - SUPERPOWERS_ROOT
+hooks:
+  pre_run:
+    - install_codex_superpowers_plugin_hooks
+  post_run: []
+shutdown: "<<KEY:ctrl-d>>"
+idle:
+  quiescence_seconds: 5
+  ready_pattern: "^›|codex>|^>"
+startup_timeout: 60
+terminal:
+  cols: 200
+  rows: 50
+session_logs:
+  pattern: "~/.codex/sessions/rollout-*.jsonl"

--- a/backends/codex.yaml
+++ b/backends/codex.yaml
@@ -1,12 +1,15 @@
 name: codex
-cli: codex
+cli: env
 args:
+  - "CODEX_HOME=${DRILL_CODEX_HOME}"
+  - codex
   - "--dangerously-bypass-approvals-and-sandbox"
 required_env:
   - OPENAI_API_KEY
+  - SUPERPOWERS_ROOT
 hooks:
   pre_run:
-    - symlink_superpowers
+    - install_codex_superpowers_plugin_hooks
   post_run: []
 shutdown: "<<KEY:ctrl-d>>"
 idle:

--- a/bin/codex-native-hook-configured
+++ b/bin/codex-native-hook-configured
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Verify the Codex native-hooks backend used an isolated trusted plugin hook.
+set -euo pipefail
+
+fail() {
+    echo "FAIL: $*"
+    exit 1
+}
+
+pass() {
+    echo "PASS: Codex native Superpowers hook configured"
+    exit 0
+}
+
+test -n "${DRILL_CODEX_HOME:-}" || fail "DRILL_CODEX_HOME is not set"
+test -n "${DRILL_WORKDIR:-}" || fail "DRILL_WORKDIR is not set"
+
+CONFIG="$DRILL_CODEX_HOME/config.toml"
+PLUGIN="$DRILL_CODEX_HOME/plugins/cache/debug/superpowers/local"
+
+test -f "$CONFIG" || fail "missing Codex config at $CONFIG"
+test -f "$PLUGIN/.codex-plugin/plugin.json" || fail "missing staged Codex plugin manifest"
+test -f "$PLUGIN/hooks/hooks-codex.json" || fail "missing staged Codex hook manifest"
+test ! -e "$DRILL_WORKDIR/.agents/skills/superpowers" || fail "legacy .agents skill symlink exists"
+
+grep -Fq "plugin_hooks = true" "$CONFIG" || fail "plugin_hooks feature not enabled"
+grep -Fq '[plugins."superpowers@debug"]' "$CONFIG" || fail "debug Superpowers plugin not enabled"
+grep -Fq '[hooks.state."superpowers@debug:hooks/hooks-codex.json:session_start:0:0"]' \
+    "$CONFIG" || fail "Superpowers Codex hook trust state missing"
+grep -Eq 'trusted_hash = "sha256:[a-f0-9]+"' "$CONFIG" || fail "trusted hook hash missing"
+
+pass

--- a/bin/skill-called
+++ b/bin/skill-called
@@ -10,6 +10,7 @@ set -euo pipefail
 command -v jq >/dev/null || { echo "jq required"; exit 127; }
 
 SKILL_NAME="$1"
+SKILL_DIR="${SKILL_NAME##*:}"
 FILE="tool_calls.jsonl"
 
 if [ ! -s "$FILE" ]; then
@@ -18,8 +19,18 @@ if [ ! -s "$FILE" ]; then
 fi
 
 COUNT=$(
-    jq -s --arg name "$SKILL_NAME" \
-        '[.[] | select(.tool == "Skill" and (.args.skill // "") == $name)] | length' \
+    jq -s --arg name "$SKILL_NAME" --arg dir "$SKILL_DIR" \
+        '[.[] | select(
+            (.tool == "Skill" and (.args.skill // "") == $name)
+            or (
+                ((.tool // "") | test("^(Bash|Shell|LocalShellCall)$"))
+                and (
+                    ((.args.command // .args.cmd // "") | test(
+                        "(^|[[:space:]'\''\"/])skills/(superpowers/)?" + $dir + "/SKILL[.]md([[:space:]'\''\";]|$)"
+                    ))
+                )
+            )
+        )] | length' \
         "$FILE"
 )
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -133,15 +133,17 @@ session_logs:
 ```yaml
 # backends/codex.yaml
 name: codex
-cli: codex
+cli: env
 args:
+  - "CODEX_HOME=${DRILL_CODEX_HOME}"
+  - codex
   - "--dangerously-bypass-approvals-and-sandbox"
 required_env:
   - OPENAI_API_KEY
   - SUPERPOWERS_ROOT
 hooks:
   pre_run:
-    - symlink_superpowers   # creates .agents/skills/superpowers symlink in test repo
+    - install_codex_superpowers_plugin_hooks
   post_run: []
 shutdown: "<<KEY:ctrl-d>>"
 idle:
@@ -156,7 +158,10 @@ session_logs:
   match_by: timestamp
 ```
 
-New backends = new YAML file. Backend variants (e.g., `codex-workspace-write.yaml`) are just copies with different args — no inheritance system needed. Scenarios reference backends by name.
+`codex-no-hooks.yaml` keeps the legacy `.agents/skills/superpowers` symlink
+path available as an explicit fallback. New backends = new YAML file. Backend
+variants (e.g., `codex-workspace-write.yaml`) are just copies with different
+args — no inheritance system needed. Scenarios reference backends by name.
 
 ## Scenario Format
 
@@ -230,7 +235,8 @@ Python functions in `setup_helpers/` that modify the cloned repo for specific sc
 - `create_base_repo(workdir)` — Clone template, verify structure
 - `add_worktree(workdir, branch, path)` — Create an existing worktree (for "already inside" scenarios)
 - `detach_head(workdir)` — Simulate Codex App detached HEAD state
-- `symlink_superpowers(workdir)` — Create `.agents/skills/superpowers` symlink (codex pre_run hook)
+- `install_codex_superpowers_plugin_hooks(workdir)` — Stage Superpowers as a Codex plugin in an isolated `CODEX_HOME` and trust that run's hook
+- `symlink_superpowers(workdir)` — Create `.agents/skills/superpowers` symlink (codex-no-hooks fallback pre_run hook)
 
 ### Setup Assertions
 
@@ -243,7 +249,8 @@ Each backend loads superpowers differently. The harness manages this per-run wit
 | Backend | Mechanism | Harness action |
 |---------|-----------|----------------|
 | Claude Code | `--plugin-dir` CLI flag | Pass flag pointing at superpowers checkout |
-| Codex | `.agents/skills/` in repo | Backend pre_run hook creates symlink |
+| Codex | Native plugin hooks in isolated `CODEX_HOME` | Backend pre_run hook stages plugin and trusted hook config |
+| Codex no-hooks fallback | `.agents/skills/` in repo | Backend pre_run hook creates symlink |
 
 This means Drill can test draft skill changes by pointing at a branch checkout of superpowers.
 

--- a/drill/engine.py
+++ b/drill/engine.py
@@ -132,6 +132,7 @@ class Engine:
     def run(self, *, output_dir: Path | None = None, run_suffix: str = "") -> RunResult:
         start_time = time.time()
         timestamp = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+        os.environ.pop("DRILL_CODEX_HOME", None)
         self.backend.validate_env()
         workdir = Path(f"/tmp/drill-{self.scenario.scenario}-{timestamp}{run_suffix}")
         self._setup(workdir)
@@ -234,7 +235,11 @@ class Engine:
         helpers = self.scenario.setup.get("helpers", [])
         run_helpers(helpers, workdir, self.fixtures_dir)
         # Backend pre_run hooks after (e.g., codex symlink needs workdir to exist)
-        hooks_needing_superpowers_root = {"symlink_superpowers", "link_gemini_extension"}
+        hooks_needing_superpowers_root = {
+            "install_codex_superpowers_plugin_hooks",
+            "link_gemini_extension",
+            "symlink_superpowers",
+        }
         for hook_name in self.backend.hooks.get("pre_run", []):
             from setup_helpers import HELPER_REGISTRY
 
@@ -352,6 +357,9 @@ class Engine:
             return log_dir
         elif self.backend.family == "codex":
             # Codex stores at ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl
+            codex_home = os.environ.get("DRILL_CODEX_HOME") or os.environ.get("CODEX_HOME")
+            if codex_home:
+                return Path(codex_home) / "sessions"
             return Path.home() / ".codex" / "sessions"
         elif self.backend.family == "gemini":
             # Gemini stores at ~/.gemini/tmp/<project-name>/chats/session-*.json

--- a/scenarios/codex-native-hooks-bootstrap.yaml
+++ b/scenarios/codex-native-hooks-bootstrap.yaml
@@ -1,0 +1,47 @@
+scenario: codex-native-hooks-bootstrap
+description: >
+  Verifies that Codex native plugin hooks bootstrap Superpowers without the
+  legacy .agents symlink workaround. This should be run with the
+  codex-plugin-hooks backend, which stages Superpowers as a Codex plugin in an
+  isolated CODEX_HOME and trusts only that run's SessionStart hook.
+user_posture: naive
+
+setup:
+  helpers:
+    - create_base_repo
+  assertions:
+    - "git rev-parse --is-inside-work-tree"
+    - "git branch --show-current | grep -q main"
+    - "test ! -e .agents/skills/superpowers"
+
+turns:
+  - intent: >
+      When Codex is at its input prompt, type this exact message and press
+      Enter:
+
+      "Let's make a react todo list"
+
+      Do NOT mention Superpowers, hooks, skills, brainstorming, planning, or
+      tests. The point is to see whether startup context makes the agent invoke
+      the right workflow on its own.
+  - intent: >
+      Once the agent has loaded a skill, started brainstorming, or started
+      writing tests/code, you are done - use the "done" action. The goal is to
+      test startup bootstrap, not to drive the todo app implementation.
+
+limits:
+  max_turns: 4
+  turn_timeout: 180
+
+verify:
+  assertions:
+    - "codex-native-hook-configured"
+    - "skill-called superpowers:brainstorming"
+  criteria:
+    - >
+      Codex ran with the Superpowers native plugin hook configured and trusted
+      in an isolated CODEX_HOME, not through the legacy .agents skill symlink.
+    - >
+      Agent loaded superpowers:brainstorming in response to the naive React todo
+      request before writing implementation code.
+  observe: true

--- a/scenarios/codex-native-hooks-bootstrap.yaml
+++ b/scenarios/codex-native-hooks-bootstrap.yaml
@@ -2,8 +2,8 @@ scenario: codex-native-hooks-bootstrap
 description: >
   Verifies that Codex native plugin hooks bootstrap Superpowers without the
   legacy .agents symlink workaround. This should be run with the
-  codex-plugin-hooks backend, which stages Superpowers as a Codex plugin in an
-  isolated CODEX_HOME and trusts only that run's SessionStart hook.
+  codex backend, which stages Superpowers as a Codex plugin in an isolated
+  CODEX_HOME and trusts only that run's SessionStart hook.
 user_posture: naive
 
 setup:

--- a/scenarios/codex-subagent-wait-mapping.yaml
+++ b/scenarios/codex-subagent-wait-mapping.yaml
@@ -1,7 +1,9 @@
 scenario: codex-subagent-wait-mapping
 description: >
   Measures whether a Codex agent follows Superpowers' Codex tool mapping
-  when translating Claude Code Task subagent result collection.
+  when translating Claude Code Task subagent result collection. This fixture
+  reads the legacy .agents symlink path and should be run with the
+  codex-no-hooks fallback backend.
 user_posture: spec-aware
 
 setup:

--- a/scenarios/codex-tool-mapping-comprehension.yaml
+++ b/scenarios/codex-tool-mapping-comprehension.yaml
@@ -1,7 +1,9 @@
 scenario: codex-tool-mapping-comprehension
 description: >
   Measures whether a Codex agent correctly reports the Superpowers Codex
-  mapping for Claude Code Task result collection.
+  mapping for Claude Code Task result collection. This fixture reads the
+  legacy .agents symlink path and should be run with the codex-no-hooks
+  fallback backend.
 user_posture: spec-aware
 
 setup:

--- a/setup_helpers/__init__.py
+++ b/setup_helpers/__init__.py
@@ -21,6 +21,7 @@ from setup_helpers.worktree import (
     create_caller_consent_plan,
     detach_head,
     detach_worktree_head,
+    install_codex_superpowers_plugin_hooks,
     link_gemini_extension,
     symlink_superpowers,
 )
@@ -31,6 +32,7 @@ HELPER_REGISTRY = {
     "add_worktree": add_worktree,
     "detach_head": detach_head,
     "symlink_superpowers": symlink_superpowers,
+    "install_codex_superpowers_plugin_hooks": install_codex_superpowers_plugin_hooks,
     "add_existing_worktree": add_existing_worktree,
     "detach_worktree_head": detach_worktree_head,
     "link_gemini_extension": link_gemini_extension,

--- a/setup_helpers/worktree.py
+++ b/setup_helpers/worktree.py
@@ -120,6 +120,7 @@ def install_codex_superpowers_plugin_hooks(workdir: Path, superpowers_root: str)
 
     config_path = codex_home / "config.toml"
     _write_codex_plugin_hooks_config(config_path)
+    _login_codex_home_with_api_key(codex_home)
     hook = _read_codex_superpowers_hook(codex_home, workdir)
     _append_codex_trusted_hook(config_path, hook["key"], hook["currentHash"])
     os.environ["DRILL_CODEX_HOME"] = str(codex_home)
@@ -152,6 +153,21 @@ plugin_hooks = true
 [plugins."superpowers@debug"]
 enabled = true
 """
+    )
+
+
+def _login_codex_home_with_api_key(codex_home: Path) -> None:
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise OSError("OPENAI_API_KEY is required to log in the isolated Codex home")
+
+    subprocess.run(
+        ["codex", "login", "--with-api-key"],
+        input=f"{api_key}\n",
+        text=True,
+        capture_output=True,
+        check=True,
+        env={**os.environ, "CODEX_HOME": str(codex_home)},
     )
 
 

--- a/setup_helpers/worktree.py
+++ b/setup_helpers/worktree.py
@@ -223,6 +223,10 @@ def _read_codex_superpowers_hook(codex_home: Path, workdir: Path) -> dict[str, s
     finally:
         _terminate_codex_app_server(proc)
 
+    return _select_codex_superpowers_hook(response)
+
+
+def _select_codex_superpowers_hook(response: dict[str, Any]) -> dict[str, str]:
     hooks = [
         hook
         for entry in response.get("result", {}).get("data", [])
@@ -237,8 +241,12 @@ def _read_codex_superpowers_hook(codex_home: Path, workdir: Path) -> dict[str, s
     hook = hooks[0]
     if hook.get("matcher") != "startup|resume|clear":
         raise RuntimeError(f"Unexpected Superpowers Codex hook matcher: {hook.get('matcher')}")
-    if "hooks/run-hook.cmd" not in (hook.get("command") or ""):
-        raise RuntimeError(f"Unexpected Superpowers Codex hook command: {hook.get('command')}")
+    command = hook.get("command") or ""
+    if "hooks/run-hook.cmd" not in command or "session-start-codex" not in command:
+        raise RuntimeError(
+            "Unexpected Superpowers Codex hook command "
+            f"(expected run-hook.cmd session-start-codex): {hook.get('command')}"
+        )
     if hook.get("trustStatus") not in {"untrusted", "trusted"}:
         raise RuntimeError(
             f"Unexpected Superpowers Codex hook trust status: {hook.get('trustStatus')}"

--- a/setup_helpers/worktree.py
+++ b/setup_helpers/worktree.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 import json
+import os
+import selectors
+import shutil
 import subprocess
+import time
 from contextlib import suppress
 from pathlib import Path
+from typing import Any, TextIO, cast
 
 from setup_helpers.base import _git
 
@@ -93,6 +98,201 @@ def symlink_superpowers(workdir: Path, superpowers_root: str) -> None:
     target = Path(superpowers_root) / "skills"
     link = skills_dir / "superpowers"
     link.symlink_to(target)
+
+
+def install_codex_superpowers_plugin_hooks(workdir: Path, superpowers_root: str) -> None:
+    """Install Superpowers as a trusted Codex plugin hook in an isolated home.
+
+    This is for Drill automation only. User installs still go through Codex's
+    interactive /hooks trust UI.
+    """
+    codex_home = workdir.parent / f"{workdir.name}-codex-home"
+    plugin_root = codex_home / "plugins" / "cache" / "debug" / "superpowers" / "local"
+
+    if codex_home.exists():
+        shutil.rmtree(codex_home)
+    plugin_root.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(
+        superpowers_root,
+        plugin_root,
+        ignore=_ignore_codex_plugin_copy,
+    )
+
+    config_path = codex_home / "config.toml"
+    _write_codex_plugin_hooks_config(config_path)
+    hook = _read_codex_superpowers_hook(codex_home, workdir)
+    _append_codex_trusted_hook(config_path, hook["key"], hook["currentHash"])
+    os.environ["DRILL_CODEX_HOME"] = str(codex_home)
+
+
+def _ignore_codex_plugin_copy(src: str, names: list[str]) -> set[str]:
+    ignored = {
+        ".git",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".ty",
+        ".venv",
+        "__pycache__",
+        "node_modules",
+    }
+    if Path(src).name == "evals":
+        ignored.add("results")
+    return ignored.intersection(names)
+
+
+def _write_codex_plugin_hooks_config(config_path: Path) -> None:
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        """[features]
+plugins = true
+hooks = true
+plugin_hooks = true
+
+[plugins."superpowers@debug"]
+enabled = true
+"""
+    )
+
+
+def _append_codex_trusted_hook(config_path: Path, key: str, current_hash: str) -> None:
+    config_path.write_text(
+        config_path.read_text()
+        + "\n"
+        + f'[hooks.state."{_toml_basic_string(key)}"]\n'
+        + f'trusted_hash = "{_toml_basic_string(current_hash)}"\n'
+    )
+
+
+def _toml_basic_string(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _read_codex_superpowers_hook(codex_home: Path, workdir: Path) -> dict[str, str]:
+    env = {**os.environ, "CODEX_HOME": str(codex_home)}
+    proc = subprocess.Popen(
+        ["codex", "app-server", "--listen", "stdio://"],
+        cwd=workdir,
+        env=env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+    )
+    try:
+        _send_codex_app_server_request(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "clientInfo": {"name": "drill", "version": "0.0.0"},
+                    "capabilities": {"experimentalApi": True},
+                },
+            },
+        )
+        _read_codex_app_server_response(proc, 1)
+        _send_codex_app_server_request(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "hooks/list",
+                "params": {"cwds": [str(workdir)]},
+            },
+        )
+        response = _read_codex_app_server_response(proc, 2)
+    finally:
+        _terminate_codex_app_server(proc)
+
+    hooks = [
+        hook
+        for entry in response.get("result", {}).get("data", [])
+        for hook in entry.get("hooks", [])
+        if hook.get("pluginId") == "superpowers@debug"
+        and hook.get("source") == "plugin"
+        and hook.get("eventName") == "sessionStart"
+    ]
+    if len(hooks) != 1:
+        raise RuntimeError(f"Expected one Superpowers Codex SessionStart hook, found {len(hooks)}")
+
+    hook = hooks[0]
+    if hook.get("matcher") != "startup|resume|clear":
+        raise RuntimeError(f"Unexpected Superpowers Codex hook matcher: {hook.get('matcher')}")
+    if "hooks/run-hook.cmd" not in (hook.get("command") or ""):
+        raise RuntimeError(f"Unexpected Superpowers Codex hook command: {hook.get('command')}")
+    if hook.get("trustStatus") not in {"untrusted", "trusted"}:
+        raise RuntimeError(
+            f"Unexpected Superpowers Codex hook trust status: {hook.get('trustStatus')}"
+        )
+    key = hook.get("key")
+    current_hash = hook.get("currentHash")
+    if not key or not current_hash:
+        raise RuntimeError("Superpowers Codex hook is missing key or currentHash")
+
+    return {"key": key, "currentHash": current_hash}
+
+
+def _send_codex_app_server_request(proc: subprocess.Popen[str], request: dict[str, Any]) -> None:
+    if proc.stdin is None:
+        raise RuntimeError("Codex app-server stdin is unavailable")
+    proc.stdin.write(json.dumps(request, separators=(",", ":")) + "\n")
+    proc.stdin.flush()
+
+
+def _read_codex_app_server_response(
+    proc: subprocess.Popen[str],
+    request_id: int,
+    timeout_seconds: float = 15,
+) -> dict[str, Any]:
+    if proc.stdout is None or proc.stderr is None:
+        raise RuntimeError("Codex app-server pipes are unavailable")
+
+    selector = selectors.DefaultSelector()
+    selector.register(proc.stdout, selectors.EVENT_READ, "stdout")
+    selector.register(proc.stderr, selectors.EVENT_READ, "stderr")
+    stderr_lines: list[str] = []
+    deadline = time.monotonic() + timeout_seconds
+    try:
+        while time.monotonic() < deadline:
+            remaining = max(0.1, deadline - time.monotonic())
+            for key, _ in selector.select(timeout=min(0.5, remaining)):
+                stream = cast(TextIO, key.fileobj)
+                line = stream.readline()
+                if not line:
+                    continue
+                if key.data == "stderr":
+                    stderr_lines.append(line)
+                    continue
+                with suppress(json.JSONDecodeError):
+                    message = json.loads(line)
+                    if message.get("id") == request_id:
+                        if "error" in message:
+                            raise RuntimeError(
+                                f"Codex app-server request failed: {message['error']}"
+                            )
+                        return message
+            if proc.poll() is not None:
+                break
+    finally:
+        selector.close()
+
+    stderr = "".join(stderr_lines).strip()
+    detail = f": {stderr}" if stderr else ""
+    raise RuntimeError(f"Timed out waiting for Codex app-server response {request_id}{detail}")
+
+
+def _terminate_codex_app_server(proc: subprocess.Popen[str]) -> None:
+    if proc.poll() is not None:
+        return
+    proc.terminate()
+    with suppress(subprocess.TimeoutExpired):
+        proc.wait(timeout=3)
+        return
+    proc.kill()
+    proc.wait(timeout=3)
 
 
 def link_gemini_extension(workdir: Path, superpowers_root: str) -> None:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -22,6 +22,13 @@ class TestLoadBackend:
         assert backend.name == "codex"
         assert backend.cli == "codex"
 
+    def test_loads_codex_plugin_hooks_backend(self, backends_dir):
+        backend = load_backend("codex-plugin-hooks", backends_dir)
+        assert backend.name == "codex-plugin-hooks"
+        assert backend.cli == "env"
+        assert backend.family == "codex"
+        assert "install_codex_superpowers_plugin_hooks" in backend.hooks["pre_run"]
+
     def test_unknown_backend_raises(self, backends_dir):
         with pytest.raises(FileNotFoundError):
             load_backend("nonexistent", backends_dir)
@@ -65,6 +72,15 @@ class TestBackendBuildCommand:
         backend = load_backend("codex", backends_dir)
         cmd = backend.build_command("/tmp/workdir")
         assert cmd[0] == "codex"
+
+    def test_codex_plugin_hooks_build_command_uses_isolated_home(
+        self, backends_dir, monkeypatch
+    ):
+        monkeypatch.setenv("DRILL_CODEX_HOME", "/tmp/drill-codex-home")
+        backend = load_backend("codex-plugin-hooks", backends_dir)
+        cmd = backend.build_command("/tmp/workdir")
+        assert cmd[:3] == ["env", "CODEX_HOME=/tmp/drill-codex-home", "codex"]
+        assert "--dangerously-bypass-approvals-and-sandbox" in cmd
 
     def test_pi_build_command_loads_local_superpowers_package(self, backends_dir, monkeypatch):
         monkeypatch.setenv("SUPERPOWERS_ROOT", "/tmp/superpowers")

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -20,14 +20,17 @@ class TestLoadBackend:
     def test_loads_codex_backend(self, backends_dir):
         backend = load_backend("codex", backends_dir)
         assert backend.name == "codex"
-        assert backend.cli == "codex"
-
-    def test_loads_codex_plugin_hooks_backend(self, backends_dir):
-        backend = load_backend("codex-plugin-hooks", backends_dir)
-        assert backend.name == "codex-plugin-hooks"
         assert backend.cli == "env"
         assert backend.family == "codex"
         assert "install_codex_superpowers_plugin_hooks" in backend.hooks["pre_run"]
+
+    def test_loads_codex_no_hooks_backend(self, backends_dir):
+        backend = load_backend("codex-no-hooks", backends_dir)
+        assert backend.name == "codex-no-hooks"
+        assert backend.cli == "codex"
+        assert backend.family == "codex"
+        assert "SUPERPOWERS_ROOT" in backend.required_env
+        assert "symlink_superpowers" in backend.hooks["pre_run"]
 
     def test_unknown_backend_raises(self, backends_dir):
         with pytest.raises(FileNotFoundError):
@@ -69,17 +72,19 @@ class TestBackendBuildCommand:
 
     def test_codex_build_command(self, backends_dir, monkeypatch):
         monkeypatch.setenv("SUPERPOWERS_ROOT", "/tmp/superpowers")
+        monkeypatch.setenv("DRILL_CODEX_HOME", "/tmp/drill-codex-home")
         backend = load_backend("codex", backends_dir)
         cmd = backend.build_command("/tmp/workdir")
-        assert cmd[0] == "codex"
+        assert cmd[:3] == ["env", "CODEX_HOME=/tmp/drill-codex-home", "codex"]
+        assert "--dangerously-bypass-approvals-and-sandbox" in cmd
 
-    def test_codex_plugin_hooks_build_command_uses_isolated_home(
+    def test_codex_no_hooks_build_command_uses_standard_codex_cli(
         self, backends_dir, monkeypatch
     ):
-        monkeypatch.setenv("DRILL_CODEX_HOME", "/tmp/drill-codex-home")
-        backend = load_backend("codex-plugin-hooks", backends_dir)
+        monkeypatch.setenv("SUPERPOWERS_ROOT", "/tmp/superpowers")
+        backend = load_backend("codex-no-hooks", backends_dir)
         cmd = backend.build_command("/tmp/workdir")
-        assert cmd[:3] == ["env", "CODEX_HOME=/tmp/drill-codex-home", "codex"]
+        assert cmd[0] == "codex"
         assert "--dangerously-bypass-approvals-and-sandbox" in cmd
 
     def test_pi_build_command_loads_local_superpowers_package(self, backends_dir, monkeypatch):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -99,7 +99,7 @@ class TestEngineLogDirs:
     def test_codex_uses_drill_codex_home_for_session_logs(self, tmp_path, monkeypatch):
         engine = object.__new__(Engine)
         engine.backend = Backend(
-            name="codex-plugin-hooks",
+            name="codex",
             cli="env",
             args=[],
             required_env=[],

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -4,6 +4,7 @@ import json
 import subprocess
 from pathlib import Path
 
+from drill.backend import Backend
 from drill.engine import Engine, RunResult, ScenarioConfig, VerifyConfig, snapshot_filesystem
 
 
@@ -92,6 +93,27 @@ class TestSnapshotFilesystem:
         assert "branch" in data
         assert "worktree_list" in data
         assert "files" in data
+
+
+class TestEngineLogDirs:
+    def test_codex_uses_drill_codex_home_for_session_logs(self, tmp_path, monkeypatch):
+        engine = object.__new__(Engine)
+        engine.backend = Backend(
+            name="codex-plugin-hooks",
+            cli="env",
+            args=[],
+            required_env=[],
+            hooks={"pre_run": []},
+            shutdown="<<KEY:ctrl-d>>",
+            idle={},
+            startup_timeout=30,
+            terminal={},
+            session_logs={},
+        )
+        codex_home = tmp_path / "codex-home"
+        monkeypatch.setenv("DRILL_CODEX_HOME", str(codex_home))
+
+        assert engine._resolve_log_dir(tmp_path / "workdir") == codex_home / "sessions"
 
 
 class TestRunResult:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 from pathlib import Path
 
@@ -48,6 +49,32 @@ class TestToolNotCalled:
         (tmp_path / "tool_calls.jsonl").write_text("")
         result = run_helper("tool-not-called", ["Read"], tmp_path)
         assert result.returncode == 0
+
+
+class TestSkillCalled:
+    def test_native_skill_tool_present(self, tmp_path):
+        (tmp_path / "tool_calls.jsonl").write_text(
+            '{"tool":"Skill","args":{"skill":"superpowers:brainstorming"}}\n'
+        )
+        result = run_helper("skill-called", ["superpowers:brainstorming"], tmp_path)
+        assert result.returncode == 0
+
+    def test_codex_skill_file_read_present(self, tmp_path):
+        command = (
+            "sed -n '1,220p' "
+            "/Users/drewritter/prime-rad/superpowers/skills/brainstorming/SKILL.md"
+        )
+        (tmp_path / "tool_calls.jsonl").write_text(
+            json.dumps({"tool": "Bash", "args": {"command": command}}) + "\n"
+        )
+        result = run_helper("skill-called", ["superpowers:brainstorming"], tmp_path)
+        assert result.returncode == 0
+
+    def test_skill_absent(self, tmp_path):
+        (tmp_path / "tool_calls.jsonl").write_text('{"tool":"Read","args":{}}\n')
+        result = run_helper("skill-called", ["superpowers:brainstorming"], tmp_path)
+        assert result.returncode == 1
+        assert "FAIL" in result.stdout
 
 
 class TestToolCount:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -132,9 +132,13 @@ class TestWorktreeHelpers:
             "key": "superpowers@debug:hooks/hooks-codex.json:session_start:0:0",
             "currentHash": "sha256:abc123",
         }
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         monkeypatch.delenv("DRILL_CODEX_HOME", raising=False)
 
-        with patch("setup_helpers.worktree._read_codex_superpowers_hook", return_value=hook):
+        with (
+            patch("setup_helpers.worktree._read_codex_superpowers_hook", return_value=hook),
+            patch("setup_helpers.worktree.subprocess.run") as run,
+        ):
             install_codex_superpowers_plugin_hooks(work_dir, str(fake_sp))
 
         codex_home = work_dir.parent / f"{work_dir.name}-codex-home"
@@ -151,6 +155,15 @@ class TestWorktreeHelpers:
             in config
         )
         assert 'trusted_hash = "sha256:abc123"' in config
+        run.assert_called_once()
+        args, kwargs = run.call_args
+        assert args == (["codex", "login", "--with-api-key"],)
+        assert kwargs["input"] == "sk-test\n"
+        assert kwargs["text"] is True
+        assert kwargs["capture_output"] is True
+        assert kwargs["check"] is True
+        assert kwargs["env"]["CODEX_HOME"] == str(codex_home)
+        assert kwargs["env"]["OPENAI_API_KEY"] == "sk-test"
 
     def test_create_caller_consent_plan(self, fixtures_dir, work_dir):
         create_base_repo(work_dir, fixtures_dir / "template-repo")

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from pathlib import Path
 from unittest.mock import call, patch
@@ -11,6 +12,7 @@ from setup_helpers.worktree import (
     add_worktree,
     create_caller_consent_plan,
     detach_head,
+    install_codex_superpowers_plugin_hooks,
     link_gemini_extension,
     symlink_superpowers,
 )
@@ -111,6 +113,44 @@ class TestWorktreeHelpers:
             f"@{fake_sp}/skills/using-superpowers/SKILL.md\n"
             f"@{fake_sp}/skills/using-superpowers/references/gemini-tools.md\n"
         )
+
+    def test_install_codex_superpowers_plugin_hooks_stages_isolated_home(
+        self, work_dir, tmp_path, monkeypatch
+    ):
+        work_dir.mkdir()
+        fake_sp = tmp_path / "superpowers"
+        (fake_sp / ".codex-plugin").mkdir(parents=True)
+        (fake_sp / ".codex-plugin" / "plugin.json").write_text('{"name":"superpowers"}\n')
+        (fake_sp / "hooks").mkdir()
+        (fake_sp / "hooks" / "hooks-codex.json").write_text('{"hooks":{}}\n')
+        (fake_sp / "hooks" / "session-start").write_text("#!/usr/bin/env sh\n")
+        (fake_sp / "hooks" / "run-hook.cmd").write_text("@echo off\n")
+        (fake_sp / "skills" / "using-superpowers").mkdir(parents=True)
+        (fake_sp / "skills" / "using-superpowers" / "SKILL.md").write_text("# Skill\n")
+
+        hook = {
+            "key": "superpowers@debug:hooks/hooks-codex.json:session_start:0:0",
+            "currentHash": "sha256:abc123",
+        }
+        monkeypatch.delenv("DRILL_CODEX_HOME", raising=False)
+
+        with patch("setup_helpers.worktree._read_codex_superpowers_hook", return_value=hook):
+            install_codex_superpowers_plugin_hooks(work_dir, str(fake_sp))
+
+        codex_home = work_dir.parent / f"{work_dir.name}-codex-home"
+        staged_plugin = codex_home / "plugins" / "cache" / "debug" / "superpowers" / "local"
+        assert (staged_plugin / ".codex-plugin" / "plugin.json").exists()
+        assert (staged_plugin / "hooks" / "hooks-codex.json").exists()
+        assert os.environ["DRILL_CODEX_HOME"] == str(codex_home)
+
+        config = (codex_home / "config.toml").read_text()
+        assert "plugin_hooks = true" in config
+        assert '[plugins."superpowers@debug"]' in config
+        assert (
+            '[hooks.state."superpowers@debug:hooks/hooks-codex.json:session_start:0:0"]'
+            in config
+        )
+        assert 'trusted_hash = "sha256:abc123"' in config
 
     def test_create_caller_consent_plan(self, fixtures_dir, work_dir):
         create_base_repo(work_dir, fixtures_dir / "template-repo")

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -9,6 +9,7 @@ from drill.setup import clone_template, run_assertions
 from setup_helpers.base import create_base_repo
 from setup_helpers.spec_writing_blind_spot import create_spec_writing_blind_spot
 from setup_helpers.worktree import (
+    _select_codex_superpowers_hook,
     add_worktree,
     create_caller_consent_plan,
     detach_head,
@@ -164,6 +165,62 @@ class TestWorktreeHelpers:
         assert kwargs["check"] is True
         assert kwargs["env"]["CODEX_HOME"] == str(codex_home)
         assert kwargs["env"]["OPENAI_API_KEY"] == "sk-test"
+
+    def test_select_codex_superpowers_hook_requires_codex_entrypoint(self):
+        response = {
+            "result": {
+                "data": [
+                    {
+                        "hooks": [
+                            {
+                                "pluginId": "superpowers@debug",
+                                "source": "plugin",
+                                "eventName": "sessionStart",
+                                "matcher": "startup|resume|clear",
+                                "command": (
+                                    '"${PLUGIN_ROOT}/hooks/run-hook.cmd" session-start-codex'
+                                ),
+                                "trustStatus": "untrusted",
+                                "key": "superpowers@debug:hooks/hooks-codex.json:session_start:0:0",
+                                "currentHash": "sha256:abc123",
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+
+        hook = _select_codex_superpowers_hook(response)
+
+        assert hook == {
+            "key": "superpowers@debug:hooks/hooks-codex.json:session_start:0:0",
+            "currentHash": "sha256:abc123",
+        }
+
+    def test_select_codex_superpowers_hook_rejects_shared_entrypoint(self):
+        response = {
+            "result": {
+                "data": [
+                    {
+                        "hooks": [
+                            {
+                                "pluginId": "superpowers@debug",
+                                "source": "plugin",
+                                "eventName": "sessionStart",
+                                "matcher": "startup|resume|clear",
+                                "command": '"${PLUGIN_ROOT}/hooks/run-hook.cmd" session-start',
+                                "trustStatus": "untrusted",
+                                "key": "superpowers@debug:hooks/hooks-codex.json:session_start:0:0",
+                                "currentHash": "sha256:abc123",
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+
+        with pytest.raises(RuntimeError, match="session-start-codex"):
+            _select_codex_superpowers_hook(response)
 
     def test_create_caller_consent_plan(self, fixtures_dir, work_dir):
         create_base_repo(work_dir, fixtures_dir / "template-repo")


### PR DESCRIPTION
## What problem are you trying to solve?

The parent `superpowers` Codex-native hooks PR needs Drill coverage, but `evals/` has moved out of the parent repo into this standalone `superpowers-evals` repository. Keeping the Drill backend/scenario changes in the parent PR would reintroduce the old inline eval tree and conflict with the new submodule boundary.

This PR carries only the eval-harness portion of SUP-248 / parent PR https://github.com/obra/superpowers/pull/1540: verifying that Codex can bootstrap Superpowers through a native trusted plugin hook in an isolated `CODEX_HOME`, without falling back to the legacy `.agents/skills/superpowers` symlink path.

## What does this PR change?

This makes the standard `codex` Drill backend use Codex native plugin hooks. The backend stages Superpowers as a local Codex plugin in a temp `CODEX_HOME`, logs that temp Codex home in with the already-required `OPENAI_API_KEY`, trusts only that run's discovered SessionStart hook hash, and collects Codex logs from the temp home. The previous symlink-based Codex backend remains available as `codex-no-hooks` for legacy fixtures and fallback testing while the native hook path bakes in.

It also adds the `codex-native-hooks-bootstrap` scenario and assertion helper that verify the isolated trusted Codex hook setup, updates docs/README examples to use `-b codex`, and labels the existing `.agents` path-dependent mapping fixtures as `codex-no-hooks` fallback scenarios.

During live testing, Codex loaded `superpowers:brainstorming` by reading the skill's `SKILL.md` rather than emitting a Claude-style native `Skill` tool call, so this PR also teaches `skill-called` to recognize Codex skill-file loads as valid skill invocation evidence.

After the parent PR split Codex into a dedicated `session-start-codex` hook script, this PR tightened hook discovery to reject a Codex hook command that still points at the shared `session-start` script.

## Relationship to superpowers

This supports the parent `superpowers` Codex native hooks implementation by moving its Drill coverage to the split eval repository. The expected before/after signal is: before, Drill's primary Codex backend symlinked Superpowers skills into `.agents`; after, Drill's primary `codex` backend stages the actual Superpowers Codex plugin hook and asserts the naive "Let's make a react todo list" prompt triggers `superpowers:brainstorming` through the native hook path.

The `codex-no-hooks` backend is intentionally a compatibility fallback, not the preferred user experience.

## Security and eval-lab checklist
- [x] This PR does not commit API keys, `.env` files, session logs, `results/`, or other run artifacts
- [x] This PR does not cause CI to run live agent evals, call model APIs, or require `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`
- [x] If this touches dangerous-mode backend flags, shell execution, environment inheritance, or log collection, the risk is explained below
- [x] If this adds or changes a scenario, setup helper, or assertion command, I considered how untrusted input could affect shell execution

Risk notes:

This adds a live Codex backend that still uses Codex's existing `--dangerously-bypass-approvals-and-sandbox` eval mode, so it remains a trusted-maintainer local eval path and must not run in public CI. The helper stages Superpowers under a temporary Drill-owned `CODEX_HOME`, writes auth and trust state only to that temp home, and reads hook metadata through `codex app-server hooks/list`; it does not mutate the caller's real `~/.codex`. The assertion helper reads only the temp config/plugin paths and verifies the legacy `.agents` symlink is absent for the native hooks scenario.

## Existing work
- [x] I searched for related open and closed PRs/issues/tickets
- Related work: parent hooks PR https://github.com/obra/superpowers/pull/1540 and Linear SUP-248. Existing `superpowers-evals` PRs #1 and #2 were merged governance/security and Pi-backend work; no duplicate Codex native hook Drill PR was found.

## Tests

```bash
uv sync --extra dev
# Resolved 39 packages; checked 38 packages

uv run pytest tests/test_setup.py::TestWorktreeHelpers::test_install_codex_superpowers_plugin_hooks_stages_isolated_home -q
# 1 passed

uv run pytest tests/test_helpers.py::TestSkillCalled -q
# 3 passed

uv run pytest tests/test_setup.py tests/test_helpers.py -q
# 33 passed

uv run pytest tests/test_backend.py tests/test_engine.py tests/test_setup.py -q
# 44 passed

uv run drill list | rg 'codex-native-hooks-bootstrap|codex-no-hooks'
# codex-native-hooks-bootstrap listed with the codex backend
# codex-subagent-wait-mapping listed with the codex-no-hooks fallback backend
# codex-tool-mapping-comprehension listed with the codex-no-hooks fallback backend

SUPERPOWERS_ROOT=/Users/drewritter/.codex/worktrees/25ce/superpowers \
  uv run drill run codex-native-hooks-bootstrap -b codex
# codex: 1 passed, 0 failed, 0 errors
# results: results/codex-native-hooks-bootstrap/codex/2026-05-14T14-46-10-b2a0a3eb

uv run ruff check
# All checks passed!

uv run ty check
# All checks passed!

SUPERPOWERS_ROOT=/Users/drewritter/.codex/worktrees/25ce/superpowers uv run pytest
# 190 passed

git diff --check
# no output

SUPERPOWERS_ROOT=/Users/drewritter/.codex/worktrees/25ce/superpowers uv run pre-commit run --all-files
# ruff check Passed; ty check Passed; pytest Passed
```

Additional parent-plugin checks run against `/Users/drewritter/.codex/worktrees/25ce/superpowers`:

```bash
tests/hooks/test-session-start.sh
# STATUS: PASSED

tests/codex-plugin-sync/test-sync-to-codex-plugin.sh
# PASS
```

## Human review
- [ ] A maintainer has reviewed the complete proposed diff before merge

## Parent submodule follow-up

After this PR merges, the parent `superpowers` hooks PR or a follow-up parent PR needs to bump the `evals` submodule pointer to the merged commit.

- [x] If this PR merges to `main`, a parent `superpowers` submodule bump PR into `dev` will be opened
