### PR TITLE
quorum: empty-capture retry/guard (PRI-2081)

### DIFF
--- a/quorum/capture.py
+++ b/quorum/capture.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import json
 import os
-from dataclasses import dataclass
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Literal
 
@@ -26,6 +28,9 @@ class CaptureResult:
     path: Path
     source_logs: tuple[Path, ...]
     row_count: int
+    # How many capture passes ran (PRI-2081): 1 = first pass succeeded;
+    # >1 = the empty-capture retry re-diffed after a delay.
+    attempts: int = 1
 
 
 @dataclass(frozen=True)
@@ -98,6 +103,58 @@ def capture_tool_calls(
                 f.write(json.dumps(row) + "\n")
                 row_count += 1
     return CaptureResult(path=out_path, source_logs=tuple(new), row_count=row_count)
+
+
+def capture_tool_calls_with_retry(
+    *,
+    log_dir: Path,
+    log_glob: str,
+    snapshot: set[str],
+    normalizer: str,
+    run_dir: Path,
+    launch_cwd: Path | None = None,
+    attempts: int = 3,
+    delay_s: float = 2.0,
+    sleep: Callable[[float], None] = time.sleep,
+) -> CaptureResult:
+    """capture_tool_calls with an empty-capture retry/guard (PRI-2081).
+
+    A run that produced no new source logs — or logs that normalize to zero
+    rows — is usually a real failure, but it is sometimes a transient race:
+    the Coding-Agent's session log is still being flushed (or renamed into
+    place) when the post-drive diff runs. Those races turned whole runs into
+    permanent stage="capture" indeterminates, paying full Gauntlet + subject
+    spend for no verdict.
+
+    Re-run the same snapshot diff up to `attempts` times, `delay_s` apart,
+    until something normalizes. Each pass rewrites
+    coding-agent-tool-calls.jsonl, so the artifact always reflects the final
+    capture. The returned `attempts` field records how many passes ran;
+    a genuinely-empty run still comes back empty (and the runner's
+    per-backend diagnostic cascade proceeds unchanged), just `delay_s *
+    (attempts - 1)` seconds later.
+    """
+    result = capture_tool_calls(
+        log_dir=log_dir,
+        log_glob=log_glob,
+        snapshot=snapshot,
+        normalizer=normalizer,
+        run_dir=run_dir,
+        launch_cwd=launch_cwd,
+    )
+    used = 1
+    while result.row_count == 0 and used < attempts:
+        sleep(delay_s)
+        used += 1
+        result = capture_tool_calls(
+            log_dir=log_dir,
+            log_glob=log_glob,
+            snapshot=snapshot,
+            normalizer=normalizer,
+            run_dir=run_dir,
+            launch_cwd=launch_cwd,
+        )
+    return replace(result, attempts=used)
 
 
 def detect_misplaced_codex_rollouts(

--- a/quorum/runner.py
+++ b/quorum/runner.py
@@ -49,7 +49,7 @@ from quorum import agy_creds
 from quorum.agy_teardown import kill_run_tmux_server
 from quorum.capture import (
     capture_token_usage,
-    capture_tool_calls,
+    capture_tool_calls_with_retry,
     detect_misplaced_codex_rollouts,
     detect_misplaced_pi_sessions,
     detect_unusable_pi_sessions,
@@ -93,6 +93,15 @@ from quorum.opencode_capture import (
 from quorum.setup_step import SetupError, run_setup
 from quorum.story_meta import StoryMetaError, read_quorum_max_time
 from setup_helpers.worktree import install_codex_superpowers_plugin_hooks
+
+# Empty-capture retry/guard (PRI-2081). A transient flush race between the
+# Coding-Agent exiting and the capture diff reading its session log used to
+# become a permanent stage="capture" indeterminate. Bounded re-diff: worst
+# case adds (attempts - 1) * delay seconds to a genuinely-empty run before
+# the per-backend diagnostic cascade proceeds unchanged.
+CAPTURE_RETRY_ATTEMPTS = 3
+CAPTURE_RETRY_DELAY_S = 2.0
+
 
 LAUNCH_CWD_SENTINEL = ".quorum-launch-cwd"
 CODING_AGENT_CONFIG_SUBDIR = "coding-agent-config"
@@ -1919,9 +1928,7 @@ def _run_scenario_inner(
             run_dir,
             substitutions=substitutions,
             required=tcfg.runtime_family == "claude",
-            forbidden_placeholders=(
-                ("$CLAUDE_MODEL",) if tcfg.runtime_family == "claude" else ()
-            ),
+            forbidden_placeholders=(("$CLAUDE_MODEL",) if tcfg.runtime_family == "claude" else ()),
         )
 
         # 7. Snapshot session-log dir.
@@ -2001,14 +2008,18 @@ def _run_scenario_inner(
                     error=RunError(stage="capture", message=str(e)),
                 )
 
-        # 9. Capture + normalize logs.
-        capture_result = capture_tool_calls(
+        # 9. Capture + normalize logs, with the empty-capture retry/guard
+        #    (PRI-2081): a session log still being flushed when the diff runs
+        #    must not turn the run into a permanent capture indeterminate.
+        capture_result = capture_tool_calls_with_retry(
             log_dir=session_log_dir,
             log_glob=tcfg.session_log_glob,
             snapshot=snap,
             normalizer=tcfg.normalizer,
             run_dir=run_dir,
             launch_cwd=launch_cwd,
+            attempts=CAPTURE_RETRY_ATTEMPTS,
+            delay_s=CAPTURE_RETRY_DELAY_S,
         )
 
         # 9b. Capture token usage — measurement only, written to

--- a/tests/quorum/conftest.py
+++ b/tests/quorum/conftest.py
@@ -29,3 +29,16 @@ def _obol_pricing_fixture(monkeypatch):
     (test_obol_smoke.py) delenv it explicitly.
     """
     monkeypatch.setenv("OBOL_PRICING_DIR", str(_PRICING_FIXTURE))
+
+
+@pytest.fixture(autouse=True)
+def _fast_capture_retry(monkeypatch):
+    """Keep the empty-capture retry (PRI-2081) instant in tests.
+
+    The retry logic still runs (attempts unchanged), but the inter-attempt
+    delay is zeroed so the runner tests that exercise genuinely-empty
+    captures don't pay (attempts - 1) * 2s of wall clock each.
+    """
+    import quorum.runner
+
+    monkeypatch.setattr(quorum.runner, "CAPTURE_RETRY_DELAY_S", 0.0)

--- a/tests/quorum/test_capture.py
+++ b/tests/quorum/test_capture.py
@@ -7,6 +7,7 @@ import yaml
 from quorum.capture import (
     capture_token_usage,
     capture_tool_calls,
+    capture_tool_calls_with_retry,
     detect_kimi_cwd_mismatch,
     detect_misplaced_pi_sessions,
     detect_unusable_pi_sessions,
@@ -400,6 +401,122 @@ def _claude_session_line(input_tokens: int, output_tokens: int) -> str:
         )
         + "\n"
     )
+
+
+_PI_TOOLCALL_LINE = (
+    json.dumps(
+        {
+            "type": "message",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "toolCall", "name": "read", "arguments": {}}],
+            },
+        }
+    )
+    + "\n"
+)
+
+
+class TestCaptureToolCallsWithRetry:
+    """Empty-capture retry/guard (PRI-2081).
+
+    A transient capture miss — the Coding-Agent's session log still being
+    flushed when the post-drive diff+normalize runs — must not become a
+    permanent stage="capture" indeterminate. The retry re-runs the same
+    snapshot diff after a delay; the injectable sleep doubles as the
+    "log arrives late" simulation hook in these tests.
+    """
+
+    def test_no_retry_when_first_capture_has_rows(self, tmp_path):
+        log_dir = _mkdir(tmp_path / "logs")
+        snap = snapshot_dir(log_dir, "*.jsonl")
+        (log_dir / "s.jsonl").write_text(_PI_TOOLCALL_LINE)
+        run_dir = _mkdir(tmp_path / "run")
+        sleeps: list[float] = []
+
+        result = capture_tool_calls_with_retry(
+            log_dir=log_dir,
+            log_glob="*.jsonl",
+            snapshot=snap,
+            normalizer="pi",
+            run_dir=run_dir,
+            sleep=sleeps.append,
+        )
+
+        assert result.row_count == 1
+        assert result.attempts == 1
+        assert sleeps == []
+
+    def test_retries_pick_up_a_late_appearing_log(self, tmp_path):
+        log_dir = _mkdir(tmp_path / "logs")
+        snap = snapshot_dir(log_dir, "*.jsonl")
+        run_dir = _mkdir(tmp_path / "run")
+
+        def sleep_then_flush(seconds: float) -> None:
+            (log_dir / "late.jsonl").write_text(_PI_TOOLCALL_LINE)
+
+        result = capture_tool_calls_with_retry(
+            log_dir=log_dir,
+            log_glob="*.jsonl",
+            snapshot=snap,
+            normalizer="pi",
+            run_dir=run_dir,
+            sleep=sleep_then_flush,
+        )
+
+        assert result.row_count == 1
+        assert [p.name for p in result.source_logs] == ["late.jsonl"]
+        assert result.attempts == 2
+        # The artifact reflects the final (successful) capture.
+        lines = result.path.read_text().strip().splitlines()
+        assert len(lines) == 1
+
+    def test_retries_pick_up_a_late_filling_log(self, tmp_path):
+        # The file exists but normalizes to zero rows (still mid-flush);
+        # content arrives during the retry delay.
+        log_dir = _mkdir(tmp_path / "logs")
+        snap = snapshot_dir(log_dir, "*.jsonl")
+        run_dir = _mkdir(tmp_path / "run")
+        (log_dir / "s.jsonl").write_text("")
+
+        def sleep_then_fill(seconds: float) -> None:
+            (log_dir / "s.jsonl").write_text(_PI_TOOLCALL_LINE)
+
+        result = capture_tool_calls_with_retry(
+            log_dir=log_dir,
+            log_glob="*.jsonl",
+            snapshot=snap,
+            normalizer="pi",
+            run_dir=run_dir,
+            sleep=sleep_then_fill,
+        )
+
+        assert result.row_count == 1
+        assert result.attempts == 2
+
+    def test_gives_up_after_bounded_attempts(self, tmp_path):
+        log_dir = _mkdir(tmp_path / "logs")
+        snap = snapshot_dir(log_dir, "*.jsonl")
+        run_dir = _mkdir(tmp_path / "run")
+        sleeps: list[float] = []
+
+        result = capture_tool_calls_with_retry(
+            log_dir=log_dir,
+            log_glob="*.jsonl",
+            snapshot=snap,
+            normalizer="pi",
+            run_dir=run_dir,
+            attempts=3,
+            delay_s=2.0,
+            sleep=sleeps.append,
+        )
+
+        assert result.row_count == 0
+        assert result.source_logs == ()
+        assert result.attempts == 3
+        assert sleeps == [2.0, 2.0]
+        # The empty artifact still exists for downstream assertions.
+        assert result.path.exists()
 
 
 class TestCaptureTokenUsage:


### PR DESCRIPTION
The harness-side half of PRI-2081 (the stuck-judge half shipped gauntlet-side: stall watchdog, gauntlet PR #10).

## Problem

A transient flush race — the Coding-Agent's session log still being written/renamed when the post-drive snapshot diff runs — turned whole runs into permanent `stage="capture"` indeterminates: full Gauntlet + subject spend for no verdict. This also gates PRI-2080's judge-skip tier, where an empty trace becomes an *unmediated* indeterminate.

## Fix

`capture_tool_calls_with_retry` re-runs the same snapshot diff up to 3 times, 2s apart, while the capture normalizes to zero rows:

- The artifact (`coding-agent-tool-calls.jsonl`) always reflects the final pass.
- `CaptureResult.attempts` records how many passes ran (diagnostic surface).
- A genuinely-empty run still comes back empty — the per-backend diagnostic cascade (misplaced-cwd detection, zero-row messages, etc.) proceeds unchanged, just `(attempts-1) × delay` later.
- Knobs are runner constants (`CAPTURE_RETRY_ATTEMPTS` / `CAPTURE_RETRY_DELAY_S`); an autouse test fixture zeroes the delay so the runner tests that exercise genuinely-empty captures stay fast.

## Token/economics symmetry (the other harness-side scope item)

Already structurally done by PRI-2130 — obol is the single cost engine and maps dialects for all backends including gemini and pi. **However**: obol 0.4.0's `pi` dialect returns zero usage against a real `~/.pi` session (May-vintage format) whose assistant messages demonstrably carry `usage` blocks (`input/output/cacheRead/cacheWrite/totalTokens` + native `cost`). The parser is in obol's compiled core, so that fix belongs in the obol repo — being filed separately with a repro. Gemini is wired but unverified here (no local gemini session sample exists to test against).

## Tests

648 passed, 1 skipped (`uv run pytest`); ruff + ty clean. New tests cover: no retry when the first pass has rows, late-appearing log picked up, late-filling (exists-but-empty) log picked up, bounded give-up with correct sleep cadence and empty artifact.

Linear: PRI-2081