### PR TITLE
fix(codex): isolate HOME so Codex loads the staged skills under test, not host ~/.agents

### DIFF
--- a/coding-agents/codex-context/launch-agent
+++ b/coding-agents/codex-context/launch-agent
@@ -10,13 +10,39 @@
 # tmux strips env from new sessions).
 #
 # Equivalent manual command (for debugging):
-#   cd "$QUORUM_AGENT_CWD" && CODEX_HOME="$CODEX_HOME" env -u OPENAI_API_KEY codex --dangerously-bypass-approvals-and-sandbox
+#   cd "$QUORUM_AGENT_CWD" && HOME="$CODEX_HOME/agent-home" CODEX_HOME="$CODEX_HOME" env -u OPENAI_API_KEY codex --dangerously-bypass-approvals-and-sandbox
+#
+# HOME isolation: Codex discovers user-scope skills and plugin marketplaces from
+# $HOME/.agents/{skills,plugins}, resolved via $HOME directly — NOT $CODEX_HOME
+# (codex core-skills loader adds an "$HOME/.agents/skills" user skill root via
+# home_dir(), with no off switch). Left at the host's HOME, a host
+# ~/.agents/skills/* symlink (e.g. into a host superpowers checkout) bleeds host
+# skills into the run and overrides the staged superpowers@debug plugin. Pinning
+# HOME (and XDG/TMPDIR) to a per-run dir under $CODEX_HOME forces Codex to load
+# the staged skills — the version actually under test. Codex auth lives in
+# $CODEX_HOME/auth.json (seeded by the runner), so isolating HOME does not affect
+# login; the scenario repo carries local git identity, so commits are unaffected.
 set -euo pipefail
 cd "$QUORUM_AGENT_CWD" || { echo "launch-agent: cannot cd to $QUORUM_AGENT_CWD" >&2; exit 1; }
+
+codex_agent_home="$CODEX_HOME/agent-home"
+mkdir -p \
+  "$codex_agent_home/.config" \
+  "$codex_agent_home/.local/share" \
+  "$codex_agent_home/.local/state" \
+  "$codex_agent_home/.cache" \
+  "$codex_agent_home/.tmp"
+
 exec env \
   -u OPENAI_API_KEY \
   -u OPENAI_BASE_URL \
   -u OPENAI_ORG_ID \
   -u OPENAI_PROJECT \
+  HOME="$codex_agent_home" \
+  XDG_CONFIG_HOME="$codex_agent_home/.config" \
+  XDG_DATA_HOME="$codex_agent_home/.local/share" \
+  XDG_STATE_HOME="$codex_agent_home/.local/state" \
+  XDG_CACHE_HOME="$codex_agent_home/.cache" \
+  TMPDIR="$codex_agent_home/.tmp" \
   CODEX_HOME="$CODEX_HOME" \
   codex --dangerously-bypass-approvals-and-sandbox "$@"

--- a/tests/quorum/test_runner.py
+++ b/tests/quorum/test_runner.py
@@ -1147,6 +1147,93 @@ def test_codex_launch_agent_scrubs_openai_api_key_env(tmp_path, monkeypatch):
     assert "OPENAI_ORG_ID" not in captured["env"]
 
 
+def test_codex_launch_agent_isolates_home(tmp_path):
+    # Codex discovers user-scope skills/plugins from $HOME/.agents (resolved via
+    # $HOME, NOT $CODEX_HOME). If HOME is left at the host's, a host
+    # ~/.agents/skills symlink bleeds host skills into the run. The launcher must
+    # pin HOME to a per-run dir so Codex uses the staged superpowers@debug skills.
+    coding_agents_dir = tmp_path / "coding-agents"
+    codex_context = coding_agents_dir / "codex-context"
+    codex_context.mkdir(parents=True)
+    shutil.copy2(
+        Path(__file__).resolve().parents[2] / "coding-agents" / "codex-context" / "launch-agent",
+        codex_context / "launch-agent",
+    )
+    shutil.copy2(
+        Path(__file__).resolve().parents[2] / "coding-agents" / "codex-context" / "HOWTO.md",
+        codex_context / "HOWTO.md",
+    )
+    run_dir = tmp_path / "run"
+    launch_cwd = tmp_path / "workdir"
+    codex_home = run_dir / "coding-agent-config"
+    launch_agent_path = run_dir / "gauntlet-agent" / "context" / "launch-agent"
+    launch_cwd.mkdir()
+
+    _populate_context_dir(
+        coding_agents_dir,
+        "codex",
+        run_dir,
+        substitutions={
+            "$QUORUM_AGENT_CWD": str(launch_cwd),
+            "$QUORUM_AGENT_CWD_SH": _shell_single_quote(str(launch_cwd)),
+            "$QUORUM_LAUNCH_AGENT": str(launch_agent_path),
+            "$QUORUM_LAUNCH_AGENT_SH": _shell_single_quote(str(launch_agent_path)),
+            "$CODEX_HOME": str(codex_home),
+            "$CODEX_HOME_SH": _shell_single_quote(str(codex_home)),
+        },
+    )
+
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    capture_path = tmp_path / "codex-capture.json"
+    _exec(
+        fake_bin / "codex",
+        "#!/usr/bin/env python3\n"
+        "import json, os\n"
+        "from pathlib import Path\n"
+        f"Path({json.dumps(str(capture_path))}).write_text(json.dumps({{\n"
+        "    'env': dict(os.environ),\n"
+        "}, sort_keys=True))\n",
+    )
+
+    host_home = tmp_path / "host-home-should-not-leak"
+    host_home.mkdir()
+    launch_env_path = str(fake_bin) + os.pathsep + os.environ["PATH"]
+    result = subprocess.run(
+        [
+            "bash",
+            "-lc",
+            "PATH="
+            + _shell_single_quote(launch_env_path)
+            + " "
+            + _shell_single_quote(str(launch_agent_path)),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={
+            "PATH": os.environ["PATH"],
+            "HOME": str(host_home),
+            "OPENAI_API_KEY": "sk-should-not-reach-codex",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    captured = json.loads(capture_path.read_text())
+    agent_home = codex_home / "agent-home"
+    # HOME is pinned inside the per-run home, not the inherited host HOME, so
+    # Codex's $HOME/.agents/{skills,plugins} discovery stays in-isolation.
+    assert captured["env"]["HOME"] == str(agent_home)
+    assert captured["env"]["HOME"] != str(host_home)
+    assert captured["env"]["HOME"].startswith(str(codex_home))
+    # XDG + TMPDIR isolated too, and the dirs were created.
+    assert captured["env"]["XDG_CONFIG_HOME"] == str(agent_home / ".config")
+    assert captured["env"]["TMPDIR"] == str(agent_home / ".tmp")
+    assert agent_home.is_dir()
+    # CODEX_HOME still set so config/sessions/plugins stay isolated.
+    assert captured["env"]["CODEX_HOME"] == str(codex_home)
+
+
 def test_copilot_context_gets_runtime_substitutions(tmp_path):
     coding_agents_dir = tmp_path / "coding-agents"
     scenarios_dir = tmp_path / "scenarios"


### PR DESCRIPTION
## Problem

Codex eval runs were silently executing the **wrong** superpowers skills. The harness sets a per-run `CODEX_HOME`, but Codex core discovers **user-scope skills and plugin marketplaces from `$HOME/.agents/{skills,plugins}`, resolved via `$HOME` directly — not `$CODEX_HOME`** (codex `core-skills` loader adds an `$HOME/.agents/skills` user skill root via `home_dir()`, with no off switch). The codex launcher set `CODEX_HOME` but left `HOME` at the host's.

On a host with `~/.agents/skills/superpowers` symlinked into a stale host superpowers checkout, the effect is severe: across two `sdd-go-fractals` runs, Codex did **100+ `sed` reads of `~/.codex/superpowers/skills/*/SKILL.md` and zero reads from the staged `$CODEX_HOME/plugins/cache/debug/superpowers/local`**. A skill section present only in the branch under test never appeared. **The `SUPERPOWERS_ROOT` under test was never executed** — so any codex A/B that varies `SUPERPOWERS_ROOT` is confounded (different roots all run the same host skills), and codex evals are non-reproducible across machines (each reads whatever is in its own `~/.agents`).

## Fix

Pin `HOME` (and `XDG_*`/`TMPDIR`) to a per-run dir under `$CODEX_HOME` in `coding-agents/codex-context/launch-agent`, mirroring the existing **opencode** and **kimi** launchers. Codex then finds an empty `$HOME/.agents` and falls back to the staged `superpowers@debug` plugin skills — the version actually under test. Also closes the latent `$HOME/.agents/plugins/marketplace.json` host-bleed surface.

**Scope / safety:**
- Codex auth is read from `$CODEX_HOME/auth.json` (seeded by the runner), so isolating `HOME` does not affect login.
- Scenario repos carry **local** git identity (`drill@test.local`), so per-task commits are unaffected by the empty `$HOME`.
- Launcher-only change; the seeder (`install_codex_superpowers_plugin_hooks`) is unchanged.

## Testing

- New `test_codex_launch_agent_isolates_home` executes the generated launcher with a fake `codex` that captures its environment, and asserts `HOME`/`XDG_CONFIG_HOME`/`TMPDIR` resolve **under `$CODEX_HOME`**, not the inherited host `HOME`. Verified **red before the fix, green after**.
- Full `tests/quorum/test_runner.py` (151 tests) passes; `ruff check` + `ruff format --check` clean on the changed test.

## Root-cause provenance

Confirmed by reading the Codex CLI source (`codex-rs/core-skills/src/loader.rs` — the `$HOME/.agents/skills` user root via `home_dir()`; `utils/home-dir/src/lib.rs` — `CODEX_HOME` resolution), plus host inspection (`~/.agents/skills/superpowers` → stale checkout) and the two runs' tool-call logs.

---
Authored by **Claude (Fable 5)** in Claude Code, at @obra's direction. Diagnosis from a read-only source/transcript investigation; change developed TDD-first.
