### PR TITLE
fix: guard negative-assertion check tools against empty capture (C1)

### DIFF
--- a/bin/skill-not-called
+++ b/bin/skill-not-called
@@ -18,6 +18,14 @@ SKILL_NAME="$1"
 SKILL_DIR="${SKILL_NAME##*:}"
 FILE="${QUORUM_TOOL_CALLS_PATH:-coding-agent-tool-calls.jsonl}"
 
+# A negative assertion can't be verified without a transcript: an empty/missing
+# capture means "we don't know", not "the skill wasn't called". Fail rather than
+# vacuously pass (mirrors implementation-tool-not-called).
+if [ ! -s "$FILE" ]; then
+    record_fail "tool-calls file missing or empty"
+    exit 1
+fi
+
 COUNT=$(
     jq -L "$(dirname "$0")" -s \
         --arg name "$SKILL_NAME" --arg dir "$SKILL_DIR" \

--- a/bin/tool-not-called
+++ b/bin/tool-not-called
@@ -8,6 +8,14 @@ command -v jq >/dev/null || { echo "jq required"; exit 127; }
 TOOL="$1"
 FILE="${QUORUM_TOOL_CALLS_PATH:-coding-agent-tool-calls.jsonl}"
 
+# A negative assertion can't be verified without a transcript: an empty/missing
+# capture means "we don't know", not "the tool wasn't called". Fail rather than
+# vacuously pass (mirrors implementation-tool-not-called).
+if [ ! -s "$FILE" ]; then
+    record_fail "tool-calls file missing or empty"
+    exit 1
+fi
+
 COUNT=$(jq -s "[.[] | select(.tool == \"$TOOL\")] | length" "$FILE" 2>/dev/null || echo 0)
 
 if [ "$COUNT" -eq 0 ]; then

--- a/docs/audits/2026-06-13-liveness-and-bitrot-audit.md
+++ b/docs/audits/2026-06-13-liveness-and-bitrot-audit.md
@@ -1,0 +1,243 @@
+# Codebase liveness & bitrot audit — running issues log
+
+Started 2026-06-13. Scope chosen with Jesse: **whole dispatch surface**
+(quorum/ + setup_helpers/ + bin/ + scenarios/ + coding-agents/), **audit-first**
+(report before deleting/fixing), **cheap-tier execution + one live run per
+adapter family**.
+
+This is the running list of everything found that needs fixing. Status legend:
+`OPEN` / `IN PROGRESS` / `FIXED` / `WONTFIX`. Sequencing decision: **capture
+bitrot first**, then check-tool consolidation.
+
+## Method / reusable artifacts
+
+- `scripts/audit_liveness.py` — stdlib-only reference-counter over the
+  string-dispatch surface (bin tools, helpers, quorum modules, agents). Counts
+  references the way the runtime resolves them (shell words), because
+  vulture/import-graphs can't see string dispatch. Re-run after future rewrites.
+- Cheap tier: `uv run ruff check` / `ty check` / `quorum check` / `quorum list`
+  / `pytest` / per-command `--help`. All green except one test (see B2).
+- Live sweep logs: `/tmp/eval-audit-live/<agent>.log`; run dirs under `results/`.
+
+## Live sweep result (one scenario per adapter family, 2026-06-13)
+
+| Agent | Verdict | Cause |
+|---|---|---|
+| codex | pass | full pipeline OK |
+| gemini | pass | full pipeline OK |
+| copilot | pass | full pipeline OK |
+| claude | indeterminate | no transcript at expected path — see **B1** |
+| opencode | indeterminate | no session export — see **B3** |
+| antigravity | indeterminate | agy plugin install path-doubling — see **B4** |
+| pi | indeterminate | env not configured — see **B5** |
+
+The harness core is sound (codex/gemini/copilot exercise drive→capture→check→
+verdict end to end). Rot is localized, not systemic. Earlier "probably
+systemic capture rot" hypothesis was **wrong** and is retracted.
+
+---
+
+## Bitrot (wired up but broken)
+
+### B1 — claude transcript capture produces no transcript  [MITIGATED 2026-06-13: pin 2.1.175]
+DECISION (Jesse): pin claude **2.1.175** for now rather than chase the new
+layout — the older CLI still writes the legacy `projects/**/*.jsonl` the harness
+globs. Root cause CONFIRMED (below): claude 2.1.x moved session transcripts to
+`sessions/<uuid>/history.jsonl`. Independent corroboration: the `prudence`
+harness (TS, bun) globs the same old `projects/**/*.jsonl` and dodges the bug
+only by forcing `CLAUDE_CONFIG_DIR` + pinning an older claude — i.e. exactly the
+pin-2.1.175 strategy. Proper fix (prefer `sessions/<uuid>/history.jsonl`, fall
+back to legacy `projects/**`) deferred; revisit when we unpin or during the TS
+capture port. Original investigation below.
+
+---
+
+The installed `claude` CLI completes the task but writes **no `*.jsonl`** under
+`${CLAUDE_CONFIG_DIR}/projects/**` where `coding-agents/claude.yaml`
+(`session_log_dir`/`session_log_glob`) looks. The project dir is created but
+contains only an empty `memory/`. Result: every claude run → `indeterminate`,
+and `coding-agent-tool-calls.jsonl` is empty (0 lines).
+- Evidence: `results/00-quorum-smoke-hello-world-claude-20260613T175406Z-cdcb/`
+- Impact: **blocks all claude verdicts** (the primary agent). gemini/codex/
+  copilot capture fine, so this is claude-CLI-specific (likely the CLI changed
+  where/whether it persists the session transcript).
+- Fix: find the claude CLI's current transcript location/trigger; update
+  `claude.yaml` capture config (and normalizer if the format moved).
+- INVESTIGATION (2026-06-13, systematic-debugging, NOT yet confirmed):
+  - Installed `claude` is **2.1.177**.
+  - Isolated run config has `projects/<munged>/memory/` only — **no `*.jsonl`,
+    no `sessions/` dir**. Subject wrote no transcript anywhere found at run
+    time (17:54Z): not in isolated `projects/`, not in real `~/.claude`.
+  - Real `~/.claude` now has a **new layout**: `sessions/<uuid>/history.jsonl`
+    + `session.json` (claude 2.1.x). The harness still globs the OLD
+    `${CLAUDE_CONFIG_DIR}/projects/**/*.jsonl`.
+  - LEADING HYPOTHESIS (unconfirmed): claude 2.1.x changed session
+    persistence — either moved to `sessions/<uuid>/history.jsonl`, or
+    `--print` one-shot mode no longer writes a `projects/` rollout jsonl that
+    the old harness relied on. codex/gemini/copilot use different capture
+    paths (`_gemini_transcripts`, antigravity `brain/**/transcript.jsonl`),
+    which is why they're unaffected — consistent with a claude-specific change.
+  - DECISIVE TEST NOT YET RUN: launch claude 2.1.177 as the harness does
+    (`--print`, isolated `CLAUDE_CONFIG_DIR`) on a trivial prompt; enumerate
+    every file it creates; confirm where (if anywhere) the transcript lands.
+    Paused pending the Python→TS migration discussion (capture fix is
+    language-independent and still P0).
+
+### B2 — antigravity stage-attribution test is FLAKY (env-sensitive)  [OPEN, P2]
+`tests/quorum/test_runner.py::TestRunScenario::
+test_antigravity_seed_runner_error_preserves_setup_stage` expects
+`verdict.error.stage == "setup"`. CONFIRMED flaky on ambient `gauntlet`
+provider state: first full run (clean env, no keys) → FAIL with stage
+`"capture"` + "No LLM provider configured"; later full run (after live evals
+this session likely persisted gauntlet provider config) → PASS. So it's not a
+clean code regression — the test fails to isolate gauntlet's global provider
+configuration. Fix: stub/clear gauntlet provider state in the test so stage
+attribution is deterministic regardless of machine config.
+
+### B3 — opencode session export not captured  [OPEN, P2]
+`final indeterminate`: "no OpenCode session export appeared under isolated
+`.quorum/session-exports`." opencode uses an export mechanism distinct from
+the projects-dir agents. Either bitrot in the export step or env.
+- Evidence: `results/opencode-superpowers-bootstrap-opencode-20260613T180320Z-5711/`
+
+### B4 — antigravity `agy` plugin install path-doubling  [OPEN, P2]
+`agy plugin install failed (exit 1)`: the install target path recursively
+nests the run-dir path into itself
+(`.../.gemini/config/plugins/superpowers/evals/results/<rundir>/coding-agent-config/.gemini/config/plugins/superpowers/evals/results/<rundir>...`).
+A path-construction bug in the antigravity setup path. (agy is gemini-based —
+writes `.gemini` config.)
+- Evidence: `results/antigravity-superpowers-bootstrap-antigravity-20260613T175848Z-40d6/`
+
+### B5 — pi requires unset env vars  [OPEN, P3 / config]
+`coding-agents/pi.yaml` requires `PI_PROVIDER`, `PI_MODEL`, `PI_API_KEY`, none
+present in the eval `.env`. Not code rot — pi can't be evaluated until these
+are provisioned. Decide: provision pi creds, or mark pi as needs-config.
+
+### B6 — gemini setup helper dead while its check is live  [OPEN, P2]
+`link_gemini_extension` (the helper that *sets up* the gemini extension) has
+**zero callers**, yet `gemini-extension-linked` (the check that asserts it
+worked) is live. Setup path was rewritten out from under the assertion. NOTE:
+gemini run still **passed**, so the current setup path works by another route —
+confirm whether `link_gemini_extension` and/or the check are now both vestigial.
+
+---
+
+## Check-tool correctness (bin/)
+
+### C1 — negative-assertion check tools false-pass on empty capture  [FIXED 2026-06-13]
+FIX: added the `[ ! -s "$FILE" ]` empty/missing-capture guard to
+`bin/tool-not-called` and `bin/skill-not-called` (mirrors the already-guarded
+`implementation-tool-not-called`); empty capture now `record_fail`s + exits 1
+instead of vacuously passing. TDD: 6 new tests in `test_trace_tools.py`
+(`*_passes_when_absent`, `*_fails_when_present`, `*_fails_on_empty_capture` for
+both tools) — watched the two empty-capture tests fail RED first, then green.
+Full `test_trace_tools.py` (51) + ruff clean. Original finding below.
+
+---
+
+`tool-not-called` and `skill-not-called` pass condition is `COUNT == 0`, with
+**no empty/missing-capture guard**. On an empty `coding-agent-tool-calls.jsonl`
+(the B1 condition) they report **PASS** — proven by direct run. Their sibling
+`implementation-tool-not-called` *is* guarded. So when capture is empty, any
+scenario asserting "skill did NOT over-trigger" (the cost scenarios) **falsely
+passes** — the one place the capture rot becomes a silent lie rather than a loud
+failure. Positive assertions (`skill-called`, etc.) fail-loud and are safe.
+Latent: the *missing*-file path throws `[: integer expression expected` (fails
+closed, but sloppy).
+
+### C2 — bin/ capture-family is copy-paste with divergent guards  [OPEN, P1]
+12 tools read the tool-call capture; each re-implements load + `jq` check +
+empty guard + count by hand. The shared seam `bin/_record` covers **output**
+(JSON emit, ERR trap) but **not input**, so the error-prone input guarding was
+left to copy-paste and diverged (C1 is the symptom). Root cause is a missing
+abstraction, not 2 bad scripts.
+- DECISION (Jesse): consolidate into a **single tool** with subcommands, e.g.
+  `check-transcript skill-not-called <args>`; update callers. Jesse suggested
+  **TypeScript**; OPEN QUESTION recorded below (TS vs Python — the parsing
+  already exists in `quorum/normalizers.py` + `capture.py`, and the repo is
+  Python). Resolve before building.
+
+---
+
+## Dead code (confirmed; small tail)
+
+### D1 — `drill/` husk  [OPEN]
+Untracked stale `*.cpython-312.pyc` (project pins 3.11), no source, not in git.
+The previous runner, superseded by quorum. Remove disk cruft.
+
+### D2 — `link_gemini_extension` helper genuinely dead  [OPEN]
+Defined + registered in `HELPER_REGISTRY`, **zero** callers (no scenario, no
+internal). Gemini-rewrite leftover. (See B6.)
+
+### D3 — `detach_head` registry key dead (function live)  [OPEN]
+`add_worktree` calls `detach_head()` internally, but no scenario dispatches the
+registry key. Unregister the key; keep the function.
+
+### D4 — `skill-before-tool-match` check tool dead  [OPEN]
+Tested, but dispatched by **zero** scenarios — the unused "skill" sibling of
+`tool-match-before-tool-match` (which is used 4×). Remove or wire up.
+
+### D5 — `refresh-claude-home-skeleton`  [OPEN / low]
+Manual ops helper: no test, no scenario dispatch. Not a check. Keep but
+consider a smoke test.
+
+---
+
+## Documentation drift (liveness signal)
+
+### E1 — architecture doc lists 10 quorum modules; 21 exist  [OPEN]
+`CLAUDE.md` Architecture section omits the whole later cluster: `agy_creds`,
+`agy_teardown`, `agy_watch`, `kimi`, `opencode_capture`, `economics`,
+`run_all`, `setup_step`, `story_meta`.
+
+### E2 — canonical actors list 4 coding-agents; 8 wired  [OPEN]
+Adds antigravity, copilot, kimi, opencode beyond Claude/Codex/Gemini/Pi.
+
+### E3 — "drill" vocabulary persists post-removal  [OPEN / low]
+`drill@test.local`, "drill scenarios" remain after the drill package was
+removed. Naming not reconciled.
+
+### E4 — kimi un-runnable here  [OPEN / env]
+`kimi` binary not installed; full config/scenario/check set present but cold.
+Not in scope for the live sweep.
+
+---
+
+## TS migration (Python → TS, bun) — decisions & prudence findings
+
+DECISIONS (Jesse): porting the whole harness to TS eventually; **runtime = bun**;
+the consolidated check tool (C2) will be the TS pilot, dispatched as a single
+tool with subcommands (`check-transcript skill-not-called <args>`), callers
+updated. C1 hardening shipped in shell now to stop the bleeding (decoupled from
+the rewrite).
+
+`prudence` (`/Users/jesse/git/superpowers/prudence`) diligence — bun-native,
+production-quality (418 tests, strict typecheck clean, ~20ms cold start →
+fine for high-fanout check-tool spawning). It solves a *different* problem
+(runs models in containers + judge panel), so it's a **design reference, not a
+dependency**. Bottom line for us:
+- **Reusable IR**: its canonical NDJSON event schema
+  (`session` / `turn_start` / `tool_execution_start` / `tool_execution_end` /
+  `turn_end` with a `usage` block) + the `toolCallId`-pairing logic in
+  `src/runview/transcript.ts` + `ParsedTranscript` aggregation
+  (`src/transcript/parse.ts`). Adopt as the shared IR for TS check-tools and the
+  basis for "tool Y called / Y-before-Z / W-not-called".
+- **Must build ourselves**: (i) an *on-disk*-layout normalizer — prudence's
+  normalizers parse *streamed* `--output-format stream-json`, not the session
+  files quorum reads; (ii) **all skill-invocation detection** — prudence has
+  none (it runs Pi `--no-skills`); our `_skill_predicate.jq` logic has no
+  counterpart there.
+- **Not a B1 reference**: it shares our old-glob bug; confirms 2.1.x layout
+  change.
+
+OPEN: incremental (strangler-fig, leaf-first: bin/ → setup_helpers → capture/
+normalizers → runner) vs big-bang. Recommendation on record: incremental — the
+audit shows codex/gemini/copilot pass end-to-end, so the system mostly works;
+don't big-bang-rewrite a working harness that's already been rewritten twice.
+The 31 existing bin/ tests become the acceptance oracle for the TS port.
+
+## Open questions for Jesse
+
+1. **C2 toolchain: TypeScript vs Python** for the consolidated `check-transcript`
+   tool. (See C2 note.) Resolve before building.
+2. **B5/E4**: provision pi + kimi creds/binaries, or mark them needs-config?

--- a/scripts/audit_liveness.py
+++ b/scripts/audit_liveness.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Liveness audit over the whole dispatch surface.
+
+This codebase dispatches by *string name* through shell and YAML — bin tools
+invoked via PATH from checks.sh, setup-helpers looked up in HELPER_REGISTRY,
+coding agents discovered from *.yaml. Static Python import analysis (vulture,
+import graphs) cannot see any of it and reports false "dead" everywhere. This
+script counts references the way the runtime actually resolves them: as shell
+words across the entire tree.
+
+It answers ONE question per unit: is this referenced anywhere outside its own
+definition? A zero means "orphan candidate" — a thing to look at, not a thing
+to delete. Bitrot (does it run?) is a separate axis the cheap-tier execution
+pass covers.
+
+Usage:
+    uv run python scripts/audit_liveness.py            # summary + orphans
+    uv run python scripts/audit_liveness.py --verbose  # + where each ref lives
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Directories that are never "the codebase" for reference-counting: output
+# artifacts, vendored venv, transient worktrees, compiled cruft.
+SKIP_DIRS = {".venv", "__pycache__", "results", ".worktrees", ".git", "node_modules"}
+
+
+def _walk(root: Path, suffixes: tuple[str, ...]) -> list[Path]:
+    out: list[Path] = []
+    for p in root.rglob("*"):
+        if any(part in SKIP_DIRS for part in p.parts):
+            continue
+        if p.is_file() and (not suffixes or p.suffix in suffixes):
+            out.append(p)
+    return out
+
+
+def _word_re(name: str) -> re.Pattern[str]:
+    # A shell "word": bounded by anything that isn't an identifier char or hyphen.
+    # This keeps `not` from matching `cannot` and `git-clean` from matching
+    # `git-cleanup`.
+    return re.compile(rf"(?<![\w-]){re.escape(name)}(?![\w-])")
+
+
+@dataclass
+class Unit:
+    name: str
+    kind: str
+    defined_in: Path
+    refs: list[Path] = field(default_factory=list)
+
+    @property
+    def rel(self) -> str:
+        return str(self.defined_in.relative_to(REPO))
+
+    @property
+    def ref_count(self) -> int:
+        return len(self.refs)
+
+
+# ---- inventory ------------------------------------------------------------
+
+
+def inventory_bin_tools() -> list[Unit]:
+    units = []
+    for p in sorted((REPO / "bin").iterdir()):
+        if p.is_file() and p.suffix != ".jq":
+            units.append(Unit(p.name, "bin-tool", p))
+    return units
+
+
+def inventory_setup_helpers() -> list[Unit]:
+    """Registry keys — the strings scenarios actually pass to `setup-helpers run`."""
+    init = (REPO / "setup_helpers" / "__init__.py").read_text()
+    tree = ast.parse(init)
+    keys: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "HELPER_REGISTRY" for t in node.targets
+        ):
+            if isinstance(node.value, ast.Dict):
+                for k, v in zip(node.value.keys, node.value.values):
+                    if isinstance(k, ast.Constant) and isinstance(v, ast.Name):
+                        keys[k.value] = v.id
+    return [
+        Unit(k, "setup-helper", REPO / "setup_helpers" / "__init__.py") for k in keys
+    ]
+
+
+def inventory_quorum_modules() -> list[Unit]:
+    units = []
+    for p in sorted((REPO / "quorum").glob("*.py")):
+        if p.stem == "__init__":
+            continue
+        units.append(Unit(p.stem, "quorum-module", p))
+    return units
+
+
+def inventory_coding_agents() -> list[Unit]:
+    return [
+        Unit(p.stem, "coding-agent", p)
+        for p in sorted((REPO / "coding-agents").glob("*.yaml"))
+    ]
+
+
+def inventory_scenarios() -> list[Unit]:
+    units = []
+    for d in sorted((REPO / "scenarios").iterdir()):
+        if d.is_dir() and (d / "story.md").exists():
+            units.append(Unit(d.name, "scenario", d))
+    return units
+
+
+# ---- reference counting ---------------------------------------------------
+
+
+def count_refs(units: list[Unit], search_files: list[Path], own_files: set[Path]) -> None:
+    """For each unit, record every searched file (not its own definition) that
+    mentions it as a shell word."""
+    contents = [(f, f.read_text(errors="ignore")) for f in search_files]
+    for u in units:
+        pat = _word_re(u.name)
+        for f, text in contents:
+            if f in own_files and u.kind != "bin-tool":
+                # bin tools legitimately reference each other (sourcing _record,
+                # wrapping `not`); count those. Other kinds: skip self-file.
+                if f == u.defined_in:
+                    continue
+            if f == u.defined_in:
+                continue
+            if pat.search(text):
+                u.refs.append(f)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--verbose", action="store_true", help="show where refs live")
+    args = ap.parse_args()
+
+    shell_files = _walk(REPO / "scenarios", (".sh",))
+    doc_files = _walk(REPO / "docs", (".md",)) + [REPO / "README.md", REPO / "CLAUDE.md"]
+    py_files = _walk(REPO / "quorum", (".py",)) + _walk(REPO / "tests", (".py",))
+    bin_files = [p for p in (REPO / "bin").iterdir() if p.is_file()]
+    yaml_files = _walk(REPO / "coding-agents", (".yaml",))
+
+    groups: dict[str, tuple[list[Unit], list[Path]]] = {
+        # bin tools: referenced from scenario shell, sibling bin tools, quorum, docs
+        "bin-tool": (inventory_bin_tools(), shell_files + bin_files + py_files + doc_files),
+        # helpers: invoked by registry-key string from scenario setup.sh + docs
+        "setup-helper": (inventory_setup_helpers(), shell_files + doc_files + py_files),
+        # quorum modules: imported across quorum + tests; named in docs
+        "quorum-module": (inventory_quorum_modules(), py_files + doc_files),
+        # coding agents: named in scenario directives, run_all, configs, docs
+        "coding-agent": (
+            inventory_coding_agents(),
+            shell_files + py_files + doc_files + yaml_files,
+        ),
+    }
+
+    all_orphans: list[Unit] = []
+    for kind, (units, search) in groups.items():
+        own = {u.defined_in for u in units}
+        count_refs(units, search, own)
+        units.sort(key=lambda u: u.ref_count)
+        print(f"\n{'=' * 70}\n{kind}  ({len(units)} units)\n{'=' * 70}")
+        for u in units:
+            flag = "  <-- ORPHAN?" if u.ref_count == 0 else ""
+            print(f"  {u.ref_count:3d}  {u.name}{flag}")
+            if u.ref_count == 0:
+                all_orphans.append(u)
+            if args.verbose and u.refs:
+                for f in u.refs[:6]:
+                    print(f"          {f.relative_to(REPO)}")
+                if len(u.refs) > 6:
+                    print(f"          ... +{len(u.refs) - 6} more")
+
+    # scenarios: liveness is structural (draft vs active), reported separately
+    scenarios = inventory_scenarios()
+    drafts = []
+    for s in scenarios:
+        checks = s.defined_in / "checks.sh"
+        if checks.exists() and re.search(r"status:\s*draft", checks.read_text()):
+            drafts.append(s.name)
+    print(f"\n{'=' * 70}\nscenarios  ({len(scenarios)} total, {len(drafts)} draft)\n{'=' * 70}")
+    for name in drafts:
+        print(f"  DRAFT  {name}")
+
+    print(f"\n{'=' * 70}\nORPHAN CANDIDATES: {len(all_orphans)}\n{'=' * 70}")
+    for u in all_orphans:
+        print(f"  [{u.kind}] {u.name}  ({u.rel})")
+    print(
+        "\nNote: orphan = zero references in the searched surface. Investigate "
+        "before deleting — a unit may be invoked by a path this script doesn't "
+        "search (Makefile, CI, manual ops)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/quorum/test_trace_tools.py
+++ b/tests/quorum/test_trace_tools.py
@@ -14,6 +14,15 @@ def _trace(tmp_path: Path, *records: dict) -> Path:
     return p
 
 
+def _empty_trace(tmp_path: Path) -> Path:
+    """A capture file that exists but is empty — the condition produced when
+    transcript capture bitrots (the agent ran but no tool-call records were
+    recovered). Negative assertions must NOT vacuously pass on this."""
+    p = tmp_path / "coding-agent-tool-calls.jsonl"
+    p.write_text("")
+    return p
+
+
 def _run(tool: str, *args: str, trace: Path, cwd: Path, sink: Path) -> int:
     return subprocess.run(
         [str(BIN / tool), *args],
@@ -1211,3 +1220,89 @@ def test_investigated_does_not_false_match_grep_substring(tmp_path):
     )
     sink = tmp_path / "s"
     assert _run("investigated", trace=trace, cwd=workdir, sink=sink) != 0
+
+
+# Negative-assertion tools (tool-not-called / skill-not-called) must
+# distinguish "agent demonstrably did not do X" from "we have no transcript to
+# judge". On an empty capture (the bitrot condition) they previously reported
+# PASS — a silent false-pass that made cost/over-trigger scenarios green when
+# the harness was actually blind. Their guarded sibling
+# implementation-tool-not-called already fails on empty; these pin the same
+# contract for the other two.
+
+
+def test_tool_not_called_passes_when_tool_absent(tmp_path):
+    parent = tmp_path / "rundir"
+    parent.mkdir()
+    workdir = parent / "coding-agent-workdir"
+    workdir.mkdir()
+    trace = _trace(parent, {"tool": "Read", "args": {}})
+    sink = tmp_path / "s"
+    assert _run("tool-not-called", "Edit", trace=trace, cwd=workdir, sink=sink) == 0
+    assert _r(sink)["passed"]
+
+
+def test_tool_not_called_fails_when_tool_present(tmp_path):
+    parent = tmp_path / "rundir"
+    parent.mkdir()
+    workdir = parent / "coding-agent-workdir"
+    workdir.mkdir()
+    trace = _trace(parent, {"tool": "Edit", "args": {}})
+    sink = tmp_path / "s"
+    assert _run("tool-not-called", "Edit", trace=trace, cwd=workdir, sink=sink) != 0
+    assert not _r(sink)["passed"]
+
+
+def test_tool_not_called_fails_on_empty_capture(tmp_path):
+    """Empty capture must not vacuously pass a negative assertion."""
+    parent = tmp_path / "rundir"
+    parent.mkdir()
+    workdir = parent / "coding-agent-workdir"
+    workdir.mkdir()
+    trace = _empty_trace(parent)
+    sink = tmp_path / "s"
+    assert _run("tool-not-called", "Edit", trace=trace, cwd=workdir, sink=sink) != 0
+    assert not _r(sink)["passed"]
+
+
+def test_skill_not_called_passes_when_skill_absent(tmp_path):
+    parent = tmp_path / "rundir"
+    parent.mkdir()
+    workdir = parent / "coding-agent-workdir"
+    workdir.mkdir()
+    trace = _trace(parent, {"tool": "Edit", "args": {}})
+    sink = tmp_path / "s"
+    assert (
+        _run("skill-not-called", "superpowers:foo", trace=trace, cwd=workdir, sink=sink)
+        == 0
+    )
+    assert _r(sink)["passed"]
+
+
+def test_skill_not_called_fails_when_skill_present(tmp_path):
+    parent = tmp_path / "rundir"
+    parent.mkdir()
+    workdir = parent / "coding-agent-workdir"
+    workdir.mkdir()
+    trace = _trace(parent, {"tool": "Skill", "args": {"skill": "superpowers:foo"}})
+    sink = tmp_path / "s"
+    assert (
+        _run("skill-not-called", "superpowers:foo", trace=trace, cwd=workdir, sink=sink)
+        != 0
+    )
+    assert not _r(sink)["passed"]
+
+
+def test_skill_not_called_fails_on_empty_capture(tmp_path):
+    """Empty capture must not vacuously pass a negative assertion."""
+    parent = tmp_path / "rundir"
+    parent.mkdir()
+    workdir = parent / "coding-agent-workdir"
+    workdir.mkdir()
+    trace = _empty_trace(parent)
+    sink = tmp_path / "s"
+    assert (
+        _run("skill-not-called", "superpowers:foo", trace=trace, cwd=workdir, sink=sink)
+        != 0
+    )
+    assert not _r(sink)["passed"]


### PR DESCRIPTION
## What problem are you trying to solve?
Two negative-assertion check tools produced **false passes** when the tool-call
capture was empty or missing. `tool-not-called` and `skill-not-called` decide on
`COUNT == 0`, and an empty/absent `coding-agent-tool-calls.jsonl` yields 0 — so
they reported PASS with no transcript to judge. This is exactly the condition the
installed `claude` 2.1.x CLI now produces (it writes its transcript to
`sessions/<uuid>/history.jsonl`, while the harness still globs the legacy
`projects/**/*.jsonl`, leaving an empty capture). Net effect: a cost/over-trigger
scenario asserting "skill X did NOT fire" would go green while the harness was
actually blind — a silent unreliable eval signal. Proven by running the tools
against an empty capture (exit 0). Their sibling `implementation-tool-not-called`
was already guarded; these two were not.

## What does this PR change?
Adds the `[ ! -s "$FILE" ]` empty/missing-capture guard to `bin/tool-not-called`
and `bin/skill-not-called` (matching `implementation-tool-not-called`): an empty
capture now `record_fail`s + exits 1 instead of passing. Also adds the reusable
`scripts/audit_liveness.py` reference-counter and a running audit log under
`docs/audits/` that tracks this and the other findings from a full
liveness/bitrot sweep.

## Relationship to superpowers
These check tools are how quorum verifies superpowers skill behavior (e.g. that a
skill did or did not over-trigger). A negative assertion that silently passes on
an empty transcript means the eval reports skills as well-behaved when it has no
evidence — the opposite of a trustworthy signal. Before: empty capture → PASS.
After: empty capture → FAIL ("we don't know" ≠ "it didn't happen").

## Security and eval-lab checklist
- [x] This PR does not commit API keys, `.env` files, session logs, `results/`, or other run artifacts
- [x] This PR does not cause CI to run live agent evals, call model APIs, or require `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`
- [x] If this touches dangerous-mode backend flags, shell execution, environment inheritance, or log collection, the risk is explained below
- [x] If this adds or changes a scenario, setup helper, or assertion command, I considered how untrusted input could affect shell execution

Risk notes:
Touches two assertion commands. The change only adds a fail-closed guard before
the existing jq query; it narrows behavior (more failures, never more passes) and
introduces no new shell execution or input handling. The new `audit_liveness.py`
is read-only static analysis (no exec, no network).

## Existing work
- [x] I searched for related open and closed PRs/issues/tickets
- Related work: none found — this surfaced during a fresh liveness/bitrot audit of the harness.

## Tests
```
uv run pytest          # 665 passed, 1 skipped
uv run pytest tests/quorum/test_trace_tools.py   # 51 passed
uv run ruff check      # All checks passed!
uv run ty check        # All checks passed!
uv run quorum check    # all scenarios ok
```
TDD: 6 new tests in `test_trace_tools.py` pin the contract for both tools
(passes-when-absent, fails-when-present, fails-on-empty-capture); the two
empty-capture tests were watched failing RED before the guard was added.

## Human review
- [ ] A maintainer has reviewed the complete proposed diff before merge

## Parent submodule follow-up
- [x] If this PR merges to `main`, a parent `superpowers` submodule bump PR into `dev` will be opened

---
*Authored in a Claude Code session (model: Opus 4.8) with Jesse, via the superpowers plugin. Other open findings from the same audit (B1 claude transcript pin, B3/B4 opencode/antigravity capture, dead-code D1–D5, doc drift) are tracked in `docs/audits/2026-06-13-liveness-and-bitrot-audit.md` as separate follow-ups, not bundled here.*
