### PR TITLE
fix(claude): force transcript persistence so capture works on latest CLI (2.1.177)

### DIFF
--- a/coding-agents/claude-context/launch-agent
+++ b/coding-agents/claude-context/launch-agent
@@ -15,9 +15,15 @@
 # calls). If capture ever comes back empty anyway, claude is a strict-capture
 # target, so the run is a loud indeterminate(stage=capture), never a silent pass.
 #
+# As of claude 2.1.176 the env-strip alone is insufficient: nested detection
+# gained additional signals (e.g. CLAUDE_CODE_CHILD_SESSION) that the strip does
+# not cover. CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1 is the authoritative
+# override — it forces transcript persistence regardless of nested-session
+# detection, so capture stays robust across claude versions.
+#
 # Equivalent manual command (for debugging):
-#   cd "$QUORUM_AGENT_CWD" && source "$CLAUDE_ENV_FILE" && env -u CLAUDECODE -u CLAUDE_CODE_SESSION_ID CLAUDE_CONFIG_DIR="$CLAUDE_CONFIG_DIR" ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" claude --dangerously-skip-permissions --plugin-dir "$SUPERPOWERS_ROOT" --model "$CLAUDE_MODEL"
+#   cd "$QUORUM_AGENT_CWD" && source "$CLAUDE_ENV_FILE" && env -u CLAUDECODE -u CLAUDE_CODE_SESSION_ID CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1 CLAUDE_CONFIG_DIR="$CLAUDE_CONFIG_DIR" ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" claude --dangerously-skip-permissions --plugin-dir "$SUPERPOWERS_ROOT" --model "$CLAUDE_MODEL"
 set -euo pipefail
 cd "$QUORUM_AGENT_CWD" || { echo "launch-agent: cannot cd to $QUORUM_AGENT_CWD" >&2; exit 1; }
 source "$CLAUDE_ENV_FILE"
-exec env -u CLAUDECODE -u CLAUDE_CODE_SESSION_ID CLAUDE_CONFIG_DIR="$CLAUDE_CONFIG_DIR" ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" claude --dangerously-skip-permissions --plugin-dir "$SUPERPOWERS_ROOT" --model "$CLAUDE_MODEL" "$@"
+exec env -u CLAUDECODE -u CLAUDE_CODE_SESSION_ID CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1 CLAUDE_CONFIG_DIR="$CLAUDE_CONFIG_DIR" ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" claude --dangerously-skip-permissions --plugin-dir "$SUPERPOWERS_ROOT" --model "$CLAUDE_MODEL" "$@"

--- a/docs/audits/2026-06-13-liveness-and-bitrot-audit.md
+++ b/docs/audits/2026-06-13-liveness-and-bitrot-audit.md
@@ -39,16 +39,33 @@ systemic capture rot" hypothesis was **wrong** and is retracted.
 
 ## Bitrot (wired up but broken)
 
-### B1 — claude transcript capture produces no transcript  [MITIGATED 2026-06-13: pin 2.1.175]
-DECISION (Jesse): pin claude **2.1.175** for now rather than chase the new
-layout — the older CLI still writes the legacy `projects/**/*.jsonl` the harness
-globs. Root cause CONFIRMED (below): claude 2.1.x moved session transcripts to
-`sessions/<uuid>/history.jsonl`. Independent corroboration: the `prudence`
-harness (TS, bun) globs the same old `projects/**/*.jsonl` and dodges the bug
-only by forcing `CLAUDE_CONFIG_DIR` + pinning an older claude — i.e. exactly the
-pin-2.1.175 strategy. Proper fix (prefer `sessions/<uuid>/history.jsonl`, fall
-back to legacy `projects/**`) deferred; revisit when we unpin or during the TS
-capture port. Original investigation below.
+### B1 — claude transcript capture produces no transcript  [RESOLVED 2026-06-13: FORCE_SESSION_PERSISTENCE=1]
+RESOLUTION: the launcher now sets `CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1`
+(`coding-agents/claude-context/launch-agent`); claude capture works on the latest
+CLI (2.1.177) with **no version pin**. The earlier "pin 2.1.175" decision and the
+"moved to `sessions/`" root cause are both **superseded — empirically disproven.**
+
+Real root cause (reconfirmed on 2.1.177): claude ≥2.1.176 *skips transcript
+persistence* when it detects a nested interactive Claude Code session. The
+existing `env -u CLAUDECODE -u CLAUDE_CODE_SESSION_ID` strip no longer covers
+every nested signal (e.g. `CLAUDE_CODE_CHILD_SESSION`), so the subject writes
+nothing. The transcript did **not** move to `sessions/`: claude still writes to
+`${CLAUDE_CONFIG_DIR}/projects/**/*.jsonl` (host had 7056 live `projects/` jsonl
+vs **0** `*.jsonl` in `sessions/`; authenticated `-p` probes also wrote to
+`projects/`) — the dir is empty purely from non-persistence, which *read* as a
+move. `CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1` is the documented override that
+forces persistence regardless of detection signals (version-proof; beats
+whack-a-mole on `env -u`). Same fix as prior exp-branch commit `5c2bebe`.
+
+Verified end-to-end on 2.1.177 (same hello-world smoke, same machine):
+- **before** (strip-only launcher) → `indeterminate`, "no Claude transcript appeared … /projects".
+- **after** (FORCE override) → `pass`, real **59K-token** capture, post-checks run.
+
+Do NOT pin 2.1.175 (defeats "stay on latest") and do NOT repoint the glob to
+`sessions/`. The `prudence` note below is **not** corroboration of a path move —
+it pinned an older claude to dodge the *same* non-persistence bug. The original
+investigation (with the now-disproven "moved to `sessions/`" hypothesis) is kept
+verbatim below as the audit trail.
 
 ---
 

--- a/scripts/audit_liveness.py
+++ b/scripts/audit_liveness.py
@@ -84,16 +84,19 @@ def inventory_setup_helpers() -> list[Unit]:
     tree = ast.parse(init)
     keys: dict[str, str] = {}
     for node in ast.walk(tree):
-        if isinstance(node, ast.Assign) and any(
-            isinstance(t, ast.Name) and t.id == "HELPER_REGISTRY" for t in node.targets
+        if (
+            isinstance(node, ast.Assign)
+            and isinstance(node.value, ast.Dict)
+            and any(isinstance(t, ast.Name) and t.id == "HELPER_REGISTRY" for t in node.targets)
         ):
-            if isinstance(node.value, ast.Dict):
-                for k, v in zip(node.value.keys, node.value.values):
-                    if isinstance(k, ast.Constant) and isinstance(v, ast.Name):
-                        keys[k.value] = v.id
-    return [
-        Unit(k, "setup-helper", REPO / "setup_helpers" / "__init__.py") for k in keys
-    ]
+            for k, v in zip(node.value.keys, node.value.values, strict=True):
+                if (
+                    isinstance(k, ast.Constant)
+                    and isinstance(k.value, str)
+                    and isinstance(v, ast.Name)
+                ):
+                    keys[k.value] = v.id
+    return [Unit(k, "setup-helper", REPO / "setup_helpers" / "__init__.py") for k in keys]
 
 
 def inventory_quorum_modules() -> list[Unit]:
@@ -107,8 +110,7 @@ def inventory_quorum_modules() -> list[Unit]:
 
 def inventory_coding_agents() -> list[Unit]:
     return [
-        Unit(p.stem, "coding-agent", p)
-        for p in sorted((REPO / "coding-agents").glob("*.yaml"))
+        Unit(p.stem, "coding-agent", p) for p in sorted((REPO / "coding-agents").glob("*.yaml"))
     ]
 
 
@@ -130,11 +132,10 @@ def count_refs(units: list[Unit], search_files: list[Path], own_files: set[Path]
     for u in units:
         pat = _word_re(u.name)
         for f, text in contents:
-            if f in own_files and u.kind != "bin-tool":
-                # bin tools legitimately reference each other (sourcing _record,
-                # wrapping `not`); count those. Other kinds: skip self-file.
-                if f == u.defined_in:
-                    continue
+            # bin tools legitimately reference each other (sourcing _record,
+            # wrapping `not`); count those. Other kinds: skip self-file.
+            if f in own_files and u.kind != "bin-tool" and f == u.defined_in:
+                continue
             if f == u.defined_in:
                 continue
             if pat.search(text):

--- a/tests/quorum/test_runner.py
+++ b/tests/quorum/test_runner.py
@@ -669,6 +669,52 @@ def test_gemini_launch_agent_is_substituted(tmp_path):
     assert "--skip-trust --approval-mode=yolo" in content
 
 
+def test_claude_launch_agent_forces_session_persistence(tmp_path):
+    """Regression (B1): the generated claude launcher must export
+    CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1.
+
+    claude >= 2.1.176 skips transcript persistence when it detects a nested
+    interactive Claude Code session; the `env -u CLAUDECODE -u
+    CLAUDE_CODE_SESSION_ID` strip no longer covers every nested-detection signal
+    (e.g. CLAUDE_CODE_CHILD_SESSION). Without the FORCE override the transcript
+    is never written, capture comes back empty, and every claude run launched
+    from inside Claude Code is a loud indeterminate(stage=capture). The override
+    forces persistence regardless of nested-session detection.
+    """
+    coding_agents_dir = tmp_path / "coding-agents"
+    scenarios_dir = tmp_path / "scenarios"
+    session_log_dir = tmp_path / "logs"
+    session_log_dir.mkdir()
+    _make_coding_agent(coding_agents_dir, "claude", session_log_dir)
+    (coding_agents_dir / "claude-context").mkdir(parents=True)
+    (coding_agents_dir / "claude-context" / "HOWTO.md").write_text("invoke `claude`")
+    shutil.copy2(
+        Path(__file__).resolve().parents[2] / "coding-agents" / "claude-context" / "launch-agent",
+        coding_agents_dir / "claude-context" / "launch-agent",
+    )
+    sd = _make_scenario(scenarios_dir, "x", with_checks=False)
+    (sd / "checks.sh").write_text("pre() { :; }\npost() { :; }\n")
+    out_root = tmp_path / "results"
+
+    with patch("quorum.runner.invoke_gauntlet", side_effect=_stub_gauntlet_pass):
+        run_scenario(
+            scenario_dir=sd,
+            coding_agent="claude",
+            coding_agents_dir=coding_agents_dir,
+            out_root=out_root,
+            skeleton_root=_empty_skeleton(tmp_path),
+        )
+
+    rd = next(out_root.iterdir())
+    shim = rd / "gauntlet-agent" / "context" / "launch-agent"
+    assert shim.exists()
+    content = shim.read_text()
+    # The nested-session identity strip is necessary but not sufficient on >=2.1.176 ...
+    assert "env -u CLAUDECODE -u CLAUDE_CODE_SESSION_ID" in content
+    # ... so the launcher must also force transcript persistence.
+    assert "CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1" in content
+
+
 def test_gemini_launch_agent_substitutes_oauth_auth_type(tmp_path, monkeypatch):
     coding_agents_dir = tmp_path / "coding-agents"
     scenarios_dir = tmp_path / "scenarios"


### PR DESCRIPTION
## Problem
Every claude eval launched from inside a Claude Code session returns `indeterminate(stage=capture)` — "no Claude transcript appeared under …/coding-agent-config/projects". The Gauntlet-Agent passes (the task succeeds), but capture is empty, so claude cost/token data is unobtainable on the latest CLI.

## Root cause (empirically confirmed on 2.1.177)
claude **≥2.1.176 skips transcript persistence** when it detects a nested interactive Claude Code session. The launcher's existing `env -u CLAUDECODE -u CLAUDE_CODE_SESSION_ID` strip no longer covers every nested-detection signal (e.g. `CLAUDE_CODE_CHILD_SESSION`), so the subject writes nothing.

This **disproves** the liveness-audit B1 theory that claude "moved transcripts to `sessions/<uuid>/history.jsonl`": claude still writes to `${CLAUDE_CONFIG_DIR}/projects/**/*.jsonl` (host had 7056 live `projects/` jsonl vs **0** in `sessions/`; authenticated `-p` probes wrote to `projects/` too). The dir is empty purely from non-persistence — which *read* as a move. So pinning 2.1.175 / repointing the glob are both wrong; `CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1` is the documented, version-proof override.

## Fix
- `coding-agents/claude-context/launch-agent`: set `CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1` (cherry-picked from verified exp-branch commit `5c2bebe`).
- `tests/quorum/test_runner.py`: regression test asserting the generated launcher carries the override (the fix originally shipped without one). TDD: RED for the right reason → GREEN.

## Verification (end-to-end, same smoke / machine / CLI 2.1.177)
| | before (strip only) | after (FORCE) |
|---|---|---|
| verdict | `indeterminate` | **`pass`** |
| capture | "no transcript appeared" | **59K tokens, \$0.13** |
| post-checks | couldn't run | `file-exists` ✓, `file-contains` ✓ |

## Also folded in (cleanup on the merged base)
- `scripts/audit_liveness.py` (from #15) tripped ruff `SIM102`×2 + `B905` and a ty `invalid-assignment`, turning whole-repo ruff/ty red on `main`. Fixed behavior-preservingly (combine ifs, `zip(strict=True)`, narrow constant keys to `str`).
- Corrected the **B1** entry in `docs/audits/2026-06-13-liveness-and-bitrot-audit.md` to the real root cause + resolution; original investigation kept as the audit trail.

## Checks
`ruff` ✓ · `ty` ✓ · `quorum check` ✓ · `pytest` 667 passed / 1 skipped. Live smoke is a trusted-maintainer op (not added to CI).

Post-merge: parent `superpowers` submodule bump (→ `dev`) per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)