### PR TITLE
fix(sdd-go-fractals): make the spec unambiguous + assert a golden output

### DIFF
--- a/fixtures/sdd-go-fractals/design.md
+++ b/fixtures/sdd-go-fractals/design.md
@@ -34,6 +34,21 @@ Flags:
 
 Output: Triangle printed to stdout, one line per row.
 
+**Rendering:** The triangle is **centered** — its apex sits over the middle of
+the base. `--size` is the **base width in characters** (the width of the bottom
+row), not the number of rows; the row count follows from the base width. With
+`--depth 0` the triangle is solid; higher depths cut the recursive Sierpinski
+gaps. Trailing whitespace on a row is not significant.
+
+Canonical output — `fractals sierpinski --size 7 --depth 0`:
+
+```text
+   *
+  ***
+ *****
+*******
+```
+
 ### `mandelbrot`
 
 Renders the Mandelbrot set as ASCII art. Maps iteration count to characters.

--- a/fixtures/sdd-go-fractals/plan.md
+++ b/fixtures/sdd-go-fractals/plan.md
@@ -48,9 +48,10 @@ Implement the Sierpinski triangle generation algorithm.
 - Implement `Generate(size, depth int, char rune) []string` that returns lines of the triangle
 - Use recursive midpoint subdivision algorithm
 - Create `internal/sierpinski/sierpinski_test.go` with tests:
-  - Small triangle (size=4, depth=2) matches expected output
+  - Filled triangle (`--size 7 --depth 0`) matches the canonical centered
+    output in design.md (`--size` is the base width)
   - Size=1 returns single character
-  - Depth=0 returns filled triangle
+  - Depth=0 returns a solid filled triangle; higher depth cuts recursive gaps
 
 **Verify:**
 - `go test ./internal/sierpinski/...` passes

--- a/scenarios/sdd-go-fractals/checks.sh
+++ b/scenarios/sdd-go-fractals/checks.sh
@@ -13,4 +13,9 @@ post() {
     command-succeeds 'go test ./...'
     file-exists 'cmd/fractals/main.go'
     git-count commits gte 4
+    # Pin --size = base width AND centered shape: the spec ambiguity that let
+    # implementations silently diverge (size=rows, or a left-aligned right
+    # triangle) while still passing their own tests. design.md canonical:
+    # `sierpinski --size 7 --depth 0`. Trailing whitespace is not significant.
+    command-succeeds 'diff <(go run ./cmd/fractals sierpinski --size 7 --depth 0 | sed "s/[[:space:]]*$//") <(printf "   *\n  ***\n *****\n*******\n")'
 }


### PR DESCRIPTION
## Problem

The `sdd-go-fractals` fixture's spec contradicts itself, and it has no canonical output — so implementations silently diverge and all still pass.

- **`--size` is defined two ways.** `design.md`: *"Width of the triangle base in characters."* `plan.md` Task 3: *"Small triangle (size=4, depth=2) matches expected output"* — but the canonical small Sierpinski triangle is **7** wide, so `size=4` only fits if `size` = row count. Direct contradiction.
- **The shape is never pinned** (centered vs right-triangle).
- **No golden output**, and `checks.sh` only gates build / `go test` / file presence / commit count — never *what the triangle looks like*.

This isn't theoretical. Three codex runs of this scenario produced **three different deliverables** for `sierpinski --size 8 --depth 0`:

| run | output |
|---|---|
| A | 8 rows × 15 wide, centered (size = rows) |
| B | 4 rows × 8 wide, centered (size = base width — matches `design.md`) |
| C | 8 rows × 8 wide, **left-aligned right triangle** (wrong shape) |

All three **passed** — each run's tests assert its own output, so the divergence was invisible to the deterministic checks *and* the SDD spec/quality reviews.

## Change

- **design.md** — pin `--size` = base width, the **centered** shape, and a **canonical output** (`sierpinski --size 7 --depth 0`).
- **plan.md** — make Task 3's example consistent with base-width semantics (no more `size=4`).
- **checks.sh** — assert the built binary's `sierpinski --size 7 --depth 0` matches the canonical output (trailing-whitespace-tolerant), so the scenario verifies *what was built*, not just that tests pass.

## Validation

Ran the new golden check against the three real deliverables above: it **passes** on the spec-compliant one (B) and **fails** both divergent ones (A size=rows, C right-triangle). `bash -n` clean; `test_scenario_pinning.py` + `test_scaffold.py` + `test_checks.py` (39 tests) pass.

## Notes / scope

- A `size=rows` or right-triangle implementation now **fails** this scenario — intended tightening; it's the bug this PR closes.
- This changes the fixture, so it's a clean break from prior runs' comparability (the prior spec was broken).
- Sibling fixtures (`sdd-go-fractals-crisp`, `-stripped`, `-critical-plan`, …) likely share the `design.md` size ambiguity — left for a follow-up to keep this PR to one problem.
- The companion behavioral eval (catching a spec contradiction *before* code is written) is a separate PR.

---
Authored by **Claude (Fable 5)** in Claude Code, at @obra's direction. Found while auditing three codex runs of this scenario; change developed + validated against those runs' deliverables.
