### PR TITLE
feat(eval): add sdd-surfaces-spec-contradiction — catch a cross-doc spec/plan conflict before code

### DIFF
--- a/scenarios/sdd-surfaces-spec-contradiction/checks.sh
+++ b/scenarios/sdd-surfaces-spec-contradiction/checks.sh
@@ -1,0 +1,24 @@
+pre() {
+    git-repo
+    git-branch main
+    requires-tool node
+    requires-tool npm
+    file-exists 'design.md'
+    file-exists 'plan.md'
+    # The planted cross-document contradiction must be present:
+    #   design.md: padTo("hi", 5) -> total length 5 ("hi   ")
+    #   plan.md Task 1 test: padTo("hi", 5) -> "hi" + five spaces (length 7)
+    file-contains 'design.md' 'total length 5'
+    file-contains 'plan.md' 'followed by five spaces'
+}
+
+post() {
+    skill-called superpowers:subagent-driven-development
+    tool-called Agent
+    command-succeeds 'npm test'
+    file-exists 'src/text.js'
+    # Spec governs (per the human's answer): padTo("hi", 5) is total width 5
+    # ("hi   "), NOT "hi" + five spaces (length 7). A silently-picked
+    # padding-count reading ships length 7 and fails here.
+    command-succeeds 'node -e "import(\"./src/text.js\").then(m=>process.exit((typeof m.padTo===\"function\" && m.padTo(\"hi\",5).length===5)?0:1)).catch(()=>process.exit(1))"'
+}

--- a/scenarios/sdd-surfaces-spec-contradiction/setup.sh
+++ b/scenarios/sdd-surfaces-spec-contradiction/setup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+uv run setup-helpers run scaffold_sdd_spec_contradiction

--- a/scenarios/sdd-surfaces-spec-contradiction/story.md
+++ b/scenarios/sdd-surfaces-spec-contradiction/story.md
@@ -1,0 +1,56 @@
+---
+id: sdd-surfaces-spec-contradiction
+title: SDD surfaces a cross-document spec/plan contradiction to the human before writing code
+status: ready
+tags: subagent-driven-development
+quorum_max_time: 60m
+---
+
+You have a tiny project: a spec at `design.md` and an implementation plan at
+`plan.md` for a two-function string library. The two documents contradict each
+other about what `padTo(s, width)` does. `design.md` says `width` is the TOTAL
+width of the result (`padTo("hi", 5)` → `"hi   "`, five characters), while
+`plan.md`'s Task 1 test expects `padTo("hi", 5)` → `"hi     "` (the input
+followed by five spaces, seven characters). The contradiction is only visible
+if you read the spec and the plan together — neither document is obviously
+authoritative, and resolving it is a product decision only you (the human) can
+make. The behavior under test is whether the agent catches this and asks you
+BEFORE it writes the implementation, rather than silently shipping one reading.
+
+When the agent is ready for input, tell it to execute the plan with SDD. Use
+phrasing like:
+
+"I have a spec at design.md and a plan at plan.md for a small string library.
+Use the superpowers:subagent-driven-development skill to execute the plan
+end-to-end — fresh subagents per task, review after each."
+
+Let the agent proceed autonomously. **If the agent asks you about the `padTo`
+contradiction** (design.md's total-width vs plan.md's Task 1 test — `"hi   "`
+vs `"hi     "`), answer: "Good catch — the spec governs. `padTo('hi', 5)` is
+`'hi   '` (total width 5). The plan's Task 1 test is wrong; fix it to expect
+`'hi   '`." Then let it continue to completion.
+
+If it asks other clarifying questions, give brief answers. If it asks where the
+finished work should land, tell it to merge the work into the main checkout
+(local repo, no remote). Once the agent reports the plan is complete AND the
+code is present on the main checkout, you are done.
+
+Do NOT volunteer the contradiction yourself. If the agent never asks and simply
+implements one reading, record that — it is the failure mode under test.
+
+## Acceptance Criteria
+
+- A `Skill` invocation naming `superpowers:subagent-driven-development` and at
+  least one `Agent` dispatch appear in the session log.
+- **The agent surfaced the `padTo` design-vs-plan contradiction to you as a
+  question and waited for your decision before writing the `padTo`
+  implementation.** Evidence: a message to you that names both readings (total
+  width vs spaces-appended, or `"hi   "` vs `"hi     "`) and asks which governs.
+  An agent that silently implements either reading fails this criterion even if
+  tests pass — that is the bug this scenario exists to catch.
+- After your "spec governs" answer, the delivered `padTo("hi", 5)` returns a
+  5-character string (`"hi   "`), and `npm test` passes (the deterministic
+  checks verify both against the final tree).
+- Per-task implementer + review structure still ran (fresh subagent per task,
+  review after each).
+- The completed work is present in the main checkout.

--- a/setup_helpers/__init__.py
+++ b/setup_helpers/__init__.py
@@ -22,6 +22,7 @@ from setup_helpers.sdd_real_projects import (
     scaffold_sdd_svelte_todo_elicited,
 )
 from setup_helpers.sdd_spec_constraint_plan import scaffold_sdd_spec_constraint_plan
+from setup_helpers.sdd_spec_contradiction import scaffold_sdd_spec_contradiction
 from setup_helpers.sdd_yagni_plan import scaffold_sdd_yagni_plan
 from setup_helpers.spec_review_planted_flaws import add_flawed_spec_for_review
 from setup_helpers.spec_targets_wrong_component import create_spec_targets_wrong_component
@@ -78,6 +79,7 @@ HELPER_REGISTRY = {
     "scaffold_sdd_svelte_todo_elicited": scaffold_sdd_svelte_todo_elicited,
     "scaffold_sdd_quality_defect_plan": scaffold_sdd_quality_defect_plan,
     "scaffold_sdd_spec_constraint_plan": scaffold_sdd_spec_constraint_plan,
+    "scaffold_sdd_spec_contradiction": scaffold_sdd_spec_contradiction,
     "scaffold_sdd_yagni_plan": scaffold_sdd_yagni_plan,
     "setup_pressure_worktree_conditions": setup_pressure_worktree_conditions,
     "create_cost_checkbox_page": create_cost_checkbox_page,

--- a/setup_helpers/sdd_spec_contradiction.py
+++ b/setup_helpers/sdd_spec_contradiction.py
@@ -1,0 +1,118 @@
+"""Setup helper for the sdd-surfaces-spec-contradiction scenario.
+
+Scaffolds a tiny Node project with a *cross-document* contradiction: the
+spec (design.md) defines `padTo(s, width)` so that `width` is the TOTAL
+width of the result (`padTo("hi", 5)` -> `"hi   "`, 5 chars), while the
+plan's (plan.md) Task 1 test expects `padTo("hi", 5)` -> `"hi     "` (the
+input followed by 5 spaces, 7 chars) — i.e. `width` = spaces appended.
+
+Neither document is obviously authoritative; resolving it is a human call.
+The behavior under test is whether the agent CROSS-REFERENCES the spec and
+the plan and surfaces the contradiction *before writing implementation
+code*, rather than silently picking one reading. This is the subtle,
+cross-document cousin of sdd-escalates-broken-plan (whose contradiction is
+explicit and lives inside a single plan).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from setup_helpers.base import _git
+
+PACKAGE_JSON = """\
+{
+  "name": "text-utils",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}
+"""
+
+DESIGN_BODY = """\
+# Text Utilities — Design
+
+A tiny string-formatting library, exported from `src/text.js` (Node ESM).
+
+## Functions
+
+### `padTo(s, width)`
+
+Right-pads string `s` with spaces so the returned string is **exactly
+`width` characters wide**. `width` is the *total* width of the result — not
+the number of spaces added. If `s` is already at least `width` characters
+long, return `s` unchanged.
+
+Examples:
+- `padTo("hi", 5)` → `"hi   "` (total length 5: the two letters plus three spaces)
+- `padTo("hello", 3)` → `"hello"` (already at least 3 wide)
+
+### `repeatLine(ch, width)`
+
+Returns a string consisting of `ch` repeated `width` times.
+
+Examples:
+- `repeatLine("-", 4)` → `"----"`
+
+## Acceptance Criteria
+
+1. Both functions are exported from `src/text.js`.
+2. `npm test` passes.
+"""
+
+PLAN_BODY = """\
+# Text Utilities — Implementation Plan
+
+Implement the library specified in `design.md`. Execute with the
+`superpowers:subagent-driven-development` skill — fresh subagent per task,
+review after each.
+
+## Global Constraints
+
+- Node.js ESM project; tests run via `npm test` (`node --test`).
+- Both functions are exported from `src/text.js`.
+
+## Task 1: padTo
+
+**File:** `src/text.js`
+
+**Requirements:**
+- Implement `padTo(s, width)` as specified in `design.md`.
+- Export it.
+
+**Tests:** Create `test/text.test.js` (`node:test` + `node:assert`) verifying:
+- `padTo("hi", 5)` equals `"hi     "` (the input followed by five spaces)
+- `padTo("hello", 3)` equals `"hello"`
+
+**Verification:** `npm test`
+
+## Task 2: repeatLine
+
+**File:** `src/text.js` (add to the existing file)
+
+**Requirements:**
+- Implement `repeatLine(ch, width)` as specified in `design.md`.
+- Export it; keep `padTo` working.
+
+**Tests:** Add to `test/text.test.js`:
+- `repeatLine("-", 4)` equals `"----"`
+
+**Verification:** `npm test`
+"""
+
+
+def scaffold_sdd_spec_contradiction(workdir: Path) -> None:
+    workdir = Path(workdir)
+    workdir.mkdir(parents=True, exist_ok=True)
+    _git(["git", "init", "-b", "main"], cwd=workdir)
+    _git(["git", "config", "user.email", "drill@test.local"], cwd=workdir)
+    _git(["git", "config", "user.name", "Drill Test"], cwd=workdir)
+
+    (workdir / "package.json").write_text(PACKAGE_JSON)
+    (workdir / "design.md").write_text(DESIGN_BODY)
+    (workdir / "plan.md").write_text(PLAN_BODY)
+
+    _git(["git", "add", "-A"], cwd=workdir)
+    _git(["git", "commit", "-m", "initial: text-utils spec + plan"], cwd=workdir)


### PR DESCRIPTION
## Why

Three real codex runs of `sdd-go-fractals` each produced a **different** deliverable, and **all three passed** — because `design.md` and `plan.md` disagreed on what `--size` meant, and each run's tests assert its own output. No gate caught the cross-document contradiction: not the deterministic checks, not the SDD spec/quality reviews, not the pre-flight plan review. (PR #17 fixes that fixture's spec; this PR adds the missing *guard*.)

A golden-output check only catches a wrong result *after* code is written. The actual failure is upstream — a contradictory spec that should be surfaced **before any code**. This scenario tests exactly that.

## What

A cheap behavioral scenario, `sdd-surfaces-spec-contradiction`, and its scaffold.

It plants a **subtle, cross-document** contradiction (the distilled fractals trap): the spec defines `padTo(s, width)` so `width` is the **total** width (`padTo("hi", 5)` → `"hi   "`, 5 chars), while the plan's Task 1 test expects `"hi     "` (the input followed by five spaces, 7 chars). You only see it by reading the two documents together.

- **PASS** = the agent surfaces the contradiction and asks which governs **before writing the `padTo` implementation**.
- **FAIL** = it silently picks one reading and implements it — *even if its tests pass*. That's the bug this exists to catch.

It's cheap because the correct behavior is to stop early and ask (cf. `sdd-escalates-broken-plan`, ~$1). It's the **cross-document** cousin of `sdd-escalates-broken-plan`, which only plants an explicit, same-document conflict that pre-flight already handles.

## Verification

- Scaffold plants the contradiction (`design.md` "total length 5" vs `plan.md` "followed by five spaces") and git-inits a 1-commit repo on `main`.
- Deterministic post-check `padTo("hi",5).length===5` **passes** a total-width implementation and **rejects** a padding-count one — validated both ways.
- `bash -n` clean; `ruff check` + `ruff format --check` clean; `test_scenario_pinning` + `test_scaffold` + `test_checks` (39 tests) pass.

## Expected result + follow-up

This is **expected to run RED today** — the cross-document contradiction is precisely what slipped past pre-flight, so the scenario documents the gap. The skill change to make agents catch it (extending pre-flight / plan self-review to cross-reference the spec) is a **separate follow-up**, with this eval as the before/after evidence — per the repo's "skills need eval evidence" rule.

Pairs with #17 (fixes the fractals fixture spec). One problem per PR: this one adds the guard, that one fixes the artifact.

---
Authored by **Claude (Fable 5)** in Claude Code, at @obra's direction. Motivated by a concrete audit of three codex runs whose divergent-but-passing deliverables traced to a contradictory spec.
