### PR TITLE
feat: managed quorum Phase 1 (shared-host AWS eval runner) + specs

### DIFF
--- a/coding-agents/opencode-context/launch-agent
+++ b/coding-agents/opencode-context/launch-agent
@@ -18,6 +18,9 @@ for name in \
   GEMINI_API_KEY GOOGLE_API_KEY \
   AWS_PROFILE AWS_REGION AWS_DEFAULT_REGION \
   AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN; do
+  if [[ "${QUORUM_MANAGED_HOST:-}" == "1" && ",${QUORUM_TARGET_ENV_KEYS:-}," != *",$name,"* ]]; then
+    continue
+  fi
   if [[ -n "${!name-}" ]]; then
     env_args+=("$name=${!name}")
   fi

--- a/docs/superpowers/plans/2026-06-12-quorum-aws-eval-runner-phase-1.md
+++ b/docs/superpowers/plans/2026-06-12-quorum-aws-eval-runner-phase-1.md
@@ -1,0 +1,1165 @@
+# Quorum AWS Eval Runner Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:subagent-driven-development` for this plan. Execute one task at a
+> time, verify it, commit it, then continue. Use `superpowers:using-git-worktrees`
+> before implementation if the main checkout is not already isolated.
+
+**Goal:** Add the smallest useful managed remote runner for Quorum evals on a
+single AWS host, with safe shared-team operation, key-backed targets, explicit
+parallelism, and a clean path toward an eval platform.
+
+**Architecture:** Keep Quorum as the only user-facing eval API. Add managed
+Quorum commands that enqueue and run jobs on the AWS host; do not add a separate
+service API in Phase 1. Store job state, run artifacts, lock files, and cooldown
+markers on the host filesystem. Provision the host in Terminus Terraform using
+the existing EC2 plus encrypted EBS plus SSM secret pattern.
+
+**Tech Stack:** Python 3.11, Click, Quorum, uv, pytest, fcntl file locks, JSONL
+job/event files, Terraform, Terminus `machine-westworld`, encrypted EBS, SSM
+SecureString, DLM snapshots, SSM Session Manager.
+
+**Specs:** This plan implements Phase 1a and Phase 1b from:
+
+- `docs/superpowers/specs/2026-06-12-quorum-aws-eval-runner-design.md`
+- `docs/superpowers/specs/2026-06-12-quorum-aws-eval-runner-phase-1-design.md`
+
+**Important Current-State Note:** Quorum already has story `tier` and `status`
+support in `quorum/story_meta.py`, `quorum/run_all.py`, and `quorum/cli.py`.
+Do not reimplement suite tiering. Build the managed runner on top of the
+existing `--tier` and `--include-drafts` seams.
+
+## Repo Boundaries
+
+Implement this as two coordinated changes:
+
+1. `superpowers-evals`
+   - Managed Quorum commands.
+   - Runtime environment sanitization.
+   - Job state and lock model.
+   - Doctor/smoke/column/batch/status/tail behavior.
+   - Unit and integration-style tests that do not launch live agent CLIs.
+
+2. `brooks/terminus`
+   - Terraform service root for the AWS runner.
+   - Userdata/bootstrap scripts.
+   - Persistent encrypted EBS, DLM backups, IAM, and SSM SecureString entries.
+   - Operator runbook and bootstrap verification.
+
+Keep Phase 1 intentionally filesystem-backed. Do not introduce a web service,
+database, queue service, container orchestrator, or multi-host scheduling in this
+plan.
+
+## User-Facing Phase 1 Shape
+
+The user-facing surface remains Quorum:
+
+```bash
+uv run quorum doctor --all
+uv run quorum doctor claude
+uv run quorum smoke claude
+uv run quorum column claude --jobs 2
+uv run quorum batch --tier sentinel --coding-agent claude --jobs 2
+uv run quorum status
+uv run quorum status <job-id>
+uv run quorum tail <job-id>
+uv run quorum tail <job-id> --child <child-id>
+```
+
+On the AWS host, raw live eval commands fail closed:
+
+```bash
+uv run quorum run scenarios/basic-follow-instructions --coding-agent claude
+uv run quorum run-all --coding-agent claude --tier sentinel
+```
+
+Those raw commands are still valid on developer laptops. On the AWS host they
+must exit with a message that points to `smoke`, `column`, or `batch`.
+
+## Managed Runner Filesystem Contract
+
+Use these defaults on the AWS host:
+
+```text
+/opt/quorum/current                 # repo checkout
+/opt/quorum/state                   # active jobs, locks, cooldowns, taint markers
+/opt/quorum/artifacts               # Quorum run artifacts and batch artifacts
+/opt/quorum/worktrees               # per-job working copies for mutable checkout work
+/opt/quorum/cache                   # uv/pip/npm/model helper cache
+/etc/quorum/target-profiles.d       # root-owned target secret profiles
+```
+
+The local test defaults should stay inside a temp directory and be controlled by:
+
+```text
+QUORUM_MANAGED_HOST=1
+QUORUM_STATE_ROOT=<path>
+QUORUM_ARTIFACT_ROOT=<path>
+QUORUM_TARGET_PROFILE_ROOT=<path>
+QUORUM_MANAGED_WORKER=1
+```
+
+`QUORUM_MANAGED_HOST=1` means managed host behavior is active.
+`QUORUM_MANAGED_WORKER=1` is set only for internal worker subprocesses and
+allows the worker to call the raw `run` and `run-all` implementation.
+
+## Job Schema
+
+Write one JSON file per job under:
+
+```text
+$QUORUM_STATE_ROOT/jobs/<job-id>.json
+```
+
+Use an append-only event stream under:
+
+```text
+$QUORUM_STATE_ROOT/events/<job-id>.jsonl
+```
+
+Use this schema for the job file:
+
+```json
+{
+  "schema_version": 1,
+  "id": "job-20260612T170501Z-a1b2",
+  "state": "planned",
+  "created_at": "2026-06-12T17:05:01Z",
+  "updated_at": "2026-06-12T17:05:01Z",
+  "started_at": null,
+  "finished_at": null,
+  "owner": "drew",
+  "host": "quorum-evals",
+  "command": ["quorum", "column", "claude", "--jobs", "2"],
+  "managed_command": "column",
+  "profile": null,
+  "coding_agents": ["claude"],
+  "tier": "sentinel",
+  "scenario_filter": null,
+  "include_drafts": false,
+  "out_root": "/opt/quorum/artifacts",
+  "log_path": "/opt/quorum/state/logs/job-20260612T170501Z-a1b2.log",
+  "locks": [],
+  "env_profiles": ["claude"],
+  "evals_repo": null,
+  "superpowers_repo": null,
+  "supervisor": null,
+  "children": [],
+  "result_rollup": null,
+  "tainted": false,
+  "taint_reason": null,
+  "taint_matches": [],
+  "artifact_bytes": null,
+  "final_exit_code": null,
+  "failure_reason": null
+}
+```
+
+Use these durable managed job states only:
+
+```text
+planned
+running
+succeeded
+failed
+interrupted
+```
+
+`orphaned` is derived by `status` when metadata exists, the recorded supervisor
+is gone or stale, and final state cannot be determined. Phase 1 fails fast on
+lock conflict; it does not implement queued or waiting states.
+
+Job state is about managed-command execution, not eval verdict. A managed batch
+can be `succeeded` while its `result_rollup` contains failed or indeterminate
+eval cells. Taint is represented with `tainted`, `taint_reason`, and
+`taint_matches`; it is not a separate lifecycle state in Phase 1.
+
+## Parallelism Model
+
+The Phase 1 runner uses three layers of concurrency:
+
+1. User jobs
+   - Multiple users may enqueue jobs.
+   - A global lock prevents overcommitting the host past configured capacity.
+
+2. Batch children
+   - A `batch` or `column` job owns a batch directory.
+   - Each scenario/target cell becomes a child record in the parent job file.
+
+3. Harness-specific `--jobs`
+   - The `jobs` argument remains the child concurrency for one batch.
+   - Do not treat it as global host capacity.
+
+Add an explicit managed host capacity setting:
+
+```text
+QUORUM_MAX_ACTIVE_BATCH_JOBS=1
+QUORUM_MAX_ACTIVE_CHILDREN=4
+```
+
+For Phase 1a, set production defaults to:
+
+```text
+QUORUM_MAX_ACTIVE_BATCH_JOBS=1
+QUORUM_MAX_ACTIVE_CHILDREN=2
+```
+
+This is enough for shared use while preserving predictable API-key and machine
+load. Phase 1b can raise child concurrency after sentinel evidence is clean.
+
+## Lock Model
+
+Use `fcntl.flock` on files under:
+
+```text
+$QUORUM_STATE_ROOT/locks
+```
+
+Acquire locks in this exact order:
+
+```text
+global
+checkout
+provider:<provider-name>
+target:<target-name>
+```
+
+Locks:
+
+- `global.active` limits total active managed jobs.
+- `checkout` is exclusive when a command mutates the shared checkout; most eval
+  runs should avoid this lock by using a fixed checkout or a job worktree.
+- `provider:<provider-name>` protects API-key family rate limits.
+- `target:<target-name>` prevents unsafe overlapping runs for targets that are
+  not concurrency-safe.
+
+Lock sidecar files contain the current holder:
+
+```json
+{
+  "job_id": "job-20260612T170501Z-a1b2",
+  "pid": 12345,
+  "hostname": "quorum-evals",
+  "started_at": "2026-06-12T17:05:01Z",
+  "command": "column claude --jobs 2"
+}
+```
+
+If a lock cannot be acquired, write the failed job record, append a lock-conflict
+event, set state `failed`, and surface the conflicting holder in `quorum status`.
+Phase 1 does not keep the job waiting for a later retry.
+
+## Target Profiles
+
+Target profiles are root-owned shell fragments:
+
+```text
+/etc/quorum/target-profiles.d/claude.env
+/etc/quorum/target-profiles.d/codex.env
+/etc/quorum/target-profiles.d/opencode.env
+/etc/quorum/target-profiles.d/kimi.env
+/etc/quorum/target-profiles.d/gemini.env
+/etc/quorum/target-profiles.d/copilot.env
+```
+
+File permissions:
+
+```text
+owner: root
+group: quorum
+mode: 0640
+```
+
+A target profile contains only allowlisted variables for that target. Example:
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-example
+```
+
+The managed runner reads a profile only inside the worker process. It must not
+write the values to the job file, event stream, stdout, stderr, or artifact
+metadata.
+
+## Runtime Environment Policy
+
+Managed commands must build a fresh environment for setup, checks, Gauntlet, and
+child `quorum run` processes. Do not inherit ambient shell secrets on the host.
+
+Always include:
+
+```text
+PATH
+HOME
+TMPDIR
+LANG
+LC_ALL
+QUORUM_WORKDIR
+QUORUM_RUN_DIR
+QUORUM_ARTIFACT_ROOT
+QUORUM_STATE_ROOT
+SUPERPOWERS_ROOT
+```
+
+Allow target credentials only from the selected profile. Permit only the
+variables explicitly mapped for the selected target. In tests, poison ambient
+secret variables and assert they do not reach setup/check/child/Gauntlet envs.
+
+## Implementation Tasks
+
+### Task 1: Managed State Foundation
+
+Files:
+
+- Add `quorum/managed_state.py`
+- Add `tests/quorum/test_managed_state.py`
+
+Implement:
+
+- `ManagedPaths`
+  - `state_root`
+  - `artifact_root`
+  - `jobs_dir`
+  - `events_dir`
+  - `locks_dir`
+  - `cooldowns_dir`
+  - `taints_dir`
+- `discover_managed_paths(env: Mapping[str, str]) -> ManagedPaths`
+- `new_job_id(now: datetime, kind: str, target: str | None) -> str`
+- `write_job_atomic(paths: ManagedPaths, job: ManagedJob) -> None`
+- `read_job(paths: ManagedPaths, job_id: str) -> ManagedJob`
+- `list_jobs(paths: ManagedPaths) -> JobListResult`
+- `append_event(paths: ManagedPaths, job_id: str, event: Mapping[str, object])`
+- `mark_job_state(paths: ManagedPaths, job_id: str, state: str, *, result_rollup: Mapping[str, object] | None = None, final_exit_code: int | None = None, failure_reason: str | None = None) -> ManagedJob`
+- `heartbeat_job(paths: ManagedPaths, job_id: str, now: datetime) -> ManagedJob`
+- `mark_job_tainted(paths: ManagedPaths, job_id: str, reason: str, matches: Sequence[Mapping[str, object]]) -> ManagedJob`
+
+Use plain dataclasses plus JSON helpers.
+
+Tests:
+
+- Creates state directories lazily.
+- Job IDs are unique, sortable, and use the spec shape
+  `job-YYYYMMDDTHHMMSSZ-a1b2`.
+- Atomic writes never leave partial JSON when replacing an existing file.
+- `list_jobs` returns a `JobListResult`, ignores malformed files, and includes
+  one diagnostic per malformed file.
+- `heartbeat_job` updates `updated_at` without mutating immutable fields.
+- `mark_job_tainted` sets `tainted=true`, preserves the previous `state`, and
+  preserves the previous `result_rollup`.
+
+Verification:
+
+```bash
+uv run pytest tests/quorum/test_managed_state.py -q
+uv run ruff check quorum/managed_state.py tests/quorum/test_managed_state.py
+uv run ty check quorum/managed_state.py tests/quorum/test_managed_state.py
+```
+
+Commit:
+
+```bash
+git add quorum/managed_state.py tests/quorum/test_managed_state.py
+git commit -m "Add managed quorum job state"
+```
+
+### Task 2: Locks, Cooldowns, and Capacity
+
+Files:
+
+- Add `quorum/locks.py`
+- Add `tests/quorum/test_locks.py`
+- Add `tests/quorum/fixtures/lock_holder.py`
+
+Implement:
+
+- `ManagedLock`
+- `LockRequest`
+- `LockConflict`
+- `acquire_locks(paths, requests, job_id, command, wait=False)`
+- `release_locks(held: Sequence[ManagedLock]) -> None`
+- `read_lock_holder(paths: ManagedPaths, lock_name: str) -> LockHolder | None`
+- `write_cooldown(paths, provider, reason, until)`
+- `read_active_cooldowns(paths, now)`
+
+Rules:
+
+- Sort lock acquisition by the fixed order in this plan.
+- Use non-blocking acquisition for user-facing enqueue/start paths.
+- Store sidecar JSON while the lock is held.
+- Remove sidecar JSON on clean release.
+- Treat stale sidecars as diagnostics only. The kernel lock is the source of
+  truth.
+- Cooldowns are JSON files under `$QUORUM_STATE_ROOT/cooldowns/<provider>.json`.
+
+Tests:
+
+- A second process cannot acquire an exclusive lock already held by a first
+  process.
+- Lock requests are acquired in deterministic order independent of caller order.
+- Sidecar content includes job ID, pid, hostname, started time, and command.
+- Cooldown read returns active cooldowns and drops expired cooldowns.
+- Lock conflict objects are JSON serializable for status output.
+
+Verification:
+
+```bash
+uv run pytest tests/quorum/test_locks.py -q
+uv run ruff check quorum/locks.py tests/quorum/test_locks.py
+uv run ty check quorum/locks.py tests/quorum/test_locks.py
+```
+
+Commit:
+
+```bash
+git add quorum/locks.py tests/quorum/test_locks.py tests/quorum/fixtures/lock_holder.py
+git commit -m "Add managed quorum locks and cooldowns"
+```
+
+### Task 3: Sanitized Runtime Environment and Raw Command Gate
+
+Files:
+
+- Add `quorum/runtime_env.py`
+- Add `tests/quorum/test_runtime_env.py`
+- Modify `quorum/cli.py`
+- Modify `quorum/runner.py`
+- Modify `quorum/setup_step.py`
+- Modify `quorum/checks.py`
+- Modify `quorum/run_all.py`
+- Modify `quorum/opencode_capture.py`
+- Modify `coding-agents/opencode-context/launch-agent`
+- Modify related existing tests:
+  - `tests/quorum/test_cli.py`
+  - `tests/quorum/test_runner.py`
+  - `tests/quorum/test_setup_step.py`
+  - `tests/quorum/test_checks.py`
+  - `tests/quorum/test_run_all.py`
+  - `tests/quorum/test_opencode_capture.py`
+
+Implement:
+
+- `is_managed_host(env) -> bool`
+- `is_managed_worker(env) -> bool`
+- `TargetProfile`
+- `TargetProfileError`
+- `load_target_profile(profile_root, target) -> TargetProfile`
+- `build_managed_env(base_env, paths, target_profile, runtime_vars) -> dict[str, str]`
+- `redact_env_for_logs(env) -> dict[str, str]`
+- `assert_raw_command_allowed(command_name, env) -> None`
+
+Raw command gate:
+
+- If `QUORUM_MANAGED_HOST=1` and `QUORUM_MANAGED_WORKER` is not `1`, block
+  `run` and `run-all`.
+- Exit with code `2`.
+- Print a short actionable message:
+
+```text
+raw live eval commands are disabled on the managed Quorum host; use quorum smoke, quorum column, or quorum batch
+```
+
+Environment threading:
+
+- `setup_step._run_scenario_script` accepts `env_base` and uses it instead of
+  `os.environ` when provided.
+- `checks.run_phase` accepts `env_base` and uses it instead of `os.environ` when
+  provided.
+- `runner.run_scenario` and `_run_scenario_inner` accept a runtime environment
+  object, then pass sanitized env to setup, checks, and Gauntlet.
+- `run_all.run_batch` accepts `env_base` and passes it to child `quorum run`
+  subprocesses.
+- `opencode_capture` stops treating provider secrets as a broad global allowlist
+  in managed mode. In managed mode, it receives the exact target env from
+  `runtime_env`.
+- `coding-agents/opencode-context/launch-agent` narrows env forwarding in
+  managed mode to the selected profile variables.
+
+Tests:
+
+- On a managed host, `quorum run` exits `2` and does not invoke runner code.
+- On a managed host, `quorum run-all` exits `2` and does not invoke batch code.
+- With `QUORUM_MANAGED_WORKER=1`, raw commands are allowed.
+- Poison ambient env values such as `OPENAI_API_KEY=ambient-poison` and
+  `ANTHROPIC_API_KEY=ambient-poison` do not reach setup, checks, child
+  `quorum run`, Gauntlet, or OpenCode launch env unless the selected target
+  profile explicitly contains them.
+- Redaction preserves key names and replaces values with `[redacted]`.
+
+Verification:
+
+```bash
+uv run pytest tests/quorum/test_runtime_env.py tests/quorum/test_cli.py -q
+uv run pytest tests/quorum/test_runner.py tests/quorum/test_setup_step.py tests/quorum/test_checks.py tests/quorum/test_run_all.py tests/quorum/test_opencode_capture.py -q
+uv run ruff check quorum/runtime_env.py quorum/cli.py quorum/runner.py quorum/setup_step.py quorum/checks.py quorum/run_all.py quorum/opencode_capture.py tests/quorum
+uv run ty check quorum/runtime_env.py quorum/cli.py quorum/runner.py quorum/setup_step.py quorum/checks.py quorum/run_all.py quorum/opencode_capture.py
+```
+
+Commit:
+
+```bash
+git add quorum/runtime_env.py quorum/cli.py quorum/runner.py quorum/setup_step.py quorum/checks.py quorum/run_all.py quorum/opencode_capture.py coding-agents/opencode-context/launch-agent tests/quorum
+git commit -m "Sanitize managed quorum runtime environment"
+```
+
+### Task 4: Target Doctor
+
+Files:
+
+- Add `quorum/doctor.py`
+- Add `tests/quorum/test_doctor.py`
+- Modify `quorum/cli.py`
+- Modify `coding-agents/*.yaml` only when a target lacks enough checked-in
+  metadata to map it to provider/profile requirements
+
+Implement:
+
+- `DoctorStatus` enum with `ready`, `blocked`, `failed`.
+- `DoctorCheck` record with `name`, `status`, `message`, and optional
+  `remediation`.
+- `run_target_doctor(target, paths, env) -> TargetDoctorResult`.
+- `run_all_doctors(paths, env) -> list[TargetDoctorResult]`.
+
+Doctor checks:
+
+- Coding-agent config exists.
+- Target profile file exists when managed host mode is active.
+- Target profile file permissions are not group/world writable.
+- Required credential variables for the target are present in the profile.
+- Required local tools exist on `PATH`.
+- Required context/home skeleton directories exist.
+- Existing Quorum scenario metadata can select at least one runnable sentinel
+  scenario for that target.
+
+Exit codes:
+
+- `quorum doctor <target>`
+  - `0` when target is ready.
+  - `3` when target is blocked by missing credentials or a known unavailable
+    local tool.
+  - `1` when the doctor itself fails.
+- `quorum doctor --all`
+  - `0` when every checked target is ready or blocked.
+  - `1` when any target has doctor failure.
+
+Output:
+
+- Human-readable table by default.
+- `--json` returns stable JSON for automation.
+
+Tests:
+
+- Ready target returns exit `0`.
+- Missing profile on managed host returns blocked with exit `3` for one target.
+- Missing profile under `--all` is reported as blocked while command exits `0`.
+- Bad profile permissions are blocked and include remediation.
+- Missing coding-agent YAML is failed and exits `1`.
+- `--json` output includes target, status, checks, and remediation strings.
+
+Verification:
+
+```bash
+uv run pytest tests/quorum/test_doctor.py tests/quorum/test_cli.py -q
+uv run ruff check quorum/doctor.py quorum/cli.py tests/quorum/test_doctor.py
+uv run ty check quorum/doctor.py quorum/cli.py
+```
+
+Commit:
+
+```bash
+git add quorum/doctor.py quorum/cli.py coding-agents tests/quorum/test_doctor.py tests/quorum/test_cli.py
+git commit -m "Add quorum target doctor"
+```
+
+### Task 5: Managed Worker, Supervisor, Status, and Tail
+
+Files:
+
+- Add `quorum/managed_commands.py`
+- Add `tests/quorum/test_managed_commands.py`
+- Modify `quorum/cli.py`
+- Modify `quorum/managed_state.py`
+
+Implement:
+
+- `create_job(kind, target, args, paths, owner) -> ManagedJob`
+- `run_managed_worker(job_id, paths, env) -> int`
+- `start_job(job, paths, supervisor) -> StartResult`
+- `status_summary(paths, limit, include_finished) -> list[ManagedJob]`
+- `tail_job(job_id, child_id=None, follow=False) -> Iterator[str]`
+
+Supervisor:
+
+- Create a small supervisor interface with two implementations:
+  - `InlineSupervisor` for tests.
+  - `TmuxSupervisor` for the AWS host.
+- Use `tmux new-session -d -s quorum-<job-id> -- <worker command>` for Phase
+  1. This avoids building a daemon and keeps SSH/SSM operations inspectable.
+- The worker command is:
+
+```bash
+env QUORUM_MANAGED_WORKER=1 uv run quorum managed-worker <job-id>
+```
+
+CLI:
+
+- Add public commands:
+  - `status`
+  - `tail`
+- Add hidden/internal command:
+  - `managed-worker`
+
+Status behavior:
+
+- `quorum status` shows active jobs first, then recent terminal jobs.
+- `quorum status <job-id>` shows job detail and child records.
+- `--json` emits stable JSON.
+
+Tail behavior:
+
+- Parent job tail reads `$QUORUM_STATE_ROOT/events/<job-id>.jsonl` and the
+  parent stdout/stderr file if present.
+- Child tail resolves from the child record to the underlying run or batch log.
+- `--follow` follows appended bytes until the job reaches a terminal status.
+
+Tests:
+
+- Creating a job writes state `planned` and a creation event.
+- Inline supervisor starts a worker and transitions `planned` to `running` to
+  `succeeded`.
+- Worker marks failed with exit code when the underlying command raises.
+- Status sorts active before terminal jobs.
+- Status JSON is parseable and contains child records.
+- Tail returns parent events.
+- Tail returns child log content when child ID is supplied.
+- Hidden worker command is callable directly in tests.
+
+Verification:
+
+```bash
+uv run pytest tests/quorum/test_managed_commands.py tests/quorum/test_cli.py -q
+uv run ruff check quorum/managed_commands.py quorum/cli.py quorum/managed_state.py tests/quorum/test_managed_commands.py
+uv run ty check quorum/managed_commands.py quorum/cli.py quorum/managed_state.py
+```
+
+Commit:
+
+```bash
+git add quorum/managed_commands.py quorum/cli.py quorum/managed_state.py tests/quorum/test_managed_commands.py tests/quorum/test_cli.py
+git commit -m "Add managed quorum worker and status commands"
+```
+
+### Task 6: Smoke, Column, Batch, Children, and Result Rollup
+
+Files:
+
+- Modify `quorum/managed_commands.py`
+- Modify `quorum/cli.py`
+- Modify `quorum/run_all.py`
+- Modify `quorum/runner.py`
+- Add or extend `tests/quorum/test_managed_commands.py`
+- Extend `tests/quorum/test_run_all.py`
+- Extend `tests/quorum/test_runner.py`
+
+Implement commands:
+
+- `quorum smoke <target>`
+  - Selects the configured smoke scenario for the target.
+  - Runs one `quorum run` inside a managed worker.
+  - Records `run_dir` in the job.
+- `quorum column <target> --jobs N`
+  - Equivalent to `quorum batch --coding-agent <target> --tier sentinel --jobs N`.
+  - Records one child per scenario/target cell.
+- `quorum batch`
+  - Wraps existing `run-all`.
+  - Requires at least one explicit target or `--all-ready-targets`.
+  - Defaults to `--tier sentinel`.
+  - Accepts `--include-drafts` only when explicitly passed.
+
+Add run-all seams:
+
+```python
+def run_batch(
+    *,
+    scenarios_root: Path,
+    coding_agents_dir: Path,
+    out_root: Path,
+    jobs: int,
+    agent_filter: list[str] | None,
+    scenario_filter: list[str] | None = None,
+    tier: str | None = None,
+    include_drafts: bool = False,
+    invoke: Callable | None = None,
+    stream: TextIO | None = None,
+    use_cursor: bool = True,
+    env_base: Mapping[str, str] | None = None,
+    on_batch_allocated: Callable[[Path], None] | None = None,
+    on_child_started: Callable[[str, MatrixEntry, list[str]], None] | None = None,
+    on_child_finished: Callable[[str, ChildResult], None] | None = None,
+) -> Path:
+```
+
+- Call `on_batch_allocated(batch_dir)` immediately after batch dir allocation.
+- Call `on_child_started(child_id, matrix_entry, command)` before launching each
+  child process.
+- Call `on_child_finished(child_id, child_result)` after each child exits.
+- Preserve current behavior when callbacks are not supplied.
+
+Add runner seams:
+
+- Expose a public helper that can run a scenario into a managed run directory
+  chosen by the caller:
+
+```python
+def run_scenario_in_dir(
+    *,
+    run_dir: Path,
+    scenario_dir: Path,
+    coding_agent: str,
+    coding_agents_dir: Path,
+    out_root: Path,
+    skeleton_root: Path | None = None,
+    env_base: Mapping[str, str] | None = None,
+) -> tuple[Path, FinalVerdict]:
+```
+
+Use it from the managed smoke command so the job can record the run directory
+before the child completes.
+
+Result rollup:
+
+- Parent managed job state is `succeeded` when the batch command completes and
+  writes expected artifacts, even when some eval cells fail.
+- `result_rollup` is `pass` only when every child verdict passed.
+- `result_rollup` is `fail` when any child verdict failed.
+- `result_rollup` is `indeterminate` when no child failed and at least one child
+  is indeterminate.
+- Preserve skipped/rate-limited child reasons in `children`.
+- If a provider cooldown is written, include it in the parent job `cooldowns`
+  list.
+
+Tests:
+
+- `smoke claude` enqueues and runs one child with managed env.
+- `column claude --jobs 2` calls `run_batch` with `tier=sentinel`,
+  `coding_agent_filter=["claude"]`, and `jobs=2`.
+- `batch --all-ready-targets` expands only doctor-ready targets.
+- `batch` without a target or `--all-ready-targets` exits `2`.
+- Child callbacks produce child job records with stable IDs.
+- Mixed child verdicts roll up according to the result rollup rules.
+- Rate-limit sentinel results write provider cooldown and preserve skipped
+  child reason.
+- Existing `run-all` tests still pass without callbacks.
+
+Verification:
+
+```bash
+uv run pytest tests/quorum/test_managed_commands.py tests/quorum/test_run_all.py tests/quorum/test_runner.py tests/quorum/test_cli.py -q
+uv run ruff check quorum/managed_commands.py quorum/cli.py quorum/run_all.py quorum/runner.py tests/quorum
+uv run ty check quorum/managed_commands.py quorum/cli.py quorum/run_all.py quorum/runner.py
+```
+
+Commit:
+
+```bash
+git add quorum/managed_commands.py quorum/cli.py quorum/run_all.py quorum/runner.py tests/quorum
+git commit -m "Add managed quorum smoke column and batch commands"
+```
+
+### Task 7: Secret Scan and Tainting
+
+Files:
+
+- Add `quorum/secret_scan.py`
+- Add `tests/quorum/test_secret_scan.py`
+- Modify `quorum/managed_commands.py`
+- Modify `quorum/managed_state.py`
+
+Implement:
+
+- `SecretPattern`
+- `build_secret_patterns(target_profile) -> list[SecretPattern]`
+- `scan_path_for_secrets(path, patterns) -> SecretScanResult`
+- `scan_job_artifacts(job, patterns) -> SecretScanResult`
+- `taint_job_on_secret_match(paths, job, result) -> ManagedJob`
+
+Patterns:
+
+- Exact value match for each secret value loaded from the target profile.
+- High-signal provider patterns:
+  - OpenAI keys beginning with `sk-`.
+  - Anthropic keys beginning with `sk-ant-`.
+  - GitHub tokens beginning with `ghp_`, `github_pat_`, or `gho_`.
+  - Gemini or Google API keys beginning with `AIza`.
+  - AWS access key IDs beginning with `AKIA` or `ASIA`.
+
+Redaction:
+
+- Never write the matched secret value to the scan result.
+- Store file path, byte offset, pattern name, and short digest:
+
+```json
+{
+  "path": "/opt/quorum/artifacts/runs/example/stdout.txt",
+  "offset": 128,
+  "pattern": "ANTHROPIC_API_KEY",
+  "digest": "sha256:12ab34cd"
+}
+```
+
+Worker behavior:
+
+- After every managed child and at parent finalization, scan the known run/batch
+  artifacts.
+- If a match is found, mark the job `tainted`, append a taint event, and exit
+  nonzero.
+- Do not delete artifacts in Phase 1. Operators need them for incident review.
+
+Tests:
+
+- Exact secret value is detected in nested artifact files.
+- High-signal provider pattern is detected without a profile value.
+- Redaction result does not contain the secret.
+- Managed worker marks a `succeeded` job as tainted when scan finds a secret.
+- Clean artifacts leave the original job state unchanged.
+
+Verification:
+
+```bash
+uv run pytest tests/quorum/test_secret_scan.py tests/quorum/test_managed_commands.py -q
+uv run ruff check quorum/secret_scan.py quorum/managed_commands.py quorum/managed_state.py tests/quorum/test_secret_scan.py
+uv run ty check quorum/secret_scan.py quorum/managed_commands.py quorum/managed_state.py
+```
+
+Commit:
+
+```bash
+git add quorum/secret_scan.py quorum/managed_commands.py quorum/managed_state.py tests/quorum/test_secret_scan.py tests/quorum/test_managed_commands.py
+git commit -m "Taint managed quorum jobs on secret leakage"
+```
+
+### Task 8: Terminus Terraform Service Root
+
+Repository:
+
+- `/Users/drewritter/prime-rad/brooks/terminus`
+
+Files:
+
+- Add `terraform/quorum-evals/backend.tf`
+- Add `terraform/quorum-evals/data.tf`
+- Add `terraform/quorum-evals/variables.tf`
+- Add `terraform/quorum-evals/main.tf`
+- Add `terraform/quorum-evals/dlm.tf`
+- Add `terraform/quorum-evals/outputs.tf`
+- Add `terraform/quorum-evals/templates/userdata.sh.tftpl`
+- Add `terraform/quorum-evals/scripts/quorum-volume-bootstrap.sh`
+- Add `terraform/quorum-evals/README.md`
+- Add `docs/runbooks/quorum-evals-operations.md`
+- Add bootstrap script tests using the existing Terminus shell-test pattern from
+  the Brainstorm volume bootstrap coverage.
+
+Terraform shape:
+
+- Backend:
+  - Bucket: existing Terminus state bucket from local convention.
+  - Key: `quorum-evals/terraform.tfstate`.
+  - Region: `us-west-1`.
+- Remote state:
+  - Reuse the existing infra state for VPC/subnet/security group references.
+- Instance:
+  - Use `module "quorum_evals"` with `../modules/machine-westworld`.
+  - Instance type default is `c7i.4xlarge`: 16 vCPU and 32 GiB RAM.
+  - Keep `var.instance_type` configurable for a measured Phase 1b resize.
+  - Root volume encrypted.
+  - IMDSv2 required by the module.
+  - Tailscale enabled using the same pattern as existing Terminus machines.
+- Persistent EBS:
+  - Size: 500 GiB for Phase 1.
+  - Type: `gp3`.
+  - Encrypted: true.
+  - `prevent_destroy`: true.
+  - Tags:
+    - `Backup = "dlm"`
+    - `Service = "quorum-evals"`
+    - `DataClass = "eval-artifacts"`
+- Attachment:
+  - Attach persistent EBS to the instance.
+- Backups:
+  - Add Terraform-managed DLM policy for the quorum evals volume.
+  - Hourly or every-2-hours retention that matches current Terminus stateful
+    machine patterns.
+- SSM parameters:
+  - Create initial `aws_ssm_parameter` resources with `ignore_changes =
+    [value]` for each target profile secret.
+  - Paths:
+
+```text
+/quorum-evals/targets/claude/ANTHROPIC_API_KEY
+/quorum-evals/targets/codex/OPENAI_API_KEY
+/quorum-evals/targets/opencode/OPENAI_API_KEY
+/quorum-evals/targets/opencode/ANTHROPIC_API_KEY
+/quorum-evals/targets/opencode/OPENROUTER_API_KEY
+/quorum-evals/targets/kimi/KIMI_API_KEY
+/quorum-evals/targets/gemini/GEMINI_API_KEY
+/quorum-evals/targets/copilot/GITHUB_TOKEN
+```
+
+IAM:
+
+- Add a service-specific policy in the `quorum-evals` root rather than relying
+  only on the broad module SSM prefix.
+- Permit `ssm:GetParameter`, `ssm:GetParameters`, and `ssm:GetParametersByPath`
+  only for:
+
+```text
+arn:aws:ssm:us-west-1:<account-id>:parameter/quorum-evals/*
+```
+
+- Permit decrypt only via SSM in `us-west-1` using a `kms:ViaService`
+  condition.
+- Do not grant write access to SSM from the instance role.
+
+Userdata:
+
+- Install system packages required for Quorum and common scenario toolchains:
+  - Python 3.11 or the distro-supported Python plus uv-managed Python.
+  - Git.
+  - uv.
+  - Node.js/npm when required by current scenarios.
+  - tmux.
+  - jq.
+  - ripgrep.
+- Create:
+
+```text
+/opt/quorum/current
+/opt/quorum/state
+/opt/quorum/artifacts
+/opt/quorum/worktrees
+/opt/quorum/cache
+/etc/quorum/target-profiles.d
+```
+
+- Create group `quorum`.
+- Ensure target profiles are root-owned and group-readable by `quorum`.
+- Mount persistent EBS using the bootstrap script.
+- Fetch SSM parameters into target profile files on boot.
+- Do not echo secret values.
+- Sync or clone the `superpowers-evals` repo into `/opt/quorum/current`.
+- Run `uv sync --extra dev` in `/opt/quorum/current`.
+
+Bootstrap script requirements:
+
+- Refuse to format an already formatted volume.
+- Refuse to mount the root disk.
+- Refuse unknown device identity.
+- Mount by filesystem UUID after first initialization.
+- Create directories with stable ownership and permissions.
+- Be idempotent across reboots.
+
+Runbook:
+
+- How to connect through SSM Session Manager.
+- How to check `quorum status`.
+- How to run `doctor`, `smoke`, and `column`.
+- How to update target secrets.
+- How to check DLM snapshot freshness.
+- How to restore the EBS volume into a replacement instance.
+- How to respond to a tainted job.
+- How to stop/start the instance without destroying state.
+
+Verification:
+
+```bash
+cd /Users/drewritter/prime-rad/brooks/terminus/terraform/quorum-evals
+terraform fmt -check
+terraform init
+terraform validate
+terraform plan
+```
+
+Also run the bootstrap script tests added in the Terminus repo.
+
+Commit in Terminus:
+
+```bash
+git add terraform/quorum-evals docs/runbooks/quorum-evals-operations.md
+git commit -m "Add quorum evals runner infrastructure"
+```
+
+### Task 9: Managed Host Dry Run
+
+Repositories:
+
+- `/Users/drewritter/prime-rad/superpowers-evals`
+- `/Users/drewritter/prime-rad/brooks/terminus`
+
+Preconditions:
+
+- Terraform plan reviewed.
+- Target SSM SecureString parameters exist.
+- At least one real target secret is written out of band.
+- Instance role has read-only access to `/quorum-evals/*`.
+
+Apply:
+
+```bash
+cd /Users/drewritter/prime-rad/brooks/terminus/terraform/quorum-evals
+terraform plan -out=tfplan
+terraform apply tfplan
+```
+
+On-host verification through SSM:
+
+```bash
+cd /opt/quorum/current
+uv sync --extra dev
+QUORUM_MANAGED_HOST=1 uv run quorum doctor --all
+QUORUM_MANAGED_HOST=1 uv run quorum doctor claude
+QUORUM_MANAGED_HOST=1 uv run quorum smoke claude
+QUORUM_MANAGED_HOST=1 uv run quorum status
+QUORUM_MANAGED_HOST=1 uv run quorum tail <job-id>
+QUORUM_MANAGED_HOST=1 uv run quorum column claude --jobs 1
+QUORUM_MANAGED_HOST=1 uv run quorum status <job-id> --json
+```
+
+Raw command gate smoke:
+
+```bash
+QUORUM_MANAGED_HOST=1 uv run quorum run-all --coding-agent claude --tier sentinel
+```
+
+Expected:
+
+- Exit code `2`.
+- Message points to managed commands.
+- No Quorum run artifacts are created by the blocked raw command.
+
+Lock smoke:
+
+```bash
+QUORUM_MANAGED_HOST=1 uv run quorum column claude --jobs 1
+QUORUM_MANAGED_HOST=1 uv run quorum column claude --jobs 1
+QUORUM_MANAGED_HOST=1 uv run quorum status
+```
+
+Expected:
+
+- First job starts or runs.
+- Second job queues or reports the conflicting holder.
+- Host active child count does not exceed configured capacity.
+
+Disconnect smoke:
+
+1. Start a `column` job through SSM.
+2. Close the SSM session.
+3. Reconnect through SSM.
+4. Run `quorum status` and `quorum tail <job-id>`.
+
+Expected:
+
+- Job continues after disconnect.
+- Status and tail can find the job.
+
+Evidence to capture in the implementation PR:
+
+- Terraform plan summary.
+- `doctor --all` output.
+- One `smoke` job ID and result.
+- One `column` job ID and result.
+- Raw command gate output.
+- Lock smoke output.
+- DLM snapshot freshness check.
+
+### Task 10: Phase 1b Sentinel Campaign
+
+Phase 1b begins after one target completes Phase 1a smoke and column evidence.
+
+Steps:
+
+1. Add or verify secrets for a second key-backed target.
+2. Run:
+
+```bash
+QUORUM_MANAGED_HOST=1 uv run quorum doctor --all
+QUORUM_MANAGED_HOST=1 uv run quorum column claude --jobs 2
+QUORUM_MANAGED_HOST=1 uv run quorum column codex --jobs 2
+```
+
+3. Increase `QUORUM_MAX_ACTIVE_CHILDREN` only after evidence shows CPU,
+   memory, disk IO, and provider limits are healthy.
+4. Run:
+
+```bash
+QUORUM_MANAGED_HOST=1 uv run quorum batch --all-ready-targets --tier sentinel --jobs 2
+```
+
+5. Record:
+   - Total runtime.
+   - Max active child count.
+   - Rate-limit cooldowns.
+   - Fail/indeterminate distribution.
+   - Any target-specific environment or toolchain blockers.
+
+Exit criteria:
+
+- At least two key-backed targets are doctor-ready.
+- Sentinel campaign can run without an interactive laptop session.
+- Multiple user jobs are safe: one active batch at a time, bounded child
+  concurrency, clear conflict status.
+- Raw live eval commands fail closed on the AWS host.
+- Job logs can be tailed after disconnect.
+- No known secret leakage in managed logs or artifacts.
+
+## Global Verification Before PR
+
+In `superpowers-evals`:
+
+```bash
+uv run ruff check
+uv run ty check
+uv run quorum check
+uv run pytest
+```
+
+In `brooks/terminus`:
+
+```bash
+cd /Users/drewritter/prime-rad/brooks/terminus/terraform/quorum-evals
+terraform fmt -check
+terraform validate
+terraform plan
+```
+
+Run any Terminus bootstrap script tests added for `quorum-evals`.
+
+## PR Description Checklist
+
+Include:
+
+- Link to the master story/ticket.
+- Phase implemented: Phase 1a, Phase 1b, or both.
+- Managed command examples.
+- Concurrency defaults.
+- Secret-profile behavior.
+- Raw-command gate behavior.
+- Terraform plan summary.
+- Verification outputs.
+- Known targets that are ready.
+- Known targets that are blocked and why.
+
+## Not In Phase 1
+
+Do not build these in this implementation:
+
+- Web UI.
+- Database-backed job store.
+- SQS, EventBridge, ECS, Batch, or Kubernetes scheduler.
+- Multi-host sharding.
+- Per-user authentication or authorization beyond AWS/SSM access.
+- Long-term artifact retention policy beyond encrypted EBS plus DLM snapshots.
+- Automatic eval result trend dashboards.
+- Agent-issued arbitrary shell command API.
+
+Those are platform evolution candidates after Phase 1 proves shared remote eval
+runs are useful and safe.

--- a/docs/superpowers/specs/2026-06-12-quorum-aws-eval-runner-design.md
+++ b/docs/superpowers/specs/2026-06-12-quorum-aws-eval-runner-design.md
@@ -1,0 +1,342 @@
+# Quorum AWS Eval Runner - design specification
+
+**Status:** Draft for Drew review.
+**Date:** 2026-06-12
+**Context:** Quorum live evals currently run from Drew's Mac Studio. Drew wants
+a team-accessible AWS node so he can ask Codex or another agent to run smoke
+tests, columns, and broader Quorum batches without relying on a local desktop.
+
+---
+
+## Goal
+
+Create a team-accessible AWS runner for trusted Quorum live evals.
+
+The v1 runner should:
+
+- let agents operate Quorum through the normal Quorum CLI rather than a new
+  eval-runner product API;
+- preserve Quorum's current local workflow for smoke runs, columns, grouped
+  batches, triage, and artifact inspection;
+- prevent accidental cross-session concurrency, quota collisions, and artifact
+  confusion when multiple humans or agents use the same host;
+- keep live eval secrets and raw transcripts off laptops where practical;
+- fit the existing Terminus Terraform, Tailscale, SSM, EBS, and S3 patterns;
+- leave a clear path to stronger Cloud Build / Stockyard isolation later.
+
+## Non-goals
+
+- Public CI live evals. Static checks remain the only public-CI-safe path.
+- Running untrusted PR scenarios or generated `setup.sh` / `checks.sh` on the
+  shared host.
+- Providing strong per-run sandbox isolation in v1. The shared host is a
+  trusted-operator tool, not a multi-tenant security boundary.
+- Building a web UI, queue daemon, or Slack bot for job submission.
+- Replacing Quorum's existing `run`, `run-all`, `show`, capture, or verdict
+  model.
+- Moving all provider auth to Cloud Build proxy nonces in the first increment.
+
+## Direction
+
+Use a long-lived Terminus-managed EC2 host for v1, and put the operator-facing
+run affordances inside Quorum.
+
+The important split is:
+
+- **Terminus owns the workstation.** Terraform provisions EC2, EBS, IAM,
+  Tailscale, SSM parameter inventory, backups, and host bootstrap.
+- **Quorum owns the eval operation.** Quorum exposes safe commands for smoke
+  runs, columns, batch profiles, locks, logs, status, tails, archive, and
+  cleanup.
+
+This avoids a second command surface such as `qrun`. Agents should be able to
+SSH to the host and run `uv run quorum ...` with first-class Quorum subcommands.
+Host-local glue can still exist for provisioning and secret materialization,
+but it should not become the user-facing eval API.
+
+## Terminus Host
+
+Add a dedicated `quorum-evals` host in the Terminus repo using the existing
+`machine-westworld` pattern.
+
+Recommended v1 defaults:
+
+- Region: `us-west-1`, matching Terminus.
+- Instance: `m6i.2xlarge` on-demand.
+- Root volume: 100 GB gp3.
+- Data volume: 500 GB encrypted gp3 mounted at `/opt/quorum`.
+- Access: Tailscale and SSM only; no public inbound application ports.
+- Tailscale identity: `quorum-evals`.
+- IAM: minimal SSM read access for `/quorum-evals/*`, plus S3 access only for
+  the private Quorum artifact archive.
+- Backups: short-retention DLM snapshots for the persistent data volume.
+
+Use on-demand for v1. Spot is attractive for cost, but Quorum runs can last for
+hours, OAuth-style auth state can be awkward to recreate, and interruption
+handling is not yet explicit.
+
+## Host Layout
+
+The host should keep mutable eval state under `/opt/quorum`:
+
+```text
+/opt/quorum/
+├── repos/
+│   ├── superpowers/
+│   └── superpowers-evals/
+├── results/
+├── logs/
+├── archive-staging/
+└── secrets-runtime/
+```
+
+`SUPERPOWERS_ROOT` should point at `/opt/quorum/repos/superpowers`.
+`superpowers-evals` should use `/opt/quorum/results` as the default or
+documented runner output root on this host.
+
+Team members should have separate Unix accounts. The host may also have a
+dedicated unprivileged `quorum-runner` account for actual job execution if the
+first implementation includes privilege separation. Users and agents should not
+need `sudo` or Docker socket access to run evals.
+
+## Quorum CLI Additions
+
+Add Quorum subcommands that express maintainer workflows directly:
+
+```bash
+uv run quorum smoke claude
+uv run quorum column copilot
+uv run quorum batch --agents claude,codex --scenarios a,b --jobs 4
+uv run quorum status
+uv run quorum tail <run-or-batch>
+uv run quorum archive <run-or-batch>
+uv run quorum cleanup --dry-run
+```
+
+These are convenience and safety affordances over `quorum run`, `run-all`, and
+`show`, not a replacement for the underlying primitives.
+
+### `quorum smoke`
+
+Runs the canonical smoke scenario for one Coding-Agent.
+
+The command should know the current smoke mapping:
+
+- `claude`, `claude-haiku`, `claude-sonnet`, and `codex` use
+  `00-quorum-smoke-hello-world`.
+- target-specific bootstrap scenarios such as `copilot-superpowers-bootstrap`,
+  `gemini-superpowers-bootstrap`, `kimi-superpowers-bootstrap`,
+  `opencode-superpowers-bootstrap`, `pi-superpowers-bootstrap`, and
+  `antigravity-superpowers-bootstrap` are used when present.
+
+### `quorum column`
+
+Runs all runnable scenarios for one Coding-Agent.
+
+It should:
+
+- preview the matrix before starting;
+- respect the target's `max_concurrency`;
+- default to `--jobs 1` for serial-capped targets;
+- write a durable command log under the batch directory or run log root;
+- print the resulting batch id and next triage command.
+
+### `quorum batch`
+
+Wraps `run-all` with named, safe profiles.
+
+Initial profiles:
+
+- `sentinel`: only `quorum_tier: sentinel`.
+- `full`: full target/scenario selection, explicit confirmation required.
+- `uncapped-group`: `claude,claude-haiku,claude-sonnet,codex,kimi` with a
+  default `--jobs 4`.
+- `capped-column`: one serial-capped target at `--jobs 1`.
+
+The command should keep the existing `run-all` behavior available. Profiles
+only encode the documented maintainer patterns so agents do not have to
+reconstruct them each time.
+
+## Locking And Concurrency
+
+Quorum currently coordinates concurrency within one `run-all` process, but not
+across separate shells. The AWS host needs cross-process locks.
+
+Add a lock layer under `/opt/quorum/locks` or the configured out root:
+
+- one global broad-sweep lock;
+- one lock per Coding-Agent target;
+- optional provider-family locks for shared quota surfaces such as Gemini /
+  Antigravity;
+- stale-lock detection that reports the owning PID, command, user, start time,
+  and log path before allowing manual cleanup.
+
+Locks should be advisory but enforced by the new Quorum commands. Low-level
+`quorum run` and `quorum run-all` can remain available for maintainers, but the
+documented AWS-host workflow should use the locking commands.
+
+The first policy should be conservative:
+
+- one broad batch at a time;
+- serial-capped targets run one column at a time;
+- Antigravity stays separate from Gemini;
+- full multi-agent grids require an explicit profile or confirmation.
+
+## Secrets And Auth
+
+Use SSM SecureString parameters under `/quorum-evals/*`. Terraform owns the
+parameter inventory and ignores values.
+
+Initial parameter families:
+
+- provider API keys needed for Claude, Gemini API-key mode, Kimi, Pi, OpenCode,
+  and Copilot provider mode;
+- Tailscale auth key for the host;
+- GitHub read token or app material if the host needs to clone private repos
+  without relying on a person's shell auth;
+- optional S3 archive settings.
+
+Secrets should be materialized into per-run or per-command environment files
+with mode `0600`, then removed when the command completes. Prefer a tmpfs
+runtime directory for secret-bearing files.
+
+Avoid personal OAuth or subscription auth on the shared host unless the account
+is a dedicated eval identity with understood spend, quota, and audit blast
+radius. This is especially important for Codex, Antigravity, Copilot, and any
+tool that uses browser or keyring state.
+
+The shared host is not a secret isolation boundary against a malicious eval.
+Do not run untrusted scenario code there. Strong host-secret isolation belongs
+in a later Cloud Build / Stockyard design.
+
+## Artifacts
+
+Treat `results/` as sensitive.
+
+The host should keep full local artifacts for short-term triage:
+
+- default: 14 days or 150 GB, whichever is hit first;
+- longer retention for selected promoted baselines;
+- dry-run cleanup before deletion.
+
+Completed runs and batches should be archivable to a private encrypted S3
+prefix. Long-term archive should prioritize:
+
+- `batch.json`;
+- `results.jsonl`;
+- each run's `verdict.json`;
+- `coding-agent-token-usage.json`;
+- normalized `coding-agent-tool-calls.jsonl` when needed for behavior triage.
+
+Raw transcripts, config homes, workdirs, and Gauntlet-Agent event streams
+should be retained only when promoted or when actively triaging a failure.
+
+## Observability And Recovery
+
+Quorum should make remote operation easy for agents:
+
+- every managed command writes a command log;
+- `quorum status` lists active runs, active locks, recent batches, owner, age,
+  command, and log path;
+- `quorum tail <id>` follows the relevant command log;
+- `quorum show <id>` remains the verdict front door;
+- stale-lock cleanup is explicit and auditable;
+- interrupted SSH sessions should not kill active jobs if they were launched
+  through the managed command path.
+
+Use `tmux`, `systemd-run --scope`, or another simple host-native mechanism for
+surviving SSH disconnects. Do not introduce a custom daemon in v1 unless the
+simple mechanism cannot provide status and cleanup.
+
+## Cost Controls
+
+EC2 cost is meaningful but not the dominant risk. Model/API spend and accidental
+parallelism are the larger risks.
+
+V1 controls:
+
+- default to smoke or sentinel-tier commands;
+- require explicit confirmation or a flag for full sweeps;
+- print matrix size before starting;
+- record estimated cost from verdict economics after each run;
+- summarize batch cost when available;
+- keep provider-specific concurrency conservative;
+- add CloudWatch/AWS budget alerts for EC2 and S3;
+- add provider-side spend alerts where available;
+- schedule stop windows only if they do not interrupt active jobs.
+
+## Cloud Build Graduation Path
+
+Move from shared host to Cloud Build / Stockyard isolation when any of these
+becomes true:
+
+- the team needs multiple concurrent eval jobs with meaningful isolation;
+- evals need to run untrusted PR branches or generated scenario code;
+- provider keys must remain host-only with per-run proxy nonces;
+- OAuth/browser/keyring targets need per-run identity rather than shared host
+  state;
+- spend attribution and cleanup need to be per-run rather than per-host;
+- a failed or malicious eval must not be able to inspect sibling artifacts or
+  host secrets.
+
+The v1 Quorum command design should survive that migration. A later isolated
+runner can execute the same `quorum smoke`, `column`, and `batch` commands
+inside a disposable box.
+
+## Implementation Seams
+
+Likely Quorum work:
+
+- add command modules for `smoke`, `column`, `batch`, `status`, `tail`,
+  `archive`, and `cleanup`;
+- add a small lock helper with tests for ownership, stale detection, and
+  non-overlap;
+- extend batch metadata with command, user, host, git SHAs, env profile, and
+  log path;
+- add archive and retention helpers;
+- document the AWS-host workflow in the README or a runbook.
+
+Likely Terminus work:
+
+- add a `terraform/quorum/evals` or similar service root;
+- instantiate `machine-westworld`;
+- add an encrypted persistent data volume and DLM policy;
+- add SSM parameter inventory under `/quorum-evals/*`;
+- add least-privilege IAM for SSM read and private S3 artifact archive access;
+- add cloud-init bootstrap for uv, Python, Node, agent CLIs, Gauntlet, Tailscale,
+  repo checkout, and filesystem layout.
+
+## Verification
+
+Before treating the AWS runner as usable:
+
+1. Static repo checks pass locally:
+
+   ```bash
+   uv run ruff check
+   uv run ty check
+   uv run quorum check
+   uv run pytest
+   ```
+
+2. Terminus Terraform plan shows no unrelated replacement of existing hosts or
+   persistent volumes.
+3. Host bootstrap installs required binaries and clones the expected repo SHAs.
+4. `quorum smoke claude` passes on the AWS host.
+5. One serial-capped smoke or bootstrap target passes on the AWS host.
+6. A small `quorum batch --profile sentinel --agents claude,codex` run completes
+   and archives summaries.
+7. `quorum status`, `tail`, `show`, archive, and cleanup paths work from a fresh
+   SSH session.
+
+## Open Questions
+
+- Which targets should v1 support on day one: API-key-only targets first, or
+  also OAuth/keyring targets with dedicated eval identities?
+- Should the actual job process run as the invoking Unix user or as a dedicated
+  `quorum-runner` account?
+- Should the first archive path be S3-only, or should it also publish a small
+  static index for easier browsing over Tailscale?
+- What retention policy is acceptable for raw transcripts: 7 days, 14 days, or
+  manual promotion only?
+

--- a/docs/superpowers/specs/2026-06-12-quorum-aws-eval-runner-design.md
+++ b/docs/superpowers/specs/2026-06-12-quorum-aws-eval-runner-design.md
@@ -1,10 +1,12 @@
 # Quorum AWS Eval Runner - design specification
 
-**Status:** Draft for Drew review.
+**Status:** Draft, revised after staff review.
 **Date:** 2026-06-12
+**Tracker:** PRI-2205
 **Context:** Quorum live evals currently run from Drew's Mac Studio. Drew wants
 a team-accessible AWS node so he can ask Codex or another agent to run smoke
-tests, columns, and broader Quorum batches without relying on a local desktop.
+tests, grid columns, baseline campaigns, reruns, and triage without relying on
+a local desktop.
 
 ---
 
@@ -18,8 +20,11 @@ The v1 runner should:
   eval-runner product API;
 - preserve Quorum's current local workflow for smoke runs, columns, grouped
   batches, triage, and artifact inspection;
+- provide a durable managed-job model so `status`, `tail`, handoff, recovery,
+  archive, and cleanup do not depend on shell history;
 - prevent accidental cross-session concurrency, quota collisions, and artifact
   confusion when multiple humans or agents use the same host;
+- support reproducible branch and `SUPERPOWERS_ROOT` comparisons;
 - keep live eval secrets and raw transcripts off laptops where practical;
 - fit the existing Terminus Terraform, Tailscale, SSM, EBS, and S3 patterns;
 - leave a clear path to stronger Cloud Build / Stockyard isolation later.
@@ -31,10 +36,12 @@ The v1 runner should:
   shared host.
 - Providing strong per-run sandbox isolation in v1. The shared host is a
   trusted-operator tool, not a multi-tenant security boundary.
-- Building a web UI, queue daemon, or Slack bot for job submission.
+- Building a web UI, queue daemon, Slack bot, or separate `qrun` command
+  surface for job submission.
 - Replacing Quorum's existing `run`, `run-all`, `show`, capture, or verdict
   model.
-- Moving all provider auth to Cloud Build proxy nonces in the first increment.
+- Solving provider-key proxy nonces, untrusted code execution, or per-run
+  spend attribution before the Cloud Build / Stockyard phase.
 
 ## Direction
 
@@ -44,15 +51,36 @@ run affordances inside Quorum.
 The important split is:
 
 - **Terminus owns the workstation.** Terraform provisions EC2, EBS, IAM,
-  Tailscale, SSM parameter inventory, backups, and host bootstrap.
+  Tailscale, SSM parameter inventory, backups, host bootstrap, and host-level
+  secret materialization.
 - **Quorum owns the eval operation.** Quorum exposes safe commands for smoke
-  runs, columns, batch profiles, locks, logs, status, tails, archive, and
-  cleanup.
+  runs, columns, batch profiles, managed jobs, locks, logs, status, tails,
+  archive, cleanup, reruns, comparisons, and handoff.
 
-This avoids a second command surface such as `qrun`. Agents should be able to
-SSH to the host and run `uv run quorum ...` with first-class Quorum subcommands.
-Host-local glue can still exist for provisioning and secret materialization,
-but it should not become the user-facing eval API.
+This avoids a second command surface. Agents should be able to SSH to the host
+and run `uv run quorum ...` with first-class Quorum subcommands. Host-local
+glue can still exist for provisioning and secret materialization, but it should
+not become the user-facing eval API.
+
+## Current Constraints
+
+The current repository shape matters for the AWS runner design:
+
+- Quorum has 10 Coding-Agent targets and 55 scenario directories.
+- The current ready matrix has hundreds of runnable cells.
+- Several targets are serial-capped with `max_concurrency: 1`.
+- `run-all --jobs` is not a hard global live-cell cap when capped agents are
+  included. Uncapped agents share the `--jobs` pool, while capped agents run in
+  dedicated lanes beside it.
+- `max_concurrency` is process-local today. Two separate SSH sessions can
+  violate the same target cap unless Quorum adds host-global locks.
+- Some scenarios have long `quorum_max_time` overrides. A broad `full` profile
+  can include 60 minute and 90 minute cells.
+- Run artifacts can be large and secret-bearing. Local `results/` already has
+  tens of GB of ignored artifacts on the Mac Studio.
+
+These constraints mean the v1 runner is not just "a bigger machine." It needs a
+managed job layer and conservative scheduling semantics.
 
 ## Terminus Host
 
@@ -63,13 +91,21 @@ Recommended v1 defaults:
 
 - Region: `us-west-1`, matching Terminus.
 - Instance: `m6i.2xlarge` on-demand.
-- Root volume: 100 GB gp3.
+- Root volume: 100 GB encrypted gp3.
 - Data volume: 500 GB encrypted gp3 mounted at `/opt/quorum`.
 - Access: Tailscale and SSM only; no public inbound application ports.
 - Tailscale identity: `quorum-evals`.
+- Tailscale ACL: dedicated `tag:quorum-evals`, not a reused broad service tag.
+  SSH should allow eval operators to non-root Unix accounts only.
 - IAM: minimal SSM read access for `/quorum-evals/*`, plus S3 access only for
-  the private Quorum artifact archive.
-- Backups: short-retention DLM snapshots for the persistent data volume.
+  the private Quorum artifact archive prefix.
+- IMDS: block access to `169.254.169.254` from eval users and eval child
+  processes, or remove runtime instance-credential dependency before jobs
+  start.
+- Data durability: `prevent_destroy` on the data volume, backup tags, DLM or
+  AWS Backup coverage, and a backup freshness verification step.
+- Operators: no `sudo`, no wheel group, and no Docker socket access for eval
+  users or agent processes.
 
 Use on-demand for v1. Spot is attractive for cost, but Quorum runs can last for
 hours, OAuth-style auth state can be awkward to recreate, and interruption
@@ -84,41 +120,162 @@ The host should keep mutable eval state under `/opt/quorum`:
 ├── repos/
 │   ├── superpowers/
 │   └── superpowers-evals/
+├── worktrees/
 ├── results/
-├── logs/
+├── state/
+│   ├── jobs/
+│   ├── locks/
+│   ├── logs/
+│   └── cooldowns/
 ├── archive-staging/
 └── secrets-runtime/
 ```
 
-`SUPERPOWERS_ROOT` should point at `/opt/quorum/repos/superpowers`.
-`superpowers-evals` should use `/opt/quorum/results` as the default or
-documented runner output root on this host.
+`SUPERPOWERS_ROOT` defaults to `/opt/quorum/repos/superpowers`.
+`superpowers-evals` defaults to `/opt/quorum/results` as the AWS host output
+root.
 
-Team members should have separate Unix accounts. The host may also have a
-dedicated unprivileged `quorum-runner` account for actual job execution if the
-first implementation includes privilege separation. Users and agents should not
-need `sudo` or Docker socket access to run evals.
+Team members should have separate Unix accounts. V1 managed jobs run as the
+invoking Unix user, not a shared `quorum-runner` account. This preserves audit
+and prevents same-UID sibling process snooping across operators. Shared
+handoff should happen through sanitized job metadata and promoted artifacts,
+not through a shared raw run directory.
+
+Host-managed secret files may be readable to a trusted `quorum-operators` group
+when that is the simplest v1 implementation, but personal OAuth/subscription
+state must not be shared that way.
+
+## Managed Job Model
+
+Add a Quorum-managed job model. This is the central seam for locks, logs,
+status, tail, archive, cleanup, reruns, comparisons, and handoff.
+
+Every managed command creates a job record before it starts side effects:
+
+```text
+/opt/quorum/state/jobs/<job-id>.json
+/opt/quorum/state/logs/<job-id>.log
+```
+
+Local development may use `<out-root>/.quorum/` as a fallback state root, but
+the AWS host uses `/opt/quorum/state` so locks cannot be bypassed by changing
+`--out-root`.
+
+### Job States
+
+Initial states:
+
+- `planned`: job record exists, locks not yet acquired.
+- `waiting`: blocked on locks or a cooldown.
+- `running`: supervisor process is active.
+- `finishing`: child runs are done, rollup/archive/finalization is running.
+- `succeeded`: managed command completed cleanly.
+- `failed`: managed command failed.
+- `interrupted`: supervisor or child process died unexpectedly.
+- `orphaned`: job metadata exists, but the recorded supervisor is gone and the
+  final state is unknown.
+
+### `job.json`
+
+`job.json` should include at least:
+
+```json
+{
+  "schema_version": 1,
+  "id": "job-20260612T183000Z-abcd",
+  "state": "running",
+  "owner": "drew",
+  "host": "quorum-evals",
+  "command": ["quorum", "batch", "--profile", "sentinel-default"],
+  "profile": "sentinel-default",
+  "coding_agents": ["claude", "kimi"],
+  "scenario_filter": null,
+  "tier": "sentinel",
+  "include_drafts": false,
+  "out_root": "/opt/quorum/results",
+  "log_path": "/opt/quorum/state/logs/job-...log",
+  "locks": ["global:broad-batch", "target:claude", "target:kimi"],
+  "env_profile": "api-key",
+  "evals_repo": {
+    "path": "/opt/quorum/repos/superpowers-evals",
+    "ref": "main",
+    "sha": "...",
+    "dirty": false
+  },
+  "superpowers_repo": {
+    "path": "/opt/quorum/repos/superpowers",
+    "ref": "main",
+    "sha": "...",
+    "dirty": false
+  },
+  "supervisor": {
+    "kind": "tmux",
+    "session": "quorum-job-...",
+    "pid": 12345
+  },
+  "children": [
+    {
+      "kind": "batch",
+      "id": "batch-...",
+      "coding_agents": ["claude", "kimi"],
+      "status": "running"
+    }
+  ],
+  "artifact_bytes": null,
+  "archive_uri": null,
+  "started_at": "2026-06-12T18:30:00Z",
+  "finished_at": null,
+  "handoff_notes": []
+}
+```
+
+Foreground commands should stream the durable log, but the job itself should
+survive SSH disconnect via `tmux`, `systemd-run`, or another simple host-native
+supervisor. The supervisor must hold locks until all child `run-all` processes
+exit.
 
 ## Quorum CLI Additions
 
 Add Quorum subcommands that express maintainer workflows directly:
 
 ```bash
+uv run quorum doctor
 uv run quorum smoke claude
 uv run quorum column copilot
-uv run quorum batch --agents claude,codex --scenarios a,b --jobs 4
+uv run quorum batch --profile sentinel-default --coding-agents claude,kimi
 uv run quorum status
-uv run quorum tail <run-or-batch>
+uv run quorum status --json
+uv run quorum tail <run-or-batch-or-job>
+uv run quorum rerun --from-batch <batch-id> --final fail,indeterminate
+uv run quorum compare <batch-a> <batch-b>
+uv run quorum promote <run-or-batch>
+uv run quorum handoff <job-id> --note "what the next agent should know"
 uv run quorum archive <run-or-batch>
 uv run quorum cleanup --dry-run
 ```
 
-These are convenience and safety affordances over `quorum run`, `run-all`, and
-`show`, not a replacement for the underlying primitives.
+Use `--coding-agents` as the canonical flag name, matching existing Quorum.
+`--agents` can be an alias if useful, but it should not be the primary
+documented spelling.
+
+These commands are convenience and safety affordances over `quorum run`,
+`run-all`, and `show`, not a replacement for the underlying primitives.
+
+### `quorum doctor`
+
+Checks whether the AWS host can run the selected target before launching a live
+eval:
+
+- required binary exists;
+- required env or host-managed secret exists;
+- `SUPERPOWERS_ROOT` exists and has the expected files;
+- repo SHAs and dirty states are recorded;
+- lock root and output root are writable;
+- target-specific auth mode is supported on this host.
 
 ### `quorum smoke`
 
-Runs the canonical smoke scenario for one Coding-Agent.
+Runs the canonical smoke scenario for one Coding-Agent at `jobs=1`.
 
 The command should know the current smoke mapping:
 
@@ -129,6 +286,10 @@ The command should know the current smoke mapping:
   `opencode-superpowers-bootstrap`, `pi-superpowers-bootstrap`, and
   `antigravity-superpowers-bootstrap` are used when present.
 
+If the canonical smoke scenario is `status: draft`, `smoke` must include it
+deliberately. It should not inherit `run-all`'s default draft exclusion by
+accident.
+
 ### `quorum column`
 
 Runs all runnable scenarios for one Coding-Agent.
@@ -136,74 +297,192 @@ Runs all runnable scenarios for one Coding-Agent.
 It should:
 
 - preview the matrix before starting;
+- print worst-case cell-minutes from `quorum_max_time`;
+- acquire the target and provider locks before starting;
 - respect the target's `max_concurrency`;
-- default to `--jobs 1` for serial-capped targets;
-- write a durable command log under the batch directory or run log root;
-- print the resulting batch id and next triage command.
+- default to `--jobs 1` for serial-capped targets and `--jobs 4` for uncapped
+  targets after AWS dry-run measurement confirms the host can sustain it;
+- write a durable command log;
+- print the resulting job id, batch id, and next triage command.
 
 ### `quorum batch`
 
-Wraps `run-all` with named, safe profiles.
+`quorum batch` should be a profile orchestrator. It should not treat one broad
+all-agent `run-all` as the scheduler for v1.
+
+Profiles expand into one or more child `run-all` batches and a meta-job
+manifest that records all child batch ids.
 
 Initial profiles:
 
-- `sentinel`: only `quorum_tier: sentinel`.
-- `full`: full target/scenario selection, explicit confirmation required.
-- `uncapped-group`: `claude,claude-haiku,claude-sonnet,codex,kimi` with a
-  default `--jobs 4`.
+- `sentinel-default`: a small configured target pair at `--tier sentinel
+  --jobs 2`. Prefer `claude,codex` only when a dedicated Codex eval identity
+  exists; otherwise use `claude` plus another Tier 1 target. This is the day
+  one low-risk campaign profile.
+- `sentinel-all`: split into one uncapped child batch and serial capped child
+  columns. Antigravity stays separate from Gemini.
+- `uncapped-group`: `claude,claude-haiku,claude-sonnet,codex,kimi --jobs 4`.
 - `capped-column`: one serial-capped target at `--jobs 1`.
+- `full-short`: `quorum_tier: full` scenarios whose effective max time is below
+  the long-haul threshold, initially 20 minutes or less.
+- `full-long-sdd`: long-haul full-tier scenarios, including 60 minute and 90
+  minute cells. This requires explicit confirmation.
+- `adhoc`: explicit scenario list only.
 
-The command should keep the existing `run-all` behavior available. Profiles
-only encode the documented maintainer patterns so agents do not have to
-reconstruct them each time.
+A raw `full` profile should not be the default safe option. If supported, it
+must print target list, scenario count, runnable cell count, worst-case
+cell-minutes, long-haul cells, estimated artifact impact, and require an
+explicit confirmation flag.
 
 ## Locking And Concurrency
 
 Quorum currently coordinates concurrency within one `run-all` process, but not
-across separate shells. The AWS host needs cross-process locks.
+across separate shells. The AWS host needs host-global locks.
 
-Add a lock layer under `/opt/quorum/locks` or the configured out root:
+Use `/opt/quorum/state/locks`, not the configured output root, for AWS host
+locks. Use `fcntl.flock` or an equivalent open-file-descriptor lock so killed
+supervisors release locks automatically. JSON sidecars should exist only for
+diagnostics.
 
-- one global broad-sweep lock;
-- one lock per Coding-Agent target;
-- optional provider-family locks for shared quota surfaces such as Gemini /
-  Antigravity;
-- stale-lock detection that reports the owning PID, command, user, start time,
-  and log path before allowing manual cleanup.
+Lock acquisition must be deterministic to avoid deadlocks. Acquire locks in
+this order:
 
-Locks should be advisory but enforced by the new Quorum commands. Low-level
-`quorum run` and `quorum run-all` can remain available for maintainers, but the
-documented AWS-host workflow should use the locking commands.
+1. global locks;
+2. provider-family locks;
+3. target locks;
+4. artifact/archive locks.
 
-The first policy should be conservative:
+Initial lock names:
 
-- one broad batch at a time;
-- serial-capped targets run one column at a time;
-- Antigravity stays separate from Gemini;
-- full multi-agent grids require an explicit profile or confirmation.
+- `global:broad-batch`;
+- `provider:google-code-assist`;
+- `provider:copilot`;
+- `provider:anthropic`;
+- `provider:openai`;
+- `provider:kimi`;
+- `target:<coding-agent>`;
+- `archive:<run-or-batch>`;
+- `cleanup`.
 
-## Secrets And Auth
+Provider locks are intentionally conservative in v1. They can be relaxed only
+after measured AWS dry runs show that a provider and target can tolerate more
+parallelism.
+
+### Command Lock Table
+
+| Command | Locks |
+| --- | --- |
+| `doctor` | none unless checking a live auth flow |
+| `smoke <target>` | `target:<target>` plus provider lock when target is capped or quota-sensitive |
+| `column <target>` | `target:<target>` plus provider lock; capped targets force `jobs=1` |
+| `batch sentinel-default` | `global:broad-batch` plus target/provider locks for the configured target pair |
+| `batch sentinel-all` | `global:broad-batch`; each child takes its target/provider locks |
+| `batch uncapped-group` | `global:broad-batch` plus target/provider locks for the group |
+| `batch capped-column` | target/provider locks for the selected target |
+| `batch full-short` | `global:broad-batch` plus selected target/provider locks |
+| `batch full-long-sdd` | `global:broad-batch` plus selected target/provider locks |
+| `rerun` | locks for the target/provider set being rerun |
+| `archive` / `promote` | `archive:<id>` |
+| `cleanup` | `cleanup`, and it must skip active jobs |
+
+When a lock cannot be acquired, Quorum should report the owning job id, owner,
+command, start time, lock path, and log path.
+
+Promote the current in-memory rate-limit latch to host state for quota-sensitive
+targets. For example, if Antigravity trips a rate-limit marker, Quorum should
+record a host-level cooldown under `/opt/quorum/state/cooldowns` and skip or
+delay subsequent Antigravity work until the cooldown expires or an operator
+clears it.
+
+## Branch And Root Selection
+
+The AWS runner must support reproducible RED/GREEN comparisons and baseline
+campaigns.
+
+Managed commands should record both repository states:
+
+- `superpowers-evals` path, ref, SHA, and dirty state;
+- `SUPERPOWERS_ROOT` path, ref, SHA, and dirty state.
+
+The default roots are:
+
+```text
+/opt/quorum/repos/superpowers-evals
+/opt/quorum/repos/superpowers
+```
+
+Managed commands should support:
+
+- `--superpowers-root <path>` for an already prepared checkout;
+- `--superpowers-ref <ref>` to create a per-job worktree under
+  `/opt/quorum/worktrees/`;
+- `--evals-ref <ref>` to create a per-job evals worktree when needed;
+- explicit refusal when a managed job would mutate a shared checkout while
+  another active job is using it.
+
+Never let one session `git checkout` a shared repo while another managed job is
+active against that checkout. Per-job worktrees or immutable prepared checkouts
+are the safe path.
+
+## Target Auth Tiers
+
+V1 must decide target support by auth mode, not by wishful target list.
+
+### Tier 1: API-key / SSM friendly
+
+These targets can run first if their provider keys are available through the
+host's secret materialization path:
+
+- Claude-family targets using `ANTHROPIC_API_KEY`;
+- Gemini in API-key mode;
+- Kimi using `KIMI_MODEL_API_KEY`;
+- Pi using `PI_PROVIDER`, `PI_MODEL`, and `PI_API_KEY`;
+- OpenCode with an explicit provider key/model config;
+- Copilot provider-mode, when backed by explicit provider credentials rather
+  than personal GitHub auth.
+
+### Tier 2: dedicated eval identity required
+
+These targets are allowed only after creating dedicated eval identities with
+visible quota, spend ownership, and documented refresh/recovery:
+
+- Codex subscription/OAuth auth;
+- Antigravity browser/keyring auth;
+- Gemini OAuth;
+- Copilot GitHub auth.
+
+### Tier 3: disallowed on the shared host
+
+Do not use personal OAuth, personal subscription auth, or a developer's normal
+browser/keyring state on the shared host.
+
+The first AWS dry run should use Tier 1 targets and any Tier 2 target whose
+dedicated eval identity is already set up. If no dedicated Codex identity
+exists, do not include Codex in the default first dry run.
+
+## Secrets And Environment
 
 Use SSM SecureString parameters under `/quorum-evals/*`. Terraform owns the
 parameter inventory and ignores values.
 
 Initial parameter families:
 
-- provider API keys needed for Claude, Gemini API-key mode, Kimi, Pi, OpenCode,
-  and Copilot provider mode;
+- provider API keys needed for Tier 1 targets;
 - Tailscale auth key for the host;
 - GitHub read token or app material if the host needs to clone private repos
   without relying on a person's shell auth;
 - optional S3 archive settings.
 
-Secrets should be materialized into per-run or per-command environment files
-with mode `0600`, then removed when the command completes. Prefer a tmpfs
-runtime directory for secret-bearing files.
+Host bootstrap or a root-owned sync step should materialize target-specific env
+files under `/opt/quorum/secrets-runtime` with restrictive permissions. Managed
+Quorum commands should copy only the selected target's required values into a
+per-job `0600` env file, preferably under tmpfs, then remove it when the job
+finishes.
 
-Avoid personal OAuth or subscription auth on the shared host unless the account
-is a dedicated eval identity with understood spend, quota, and audit blast
-radius. This is especially important for Codex, Antigravity, Copilot, and any
-tool that uses browser or keyring state.
+Managed commands must construct a sanitized environment. They should not pass
+the invoking shell's full `os.environ` to live evals on the AWS host. Only
+allowlisted variables and the selected target's credential material should be
+present.
 
 The shared host is not a secret isolation boundary against a malicious eval.
 Do not run untrusted scenario code there. Strong host-secret isolation belongs
@@ -216,52 +495,116 @@ Treat `results/` as sensitive.
 The host should keep full local artifacts for short-term triage:
 
 - default: 14 days or 150 GB, whichever is hit first;
-- longer retention for selected promoted baselines;
+- longer retention for selected promoted baselines and failure bundles;
 - dry-run cleanup before deletion.
 
+Cleanup must not break `quorum show`. Current batch rendering depends on local
+run `verdict.json` files, so either:
+
+- keep thin local summaries for every archived run; or
+- make `quorum show` archive-aware before deleting local summaries.
+
+### Promotion
+
+Add `quorum promote <run-or-batch>` to freeze important evidence before cleanup.
+
+Promoted artifacts can include:
+
+- full raw run directory;
+- Gauntlet-Agent event streams;
+- Coding-Agent session logs;
+- normalized tool calls;
+- token usage;
+- command log;
+- archive manifest;
+- operator note explaining why the artifact is retained.
+
+Promotion should be explicit because raw artifacts may contain secrets or
+sensitive transcript content.
+
+### Archive Manifest
+
 Completed runs and batches should be archivable to a private encrypted S3
-prefix. Long-term archive should prioritize:
+prefix. Each archive should write a manifest with:
+
+- source run or batch id;
+- source job id;
+- archive URI;
+- repo SHAs and dirty states;
+- command/profile;
+- created time and operator;
+- included file list;
+- excluded sensitive file classes;
+- byte counts by component;
+- whether the artifact is promoted.
+
+Default long-term archive should prioritize:
 
 - `batch.json`;
 - `results.jsonl`;
 - each run's `verdict.json`;
 - `coding-agent-token-usage.json`;
-- normalized `coding-agent-tool-calls.jsonl` when needed for behavior triage.
+- normalized `coding-agent-tool-calls.jsonl` when needed for behavior triage;
+- command log;
+- thin local summaries required by `quorum show`.
 
 Raw transcripts, config homes, workdirs, and Gauntlet-Agent event streams
 should be retained only when promoted or when actively triaging a failure.
 
-## Observability And Recovery
+## Observability, Handoff, And Recovery
 
 Quorum should make remote operation easy for agents:
 
 - every managed command writes a command log;
-- `quorum status` lists active runs, active locks, recent batches, owner, age,
-  command, and log path;
+- `quorum status` lists active jobs, active locks, recent batches, owner, age,
+  command, repo SHAs, out root, and log path;
+- `quorum status --json` provides the same state for agents;
 - `quorum tail <id>` follows the relevant command log;
 - `quorum show <id>` remains the verdict front door;
+- `quorum handoff <job-id> --note ...` appends a note to `job.json`;
 - stale-lock cleanup is explicit and auditable;
-- interrupted SSH sessions should not kill active jobs if they were launched
-  through the managed command path.
+- interrupted SSH sessions do not kill managed jobs;
+- orphan detection reports jobs whose supervisor is gone before cleanup.
 
-Use `tmux`, `systemd-run --scope`, or another simple host-native mechanism for
-surviving SSH disconnects. Do not introduce a custom daemon in v1 unless the
-simple mechanism cannot provide status and cleanup.
+Use `tmux`, a transient `systemd-run` service, or another simple host-native
+mechanism for surviving SSH disconnects. Do not introduce a custom daemon in v1
+unless the simple mechanism cannot provide status and cleanup.
+
+## Rerun And Compare
+
+Add first-class support for common triage loops:
+
+```bash
+uv run quorum rerun --from-batch <batch-id> --final fail,indeterminate
+uv run quorum rerun --from-batch <batch-id> --coding-agents claude --scenarios a,b
+uv run quorum compare <batch-a> <batch-b>
+```
+
+`rerun` should preserve the original batch metadata and record what changed:
+repo SHA, `SUPERPOWERS_ROOT`, target, scenario, profile, and effective command.
+
+`compare` should work on summary artifacts when raw artifacts have been cleaned
+up. It should report per-cell final verdict changes, missing cells, cost/time
+changes when available, and links to promoted artifacts.
 
 ## Cost Controls
 
-EC2 cost is meaningful but not the dominant risk. Model/API spend and accidental
-parallelism are the larger risks.
+EC2 cost is meaningful but not the dominant risk. Model/API spend, long-haul
+scenarios, and accidental parallelism are larger risks.
 
 V1 controls:
 
 - default to smoke or sentinel-tier commands;
-- require explicit confirmation or a flag for full sweeps;
-- print matrix size before starting;
+- default `sentinel-default` to a small configured target pair, not all targets;
+- require explicit confirmation or a flag for `sentinel-all`, `full-short`, and
+  `full-long-sdd`;
+- split long-haul SDD-style scenarios out of ordinary `full`;
+- print matrix size, runnable cells, skipped cells, long-haul cells, and
+  worst-case cell-minutes before starting;
 - record estimated cost from verdict economics after each run;
 - summarize batch cost when available;
 - keep provider-specific concurrency conservative;
-- add CloudWatch/AWS budget alerts for EC2 and S3;
+- add CloudWatch/AWS budget alerts for EC2, EBS, snapshots, and S3;
 - add provider-side spend alerts where available;
 - schedule stop windows only if they do not interrupt active jobs.
 
@@ -276,67 +619,126 @@ becomes true:
 - OAuth/browser/keyring targets need per-run identity rather than shared host
   state;
 - spend attribution and cleanup need to be per-run rather than per-host;
-- a failed or malicious eval must not be able to inspect sibling artifacts or
-  host secrets.
+- a failed or malicious eval must not be able to inspect sibling artifacts,
+  host secrets, or instance credentials.
 
 The v1 Quorum command design should survive that migration. A later isolated
-runner can execute the same `quorum smoke`, `column`, and `batch` commands
-inside a disposable box.
+runner can execute the same `quorum smoke`, `column`, `batch`, `rerun`, and
+`compare` commands inside a disposable box.
+
+Do not overclaim Cloud Build nonce isolation for Quorum until the current
+Cloud Build path is freshly validated for this use case.
 
 ## Implementation Seams
 
+This should remain one umbrella design, but it needs two implementation plans.
+
+### Quorum CLI / Ops Plan
+
 Likely Quorum work:
 
-- add command modules for `smoke`, `column`, `batch`, `status`, `tail`,
-  `archive`, and `cleanup`;
-- add a small lock helper with tests for ownership, stale detection, and
-  non-overlap;
-- extend batch metadata with command, user, host, git SHAs, env profile, and
-  log path;
-- add archive and retention helpers;
+- add managed-job state under `.quorum` locally and `/opt/quorum/state` on the
+  AWS host;
+- add lock helpers with `fcntl.flock`, JSON sidecars, deterministic acquisition,
+  ownership reporting, and stale/orphan detection;
+- add command modules for `doctor`, `smoke`, `column`, `batch`, `status`,
+  `tail`, `rerun`, `compare`, `promote`, `handoff`, `archive`, and `cleanup`;
+- extend batch metadata additively with `job_id`, command, profile, user, host,
+  repo SHAs, out root, log path, locks, tier, scenario filter, env profile,
+  effective concurrency, archive URI, and artifact byte counts;
+- preserve compatibility with current `batch.json` consumers and tests;
+- ensure cleanup preserves thin summaries or make `show` archive-aware before
+  deleting local run directories;
 - document the AWS-host workflow in the README or a runbook.
+
+### Terminus Infra Plan
 
 Likely Terminus work:
 
 - add a `terraform/quorum/evals` or similar service root;
 - instantiate `machine-westworld`;
-- add an encrypted persistent data volume and DLM policy;
+- add an encrypted persistent data volume with `prevent_destroy`, backup tags,
+  DLM or AWS Backup policy, and backup freshness verification;
 - add SSM parameter inventory under `/quorum-evals/*`;
 - add least-privilege IAM for SSM read and private S3 artifact archive access;
-- add cloud-init bootstrap for uv, Python, Node, agent CLIs, Gauntlet, Tailscale,
-  repo checkout, and filesystem layout.
+- block IMDS for eval users/processes;
+- add dedicated Tailscale tag and SSH ACLs;
+- add cloud-init bootstrap for uv, Python, Node, agent CLIs, Gauntlet,
+  Tailscale, repo checkout, filesystem layout, budgets, and secret
+  materialization;
+- verify Terraform plans do not replace existing Terminus hosts or persistent
+  volumes.
 
-## Verification
+## Implementation Sequence
+
+1. Add managed-job state, locks, logs, `status`, and `tail` locally without
+   changing live eval execution.
+2. Extend batch metadata additively and update tests.
+3. Add `doctor`, `smoke`, `column`, and `batch` profile wrappers over existing
+   `run` / `run-all`.
+4. Add branch/root pinning and per-job worktree support.
+5. Add `rerun`, `compare`, `promote`, `archive`, and `cleanup`.
+6. Write the Terminus infra plan.
+7. Provision the AWS host.
+8. Run the AWS dry-run campaign and adjust defaults from measured data.
+
+## Testing Strategy
+
+Static/unit checks remain safe for CI:
+
+```bash
+uv run ruff check
+uv run ty check
+uv run quorum check
+uv run pytest
+```
+
+Add Quorum tests for:
+
+- lock ownership, conflict reporting, deterministic acquisition, and orphan
+  detection;
+- job state transitions and `status --json`;
+- durable log creation and `tail`;
+- smoke mapping, including draft smoke scenarios;
+- profile expansion into child batches;
+- additive batch metadata;
+- branch/root metadata capture;
+- cleanup dry-run planning and `quorum show` preservation;
+- archive manifest generation;
+- rerun and compare behavior using fake batch/run artifacts.
+
+Use `CliRunner` with fake `run_batch` or fake child invocations for command API
+tests. AWS verification stays manual/runbook-level.
+
+## AWS Dry-Run Verification
 
 Before treating the AWS runner as usable:
 
-1. Static repo checks pass locally:
-
-   ```bash
-   uv run ruff check
-   uv run ty check
-   uv run quorum check
-   uv run pytest
-   ```
-
-2. Terminus Terraform plan shows no unrelated replacement of existing hosts or
+1. Terminus Terraform plan shows no unrelated replacement of existing hosts or
    persistent volumes.
+2. Tailscale identity, ACL, SSH behavior, IAM, IMDS blocking, data-volume mount,
+   backup tags, and backup policy are verified.
 3. Host bootstrap installs required binaries and clones the expected repo SHAs.
-4. `quorum smoke claude` passes on the AWS host.
-5. One serial-capped smoke or bootstrap target passes on the AWS host.
-6. A small `quorum batch --profile sentinel --agents claude,codex` run completes
-   and archives summaries.
-7. `quorum status`, `tail`, `show`, archive, and cleanup paths work from a fresh
-   SSH session.
+4. `quorum doctor claude` passes.
+5. `quorum smoke claude` passes.
+6. One configured capped or Tier 2 target smoke/bootstrap passes, if such a
+   target identity is ready.
+7. `quorum batch --profile sentinel-default` completes with the configured
+   day-one target pair.
+8. `quorum batch --profile uncapped-group --tier sentinel` completes only after
+   the smaller sentinel run is healthy.
+9. `status`, `tail`, `show`, `handoff`, archive, promote, and cleanup dry-run
+   work from a fresh SSH session.
+10. The run records p50/p90/p99 cell duration, queue wait, active live cells,
+    CPU, memory, EBS IOPS/throughput/queue, network, artifact bytes by
+    component, provider 429s/quota errors, cost coverage, archive upload
+    bytes/time, and cleanup reclaimable bytes.
 
 ## Open Questions
 
-- Which targets should v1 support on day one: API-key-only targets first, or
-  also OAuth/keyring targets with dedicated eval identities?
-- Should the actual job process run as the invoking Unix user or as a dedicated
-  `quorum-runner` account?
+- Which Tier 2 dedicated eval identities do we want before day one?
 - Should the first archive path be S3-only, or should it also publish a small
-  static index for easier browsing over Tailscale?
-- What retention policy is acceptable for raw transcripts: 7 days, 14 days, or
-  manual promotion only?
-
+  private index for easier browsing over Tailscale?
+- What raw transcript retention is acceptable: 7 days, 14 days, or manual
+  promotion only?
+- What is the first measured threshold for relaxing any provider-family lock?

--- a/docs/superpowers/specs/2026-06-12-quorum-aws-eval-runner-design.md
+++ b/docs/superpowers/specs/2026-06-12-quorum-aws-eval-runner-design.md
@@ -8,6 +8,10 @@ a team-accessible AWS node so he can ask Codex or another agent to run smoke
 tests, grid columns, baseline campaigns, reruns, and triage without relying on
 a local desktop.
 
+This document is the roadmap-level design. The normative Phase 1 implementation
+contract is `docs/superpowers/specs/2026-06-12-quorum-aws-eval-runner-phase-1-design.md`.
+When the two differ, the Phase 1 spec controls current implementation scope.
+
 ---
 
 ## Goal
@@ -54,8 +58,9 @@ The important split is:
   Tailscale, SSM parameter inventory, backups, host bootstrap, and host-level
   secret materialization.
 - **Quorum owns the eval operation.** Quorum exposes safe commands for smoke
-  runs, columns, batch profiles, managed jobs, locks, logs, status, tails,
-  archive, cleanup, reruns, comparisons, and handoff.
+  runs, columns, batch profiles, managed jobs, locks, logs, status, and tails
+  in Phase 1. Archive, cleanup, reruns, comparisons, and handoff are roadmap
+  work for later phases.
 
 This avoids a second command surface. Agents should be able to SSH to the host
 and run `uv run quorum ...` with first-class Quorum subcommands. Host-local
@@ -123,11 +128,11 @@ The host should keep mutable eval state under `/opt/quorum`:
 ├── worktrees/
 ├── results/
 ├── state/
+│   ├── cooldowns/
 │   ├── jobs/
 │   ├── locks/
 │   ├── logs/
-│   └── cooldowns/
-├── archive-staging/
+│   └── volume-identity.json
 └── secrets-runtime/
 ```
 
@@ -141,14 +146,16 @@ and prevents same-UID sibling process snooping across operators. Shared
 handoff should happen through sanitized job metadata and promoted artifacts,
 not through a shared raw run directory.
 
-Host-managed secret files may be readable to a trusted `quorum-operators` group
-when that is the simplest v1 implementation, but personal OAuth/subscription
-state must not be shared that way.
+Host-managed source secret profiles should be root-only. Managed jobs
+materialize only the selected target credentials into a per-job `0600` runtime
+file for the invoking operator. Personal OAuth/subscription state must not be
+shared through the host.
 
 ## Managed Job Model
 
-Add a Quorum-managed job model. This is the central seam for locks, logs,
-status, tail, archive, cleanup, reruns, comparisons, and handoff.
+Add a Quorum-managed job model. In Phase 1 this is the central seam for locks,
+logs, status, tail, and recovery. Later phases can reuse the same seam for
+archive, cleanup, reruns, comparisons, and handoff.
 
 Every managed command creates a job record before it starts side effects:
 
@@ -166,18 +173,20 @@ the AWS host uses `/opt/quorum/state` so locks cannot be bypassed by changing
 Initial states:
 
 - `planned`: job record exists, locks not yet acquired.
-- `waiting`: blocked on locks or a cooldown.
 - `running`: supervisor process is active.
-- `finishing`: child runs are done, rollup/archive/finalization is running.
 - `succeeded`: managed command completed cleanly.
 - `failed`: managed command failed.
 - `interrupted`: supervisor or child process died unexpectedly.
 - `orphaned`: job metadata exists, but the recorded supervisor is gone and the
   final state is unknown.
 
+Phase 1 should fail fast on lock conflicts and cooldowns rather than adding a
+queue. `waiting` and richer `finishing` substates belong to later platform
+phases if a queue or archive finalizer is added.
+
 ### `job.json`
 
-`job.json` should include at least:
+`job.json` should include at least the Phase 1 operational fields:
 
 ```json
 {
@@ -222,12 +231,16 @@ Initial states:
     }
   ],
   "artifact_bytes": null,
-  "archive_uri": null,
+  "result_rollup": null,
+  "tainted": false,
   "started_at": "2026-06-12T18:30:00Z",
-  "finished_at": null,
-  "handoff_notes": []
+  "finished_at": null
 }
 ```
+
+Later phases can add archive URIs, handoff notes, cleanup state, and comparison
+metadata without requiring current `batch.json`, `results.jsonl`, or
+`verdict.json` readers to understand them.
 
 Foreground commands should stream the durable log, but the job itself should
 survive SSH disconnect via `tmux`, `systemd-run`, or another simple host-native
@@ -236,16 +249,23 @@ exit.
 
 ## Quorum CLI Additions
 
-Add Quorum subcommands that express maintainer workflows directly:
+Add Quorum subcommands that express maintainer workflows directly.
+
+Phase 1 command surface:
 
 ```bash
 uv run quorum doctor
 uv run quorum smoke claude
 uv run quorum column copilot
-uv run quorum batch --profile sentinel-default --coding-agents claude,kimi
+uv run quorum batch --profile sentinel-default
 uv run quorum status
 uv run quorum status --json
 uv run quorum tail <run-or-batch-or-job>
+```
+
+Later platform phases can add:
+
+```bash
 uv run quorum rerun --from-batch <batch-id> --final fail,indeterminate
 uv run quorum compare <batch-a> <batch-b>
 uv run quorum promote <run-or-batch>
@@ -259,7 +279,9 @@ Use `--coding-agents` as the canonical flag name, matching existing Quorum.
 documented spelling.
 
 These commands are convenience and safety affordances over `quorum run`,
-`run-all`, and `show`, not a replacement for the underlying primitives.
+`run-all`, and `show`, not a replacement for the underlying primitives. On the
+AWS host, raw live `run` and `run-all` should still fail closed outside the
+managed worker so they cannot bypass locks by accident.
 
 ### `quorum doctor`
 
@@ -316,9 +338,9 @@ manifest that records all child batch ids.
 Initial profiles:
 
 - `sentinel-default`: a small configured target pair at `--tier sentinel
-  --jobs 2`. Prefer `claude,codex` only when a dedicated Codex eval identity
-  exists; otherwise use `claude` plus another Tier 1 target. This is the day
-  one low-risk campaign profile.
+  --jobs 1` per child. Prefer `claude,codex` only when a dedicated Codex eval
+  identity exists; otherwise use `claude` plus another Tier 1 target. This is
+  the day one low-risk campaign profile.
 - `sentinel-all`: split into one uncapped child batch and serial capped child
   columns. Antigravity stays separate from Gemini.
 - `uncapped-group`: `claude,claude-haiku,claude-sonnet,codex,kimi --jobs 4`.
@@ -641,26 +663,25 @@ Likely Quorum work:
   AWS host;
 - add lock helpers with `fcntl.flock`, JSON sidecars, deterministic acquisition,
   ownership reporting, and stale/orphan detection;
-- add command modules for `doctor`, `smoke`, `column`, `batch`, `status`,
-  `tail`, `rerun`, `compare`, `promote`, `handoff`, `archive`, and `cleanup`;
+- add Phase 1 command modules for `doctor`, `smoke`, `column`, `batch`,
+  `status`, and `tail`;
 - extend batch metadata additively with `job_id`, command, profile, user, host,
   repo SHAs, out root, log path, locks, tier, scenario filter, env profile,
-  effective concurrency, archive URI, and artifact byte counts;
+  effective concurrency, result rollup, taint state, and artifact byte counts;
 - preserve compatibility with current `batch.json` consumers and tests;
-- ensure cleanup preserves thin summaries or make `show` archive-aware before
-  deleting local run directories;
 - document the AWS-host workflow in the README or a runbook.
 
 ### Terminus Infra Plan
 
 Likely Terminus work:
 
-- add a `terraform/quorum/evals` or similar service root;
+- add a `terraform/quorum-evals/` service root;
 - instantiate `machine-westworld`;
 - add an encrypted persistent data volume with `prevent_destroy`, backup tags,
   DLM or AWS Backup policy, and backup freshness verification;
 - add SSM parameter inventory under `/quorum-evals/*`;
-- add least-privilege IAM for SSM read and private S3 artifact archive access;
+- add least-privilege IAM for SSM read. Private S3 artifact archive access is a
+  later phase;
 - block IMDS for eval users/processes;
 - add dedicated Tailscale tag and SSH ACLs;
 - add cloud-init bootstrap for uv, Python, Node, agent CLIs, Gauntlet,
@@ -671,16 +692,32 @@ Likely Terminus work:
 
 ## Implementation Sequence
 
+Phase 1a:
+
 1. Add managed-job state, locks, logs, `status`, and `tail` locally without
    changing live eval execution.
-2. Extend batch metadata additively and update tests.
-3. Add `doctor`, `smoke`, `column`, and `batch` profile wrappers over existing
-   `run` / `run-all`.
-4. Add branch/root pinning and per-job worktree support.
-5. Add `rerun`, `compare`, `promote`, `archive`, and `cleanup`.
-6. Write the Terminus infra plan.
-7. Provision the AWS host.
-8. Run the AWS dry-run campaign and adjust defaults from measured data.
+2. Make AWS host-mode raw live `run` / `run-all` fail closed outside the
+   managed worker.
+3. Add sanitized run-environment plumbing and selected-target secret
+   materialization.
+4. Add `doctor`, `smoke`, and sentinel `column` wrappers over existing `run` /
+   `run-all`.
+5. Write the Terminus infra plan.
+6. Provision the AWS host.
+7. Run the Phase 1a AWS dry run with one ready key-backed target.
+
+Phase 1b:
+
+1. Add the explicit `sentinel-default` batch profile manifest.
+2. Run the provider-diverse sentinel campaign after a second key-backed target is
+   honestly `doctor`-ready.
+3. Adjust defaults from measured data.
+
+Later phases:
+
+- branch/root pinning and per-job worktree creation;
+- `rerun`, `compare`, `promote`, `archive`, `handoff`, and `cleanup`;
+- S3/private index, queueing, Slack/web submission, and multi-host workers.
 
 ## Testing Strategy
 
@@ -702,10 +739,7 @@ Add Quorum tests for:
 - smoke mapping, including draft smoke scenarios;
 - profile expansion into child batches;
 - additive batch metadata;
-- branch/root metadata capture;
-- cleanup dry-run planning and `quorum show` preservation;
-- archive manifest generation;
-- rerun and compare behavior using fake batch/run artifacts.
+- branch/root metadata capture.
 
 Use `CliRunner` with fake `run_batch` or fake child invocations for command API
 tests. AWS verification stays manual/runbook-level.
@@ -721,18 +755,14 @@ Before treating the AWS runner as usable:
 3. Host bootstrap installs required binaries and clones the expected repo SHAs.
 4. `quorum doctor claude` passes.
 5. `quorum smoke claude` passes.
-6. One configured capped or Tier 2 target smoke/bootstrap passes, if such a
-   target identity is ready.
-7. `quorum batch --profile sentinel-default` completes with the configured
-   day-one target pair.
-8. `quorum batch --profile uncapped-group --tier sentinel` completes only after
-   the smaller sentinel run is healthy.
-9. `status`, `tail`, `show`, `handoff`, archive, promote, and cleanup dry-run
-   work from a fresh SSH session.
-10. The run records p50/p90/p99 cell duration, queue wait, active live cells,
-    CPU, memory, EBS IOPS/throughput/queue, network, artifact bytes by
-    component, provider 429s/quota errors, cost coverage, archive upload
-    bytes/time, and cleanup reclaimable bytes.
+6. `quorum column claude` starts as a managed sentinel column and writes a batch
+   artifact.
+7. `status`, `tail`, and `show` work from a fresh SSH session.
+8. `quorum batch --profile sentinel-default` completes only after a second
+   key-backed target is ready.
+9. The run records p50/p90/p99 cell duration, lock conflicts/cooldowns, active
+   live cells, CPU, memory, EBS IOPS/throughput/queue, network, artifact bytes
+   by component, provider 429s/quota errors, and cost coverage.
 
 ## Open Questions
 

--- a/docs/superpowers/specs/2026-06-12-quorum-aws-eval-runner-phase-1-design.md
+++ b/docs/superpowers/specs/2026-06-12-quorum-aws-eval-runner-phase-1-design.md
@@ -1,0 +1,753 @@
+# Quorum AWS Eval Runner Phase 1 - design specification
+
+**Status:** Draft for Drew review.
+**Date:** 2026-06-12
+**Tracker:** PRI-2205
+**Parent spec:** `docs/superpowers/specs/2026-06-12-quorum-aws-eval-runner-design.md`
+
+---
+
+## Goal
+
+Phase 1 creates the smallest useful shared AWS runner for trusted Quorum live
+evals.
+
+The outcome is a remote Quorum workstation, not a full eval platform:
+
+- agents SSH to a Terminus-managed host;
+- agents operate through first-class `uv run quorum ...` commands;
+- live runs have durable job records, durable logs, and host-global locks;
+- every target has a host-managed, key-backed readiness contract;
+- results remain ordinary Quorum artifacts that `quorum show` can render.
+
+Phase 1 should be platform-shaped without being a platform service. The command
+surface should survive later queue, API, UI, Slack, or disposable-worker
+backends, but those backends are not built now.
+
+## Non-goals
+
+- Web UI.
+- Slack submission bot.
+- Long-running queue daemon.
+- Custom scheduler service.
+- Multi-host parallelism.
+- S3 archive, promotion, compare, cleanup, or private result index.
+- Public CI live evals.
+- Running untrusted PRs or generated scenario code on the shared host.
+- Strong per-run sandbox isolation.
+- Personal OAuth, browser, keyring, or subscription auth as supported runtime
+  dependencies.
+
+## Current Constraints
+
+The local repository already has the primitive run surface:
+
+- `quorum run` runs one scenario against one Coding-Agent.
+- `quorum run-all` runs a scenario-by-agent matrix and writes
+  `results/batches/<batch-id>/`.
+- `quorum show` renders run and batch verdicts from local artifacts.
+
+Phase 1 should wrap those primitives rather than replace them.
+
+Important current behavior:
+
+- `run-all --jobs` is a process-local worker-pool size. It is not a host-wide
+  live-cell cap.
+- Agents with `max_concurrency` in `coding-agents/*.yaml` get dedicated lanes
+  beside the shared `--jobs` pool. A broad `run-all` can therefore exceed the
+  numeric `--jobs` count.
+- `max_concurrency` is process-local. Two SSH sessions can currently violate
+  the same target cap unless Quorum adds host-global locks.
+- `run-all` excludes `status: draft` scenarios unless `--include-drafts` is
+  set. A target smoke command must include draft smoke scenarios deliberately
+  when the target's bootstrap smoke is still draft.
+- Current target auth is mixed:
+  - Claude-family targets are API-key-backed through `ANTHROPIC_API_KEY`.
+  - Gemini is API-key-backed by default through `GEMINI_API_KEY`.
+  - Kimi is API-key-backed through `KIMI_MODEL_API_KEY`.
+  - Pi is API-key-backed through `PI_PROVIDER`, `PI_MODEL`, and `PI_API_KEY`.
+  - Copilot has provider-mode support through `COPILOT_PROVIDER_*`.
+  - OpenCode runs from provider key env such as `OPENAI_API_KEY`.
+  - Codex currently requires copied ChatGPT subscription auth and strips
+    OpenAI API-key env in its launcher.
+  - Antigravity currently preflights Code Assist browser/keyring auth.
+
+Phase 1 must make that mixed auth reality explicit. It should not quietly call
+a target supported because a developer happened to be logged in on the host.
+
+## Direction
+
+Use one long-lived Terminus host plus a small Quorum managed-job layer.
+
+The split is:
+
+- **Terminus owns the host.** Terraform creates the EC2 instance, EBS volume,
+  IAM role, SSM parameter inventory, Tailscale access, backup tags, and
+  bootstrap.
+- **Quorum owns live-eval operation.** Quorum creates job metadata, logs,
+  target readiness checks, sanitized env files, host-global locks, and the
+  managed command wrappers over `run` / `run-all`.
+
+There is no separate `qrun` command, HTTP API, daemon, or queue in Phase 1.
+
+## Operator Workflow
+
+The happy path should look like this:
+
+```bash
+ssh quorum-evals
+cd /opt/quorum/repos/superpowers-evals
+
+uv run quorum doctor --all
+uv run quorum smoke claude
+uv run quorum column claude
+uv run quorum batch --profile sentinel-default
+uv run quorum status
+uv run quorum tail <job-id>
+uv run quorum show <batch-id> --results-root /opt/quorum/results
+```
+
+Managed live commands print the job id and durable log path early. If the SSH
+session disconnects, the run continues under its supervisor. Another agent can
+later use `status`, `tail`, and `show` to recover.
+
+## Terminus Host
+
+Create a single service root in the Terminus repo for the Phase 1 host:
+
+```text
+terraform/quorum-evals/
+```
+
+The Terraform state should be scoped to the Quorum eval runner and not mixed
+into an unrelated service root.
+
+Use the existing `machine-westworld` module for the named EC2 instance:
+
+- Region: `us-west-1`.
+- Instance name: `quorum-evals`.
+- Instance type: `m6i.2xlarge` on-demand.
+- Root volume: 100 GB encrypted gp3.
+- Security group: outbound only, no inbound application ports.
+- Access: Tailscale SSH and SSM Session Manager.
+- Managed policies: SSM managed instance support.
+- IAM: SSM read for `/quorum-evals/*` and no broader secret prefixes.
+
+Add the data volume in the service root, following the existing Brainstorm and
+monitoring EBS patterns:
+
+- 500 GB encrypted gp3 data volume.
+- Attached to the `quorum-evals` instance.
+- Mounted at `/opt/quorum`.
+- `prevent_destroy = true`.
+- Backup/discovery tags for snapshot policy.
+- A backup freshness check in the operational runbook before the host is
+  considered durable.
+
+Use on-demand for Phase 1. Spot and stop/start scheduling are later cost
+optimizations once interruption behavior is measured.
+
+## Host Layout
+
+The host keeps mutable eval state under `/opt/quorum`:
+
+```text
+/opt/quorum/
+├── repos/
+│   ├── superpowers/
+│   └── superpowers-evals/
+├── worktrees/
+├── results/
+├── state/
+│   ├── jobs/
+│   ├── locks/
+│   └── logs/
+└── secrets-runtime/
+```
+
+Default paths:
+
+- `SUPERPOWERS_ROOT=/opt/quorum/repos/superpowers`
+- eval repo: `/opt/quorum/repos/superpowers-evals`
+- results root: `/opt/quorum/results`
+- state root: `/opt/quorum/state`
+
+Local development and tests may use a repo-local state root such as
+`<out-root>/.quorum/`, but the AWS host must use `/opt/quorum/state` so locks
+cannot be bypassed by changing `--out-root`.
+
+Set `QUORUM_STATE_ROOT=/opt/quorum/state` in the host Quorum environment. The
+managed-command implementation should prefer that env var when present and
+fall back to local state only outside the host.
+
+## User And Process Model
+
+Team members should have separate Unix accounts. Phase 1 jobs run as the
+invoking Unix user.
+
+This preserves basic auditability and avoids same-UID process snooping between
+operators. Phase 1 does not need a shared `quorum-runner` service account.
+
+Operator accounts should not have:
+
+- passwordless `sudo`;
+- wheel/admin group membership;
+- Docker socket access.
+
+Bootstrap and secret sync can run as root through cloud-init, SSM, or an
+explicit operator action. Live eval child processes should run as the operator.
+
+## Target Readiness Contract
+
+Phase 1 supports all targets through host-managed eval credentials, but a
+target is usable only after `doctor` proves the target's key-backed path works.
+
+Definition of ready:
+
+```bash
+uv run quorum doctor <target>
+```
+
+must prove that:
+
+- the target binary exists;
+- required Superpowers files exist under `SUPERPOWERS_ROOT`;
+- required provider credentials are available from the host-managed profile;
+- a sanitized run environment can be built without inheriting personal shell
+  secrets;
+- the target can authenticate without personal OAuth, browser, keyring, or
+  subscription state;
+- any target-specific preflight passes or fails with a redacted diagnostic.
+
+`doctor --all` reports every target as `ready`, `blocked`, or `failed`.
+
+Meanings:
+
+- `ready`: the target can run from host-managed eval credentials.
+- `blocked`: Quorum does not yet have a key-backed adapter for this target, or
+  the provider CLI does not expose one that has been verified locally.
+- `failed`: the target has a key-backed adapter, but this host is missing a
+  binary, secret, repo file, or provider preflight.
+
+Blocked targets are still in Phase 1 scope. They are not counted as supported
+until their key-backed adapter work lands.
+
+### Phase 1 Credential Profiles
+
+Use SSM SecureString parameters under `/quorum-evals/*`. Terraform owns the
+parameter inventory with placeholder values and ignores secret value changes.
+
+Initial credential families:
+
+| Target | Credential contract |
+| --- | --- |
+| `claude` | `ANTHROPIC_API_KEY`, `SUPERPOWERS_ROOT` |
+| `claude-haiku` | `ANTHROPIC_API_KEY`, `SUPERPOWERS_ROOT` |
+| `claude-sonnet` | `ANTHROPIC_API_KEY`, `SUPERPOWERS_ROOT` |
+| `gemini` | `GEMINI_API_KEY`, `SUPERPOWERS_ROOT`, `GEMINI_AUTH_TYPE=gemini-api-key` |
+| `kimi` | `KIMI_MODEL_API_KEY`, optional `KIMI_MODEL_NAME`, `SUPERPOWERS_ROOT` |
+| `pi` | `PI_PROVIDER`, `PI_MODEL`, `PI_API_KEY`, optional provider extras, `SUPERPOWERS_ROOT` |
+| `copilot` | provider-mode `COPILOT_PROVIDER_*`, `SUPERPOWERS_ROOT` |
+| `opencode` | explicit provider key env and pinned model, `SUPERPOWERS_ROOT` |
+| `codex` | key-backed Codex mode to be implemented and verified; no ChatGPT subscription auth |
+| `antigravity` | key-backed Antigravity mode to be implemented and verified; no Code Assist browser/keyring auth |
+
+For `codex` and `antigravity`, the implementation must verify the current CLI
+auth surface before choosing exact env names or flags. Until that is done,
+`doctor codex` and `doctor antigravity` should return `blocked`, not silently
+fall back to personal login state.
+
+## Secrets Runtime
+
+The host materializes restricted target env files under:
+
+```text
+/opt/quorum/secrets-runtime/<target>.env
+```
+
+Recommended ownership:
+
+- `root:quorum-operators`
+- mode `0640`
+
+Managed Quorum commands copy the selected target profile into a per-job env
+file with mode `0600`, preferably under a tmpfs location. The per-job env file
+is deleted when the job finishes.
+
+Live child processes receive an allowlisted environment, not the invoking
+shell's full `os.environ`.
+
+Allowed env classes:
+
+- `PATH`, `HOME`, `TERM`, locale, certificate, and proxy variables required by
+  the CLI;
+- Quorum runtime paths such as `SUPERPOWERS_ROOT`, `QUORUM_STATE_ROOT`, and the
+  per-target config-dir env;
+- selected provider credentials for the target being run;
+- target-specific non-secret model/provider config.
+
+Disallowed Phase 1 runtime dependencies:
+
+- `~/.codex/auth.json` ChatGPT subscription auth;
+- `~/.gemini/oauth_creds.json`;
+- browser cookies;
+- macOS keychain or Linux keyring state;
+- a developer's personal GitHub/Copilot login;
+- credentials embedded in proxy URLs.
+
+## Managed Job Model
+
+Every managed live command creates a job record before launching the child run:
+
+```text
+/opt/quorum/state/jobs/<job-id>.json
+/opt/quorum/state/logs/<job-id>.log
+```
+
+Job ids use a sortable timestamp and short random suffix:
+
+```text
+job-20260612T190000Z-a1b2
+```
+
+Initial states:
+
+- `planned`: metadata written, locks not yet acquired.
+- `running`: supervisor is active and locks are held.
+- `succeeded`: child command exited successfully.
+- `failed`: child command exited with a nonzero managed-command failure.
+- `interrupted`: supervisor observed interruption or child termination.
+- `orphaned`: metadata exists, but the recorded supervisor is gone and the
+  final child state cannot be determined.
+
+Phase 1 should fail fast on lock conflict. It should not implement a queue.
+Queued/waiting states belong to a later platform phase.
+
+Minimum `job.json` schema:
+
+```json
+{
+  "schema_version": 1,
+  "id": "job-20260612T190000Z-a1b2",
+  "state": "running",
+  "owner": "drew",
+  "host": "quorum-evals",
+  "command": ["quorum", "batch", "--profile", "sentinel-default"],
+  "managed_command": "batch",
+  "profile": "sentinel-default",
+  "coding_agents": ["claude", "gemini"],
+  "scenario_filter": null,
+  "tier": "sentinel",
+  "include_drafts": false,
+  "out_root": "/opt/quorum/results",
+  "log_path": "/opt/quorum/state/logs/job-20260612T190000Z-a1b2.log",
+  "locks": ["global:broad-batch", "target:claude", "target:gemini"],
+  "env_profiles": ["claude", "gemini"],
+  "evals_repo": {
+    "path": "/opt/quorum/repos/superpowers-evals",
+    "branch": "main",
+    "sha": "abc123",
+    "dirty": false
+  },
+  "superpowers_repo": {
+    "path": "/opt/quorum/repos/superpowers",
+    "branch": "main",
+    "sha": "def456",
+    "dirty": false
+  },
+  "supervisor": {
+    "kind": "tmux",
+    "name": "quorum-job-20260612T190000Z-a1b2",
+    "pid": 12345
+  },
+  "children": [],
+  "started_at": "2026-06-12T19:00:00Z",
+  "finished_at": null,
+  "final_exit_code": null
+}
+```
+
+The schema is intentionally additive. Existing `batch.json`, `results.jsonl`,
+and `verdict.json` readers should not need to understand job records.
+
+## Supervisor
+
+Use a host-native supervisor for Phase 1, preferably `tmux` because the eval
+workflow already uses terminal sessions and it is easy for agents to inspect.
+
+Requirements:
+
+- the supervisor process, not the initiating CLI process, holds lock file
+  descriptors for the lifetime of the child run;
+- stdout and stderr from the child command append to the durable job log;
+- the initiating CLI can stream the log while connected;
+- SSH disconnect does not terminate the child run;
+- `status` can detect whether the supervisor is still alive.
+
+`systemd-run --user` or transient system services are acceptable only if they
+meet the same lock and log requirements without adding a custom daemon.
+
+## Locking And Concurrency
+
+Host-global locks live under:
+
+```text
+/opt/quorum/state/locks/
+```
+
+Use `fcntl.flock` or an equivalent open-file-descriptor lock. JSON sidecars may
+be written for diagnostics, but the open descriptor is the source of truth so
+killed supervisors release locks automatically.
+
+Acquire locks in deterministic order:
+
+1. global locks;
+2. provider locks;
+3. target locks.
+
+Initial locks:
+
+| Lock | Purpose |
+| --- | --- |
+| `global:broad-batch` | Prevent overlapping broad campaigns. |
+| `provider:anthropic` | Conservative Claude-family coordination. |
+| `provider:openai` | Codex/OpenCode/OpenAI-backed provider coordination. |
+| `provider:google` | Gemini/Antigravity coordination. |
+| `provider:kimi` | Kimi provider coordination. |
+| `provider:copilot` | Copilot provider coordination. |
+| `target:<name>` | Prevent same-target overlap across SSH sessions. |
+
+Phase 1 locking policy:
+
+- `doctor`: no locks unless it performs a live provider preflight.
+- `smoke <target>`: `target:<target>` plus provider lock.
+- `column <target>`: `target:<target>` plus provider lock.
+- `batch sentinel-default`: `global:broad-batch` plus selected target/provider
+  locks.
+
+On conflict, Quorum exits nonzero and reports:
+
+- lock name;
+- owning job id if known;
+- owning user if known;
+- owning command if known;
+- job log path if known.
+
+No queueing is required in Phase 1.
+
+## Commands
+
+### `quorum doctor`
+
+Purpose: report whether the host can run one or more targets from key-backed
+eval credentials.
+
+Shape:
+
+```bash
+uv run quorum doctor <target>
+uv run quorum doctor --all
+uv run quorum doctor <target> --json
+```
+
+Checks:
+
+- repo path and `SUPERPOWERS_ROOT`;
+- target YAML loads and required Superpowers files exist;
+- target binary exists;
+- host state root and output root are writable;
+- required secret profile exists;
+- target env can be sanitized and materialized;
+- target auth mode is not personal login state;
+- target-specific preflight passes when safe to run.
+
+`doctor` should redact secret values in all output.
+
+### `quorum smoke`
+
+Purpose: run the canonical smoke/bootstrap scenario for one target.
+
+Shape:
+
+```bash
+uv run quorum smoke <target>
+```
+
+Behavior:
+
+- runs as a managed job;
+- validates `doctor <target>` first;
+- acquires target/provider locks;
+- uses `jobs=1`;
+- includes draft smoke scenarios deliberately when the target's smoke scenario
+  is still draft;
+- writes the job log;
+- prints job id, run id, final verdict, and the `quorum show` command.
+
+Smoke mapping should be explicit and tested. Claude-family and Codex targets
+use `00-quorum-smoke-hello-world` unless a target-specific bootstrap scenario
+is configured. Targets with bootstrap scenarios use those scenarios.
+
+### `quorum column`
+
+Purpose: run all runnable scenarios for one target.
+
+Shape:
+
+```bash
+uv run quorum column <target>
+```
+
+Behavior:
+
+- validates `doctor <target>` first;
+- previews the matrix before starting;
+- prints runnable, skipped, draft, and long-time cell counts;
+- acquires target/provider locks;
+- invokes existing `run-all` with `--coding-agents <target>`;
+- defaults to `--jobs 1` when the target YAML has `max_concurrency: 1`;
+- defaults uncapped targets to `--jobs 1` before measurement;
+- may raise the configured uncapped default after the AWS dry run confirms the
+  host and provider can sustain more parallelism;
+- writes the job log;
+- prints job id, batch id, final rollup, and the `quorum show` command.
+
+### `quorum batch --profile sentinel-default`
+
+Purpose: run the day-one shared sentinel campaign.
+
+Shape:
+
+```bash
+uv run quorum batch --profile sentinel-default
+```
+
+Behavior:
+
+- profile is configured in Quorum, not in shell aliases;
+- target list contains only doctor-ready targets;
+- default tier is `sentinel`;
+- profile is small enough for routine team use;
+- acquires `global:broad-batch` plus target/provider locks;
+- invokes one or more existing `run-all` child commands;
+- records child batch ids in `job.json`;
+- prints job id, child batch ids, rollup, and `quorum show` commands.
+
+Phase 1 does not need `sentinel-all`, `full-short`, or long-haul profiles.
+
+### `quorum status`
+
+Purpose: show active and recent managed jobs.
+
+Shape:
+
+```bash
+uv run quorum status
+uv run quorum status --json
+```
+
+Reports:
+
+- job id;
+- state;
+- owner;
+- age;
+- managed command;
+- targets;
+- locks;
+- repo SHAs;
+- log path;
+- child run or batch ids when known.
+
+`status` should mark jobs orphaned when job metadata exists but the recorded
+supervisor is gone and the final state was not written.
+
+### `quorum tail`
+
+Purpose: follow a job's durable command log.
+
+Shape:
+
+```bash
+uv run quorum tail <job-id>
+```
+
+It should resolve full ids and unambiguous prefixes. It does not need to tail
+raw target transcripts in Phase 1.
+
+## Branch And Root Metadata
+
+Phase 1 records repo identity; it does not need to implement per-job worktree
+creation.
+
+Every managed job records:
+
+- evals repo path, branch, SHA, dirty state;
+- `SUPERPOWERS_ROOT` path, branch, SHA, dirty state;
+- current command argv;
+- results root.
+
+If either repo is dirty, the managed command should print a clear warning and
+record `dirty: true`. It may still run, because Phase 1 is an operator tool,
+but the resulting batch must not be presented as a clean baseline.
+
+Per-job `--superpowers-ref`, `--evals-ref`, and immutable worktree preparation
+are Phase 2 work. Phase 1 can still run against an operator-prepared
+`SUPERPOWERS_ROOT`; it records the path, branch, SHA, and dirty state rather
+than creating the checkout itself.
+
+## Results And Artifacts
+
+Phase 1 keeps using the existing Quorum result layout under:
+
+```text
+/opt/quorum/results/
+```
+
+No archive or cleanup command is required in Phase 1.
+
+Phase 1 should avoid making future cleanup impossible:
+
+- job metadata records child run and batch ids;
+- managed commands print artifact paths;
+- target env files are excluded from copied artifacts when possible;
+- secret-bearing diagnostics are redacted;
+- `quorum show` remains the verdict front door.
+
+Disk pressure is handled manually in Phase 1. `doctor --all` should warn when
+free space under `/opt/quorum` is below a conservative threshold, initially 100
+GB.
+
+## Data Flow
+
+Managed smoke, column, and sentinel batch follow this flow:
+
+1. Resolve host paths and state root.
+2. Run `doctor` checks for selected targets.
+3. Create `job.json` in `planned` state.
+4. Build sanitized per-target env profiles.
+5. Acquire required locks.
+6. Start the supervisor.
+7. Supervisor updates `job.json` to `running` and holds lock descriptors.
+8. Supervisor invokes existing `quorum run` or `quorum run-all`.
+9. Child writes normal run/batch artifacts under `/opt/quorum/results`.
+10. Supervisor records child ids, final state, exit code, and finish time.
+11. Initiating CLI streams the durable log while connected.
+
+## Error Handling
+
+`doctor` failures are non-destructive and should be actionable.
+
+Managed command failures:
+
+- missing secret profile: fail before job launch;
+- blocked key-backed adapter: fail before job launch;
+- lock conflict: fail before job launch with owner/log details;
+- child `run` / `run-all` nonzero exit: mark job `failed`;
+- SSH disconnect: no state change; supervisor continues;
+- supervisor gone before final state: `status` marks job `orphaned`;
+- malformed `job.json`: `status` reports the file path and continues listing
+  other jobs.
+
+Secret values must never appear in command logs, job JSON, or failure messages.
+
+## Testing
+
+Static checks remain safe for CI:
+
+```bash
+uv run ruff check
+uv run ty check
+uv run quorum check
+uv run pytest
+```
+
+Add unit tests for:
+
+- state-root discovery;
+- job id allocation and `job.json` schema;
+- job state transitions;
+- durable log path creation;
+- lock acquisition, release, deterministic ordering, and conflict reporting;
+- target-to-provider lock mapping;
+- `doctor` ready/blocked/failed output;
+- secret redaction;
+- smoke scenario mapping, including draft bootstrap scenarios;
+- `column` command expansion over existing `run-all`;
+- `sentinel-default` profile expansion;
+- `status --json`;
+- orphan detection;
+- `tail` id/prefix resolution.
+
+Use fake child invocations for command tests. Live Quorum evals and AWS
+provisioning are manual/dry-run verification, not public CI.
+
+## AWS Dry-Run Verification
+
+Before Phase 1 is considered usable:
+
+1. Terraform plan shows no unrelated replacement of existing Terminus
+   resources.
+2. The host appears in Tailscale as `quorum-evals`.
+3. SSM Session Manager can reach the instance.
+4. `/opt/quorum` is mounted from the persistent encrypted data volume.
+5. Data volume has `prevent_destroy` and backup tags.
+6. Required binaries are installed.
+7. Repos are cloned at expected branches.
+8. `uv sync --extra dev` succeeds in the eval repo.
+9. `uv run quorum doctor --all` reports ready, blocked, or failed for every
+   target with no unclassified target.
+10. At least one key-backed target smoke passes.
+11. At least one target column starts and writes a batch artifact.
+12. `sentinel-default` completes with its configured ready target set.
+13. A disconnected SSH session does not kill the managed job.
+14. A second SSH session can run `status`, `tail`, and `show`.
+15. A deliberate lock conflict exits clearly and does not start a second live
+   run.
+
+Record dry-run measurements:
+
+- wall time;
+- runnable cell count;
+- p50/p90/p99 cell duration when available;
+- active live-cell count;
+- CPU, memory, disk free, and network observations;
+- artifact bytes written;
+- provider rate-limit/auth failures;
+- rough provider/model cost from existing Quorum economics where available.
+
+## Phase 1 Exit Criteria
+
+Phase 1 is complete when:
+
+- Terminus provisions `quorum-evals` through Terraform.
+- `/opt/quorum` host layout exists on persistent EBS.
+- host-managed secret profiles exist for every target family.
+- `doctor --all` classifies every target and at least the intended day-one
+  target set is `ready`.
+- key-backed adapter work lands for any target counted as supported.
+- `smoke <target>`, `column <target>`, and `batch --profile sentinel-default`
+  run as managed jobs.
+- managed jobs survive SSH disconnect.
+- `status` and `tail` recover job state from a fresh SSH session.
+- host-global locks prevent target/provider conflicts across sessions.
+- job metadata records owner, command, repo SHAs, dirty states, locks, log
+  path, out root, child ids, and final state.
+- results remain inspectable through `quorum show`.
+- dry-run measurements are captured and used to adjust default parallelism.
+
+## Deferred To Later Phases
+
+- `rerun`
+- `compare`
+- `promote`
+- `archive`
+- `cleanup`
+- S3 artifact manifests
+- private result index
+- branch/ref worktree creation
+- queueing and scheduling
+- web or Slack submission
+- Cloud Build / Stockyard isolation
+- multi-host parallelism
+- per-run spend attribution

--- a/docs/superpowers/specs/2026-06-12-quorum-aws-eval-runner-phase-1-design.md
+++ b/docs/superpowers/specs/2026-06-12-quorum-aws-eval-runner-phase-1-design.md
@@ -132,17 +132,52 @@ Use the existing `machine-westworld` module for the named EC2 instance:
 - Access: Tailscale SSH and SSM Session Manager.
 - Managed policies: SSM managed instance support.
 - IAM: SSM read for `/quorum-evals/*` and no broader secret prefixes.
+- IAM: `kms:Decrypt` must be scoped to SSM use, matching the existing
+  Brainstorm/Claw Eng pattern.
+- IMDS: eval users and eval child processes must not be able to reach
+  `169.254.169.254` or the IPv6 IMDS endpoint if IPv6 metadata is enabled.
+  The existing `machine-westworld` module enables IMDSv2, so the service root
+  or bootstrap must add an explicit host firewall, unit sandbox, or equivalent
+  control and verify it in the dry run.
 
 Add the data volume in the service root, following the existing Brainstorm and
 monitoring EBS patterns:
 
 - 500 GB encrypted gp3 data volume.
+- Data volume availability zone is derived from the selected subnet, not
+  hardcoded independently.
 - Attached to the `quorum-evals` instance.
 - Mounted at `/opt/quorum`.
 - `prevent_destroy = true`.
-- Backup/discovery tags for snapshot policy.
-- A backup freshness check in the operational runbook before the host is
-  considered durable.
+- Steady-state userdata is mount-only and must never auto-format an attached
+  data volume. Blank-volume initialization is an explicit one-shot operator or
+  SSM action.
+- DLM or AWS Backup policy is created for the data volume, not only tags.
+- Dry-run verification checks that the backup policy is enabled and at least
+  one recent snapshot exists before the host is considered durable.
+- The runbook includes replacement-host restore steps for `/opt/quorum`.
+
+SSM parameter inventory for Phase 1:
+
+```text
+/quorum-evals/tailscale-auth-key
+/quorum-evals/github-read-token
+/quorum-evals/targets/claude/ANTHROPIC_API_KEY
+/quorum-evals/targets/gemini/GEMINI_API_KEY
+/quorum-evals/targets/kimi/KIMI_MODEL_API_KEY
+/quorum-evals/targets/pi/PI_PROVIDER
+/quorum-evals/targets/pi/PI_MODEL
+/quorum-evals/targets/pi/PI_API_KEY
+/quorum-evals/targets/copilot/COPILOT_PROVIDER_BASE_URL
+/quorum-evals/targets/copilot/COPILOT_PROVIDER_TYPE
+/quorum-evals/targets/copilot/COPILOT_PROVIDER_API_KEY
+/quorum-evals/targets/copilot/COPILOT_PROVIDER_BEARER_TOKEN
+/quorum-evals/targets/opencode/OPENAI_API_KEY
+```
+
+Terraform owns the inventory with placeholder values and `ignore_changes` on
+secret values. Bootstrap or `doctor` must reject placeholder values before
+running live evals.
 
 Use on-demand for Phase 1. Spot and stop/start scheduling are later cost
 optimizations once interruption behavior is measured.
@@ -194,13 +229,23 @@ Operator accounts should not have:
 - wheel/admin group membership;
 - Docker socket access.
 
+Bootstrap owns creation of the `quorum-operators` group, operator account
+membership, `/opt/quorum` directory permissions, and `/opt/quorum/secrets-runtime`
+permissions. Bootstrap must not add eval operators to `sudo`, `wheel`, or
+`docker`.
+
+Tailscale must advertise a dedicated `tag:quorum-evals` identity. The Tailscale
+ACL must allow SSH only to non-root operator accounts on this host. Root access
+is reserved for SSM break-glass and bootstrap operations.
+
 Bootstrap and secret sync can run as root through cloud-init, SSM, or an
 explicit operator action. Live eval child processes should run as the operator.
 
 ## Target Readiness Contract
 
-Phase 1 supports all targets through host-managed eval credentials, but a
-target is usable only after `doctor` proves the target's key-backed path works.
+Phase 1 classifies every known target and supports targets only through
+host-managed eval credentials. A target is usable only after `doctor` proves
+the target's key-backed path works.
 
 Definition of ready:
 
@@ -229,8 +274,21 @@ Meanings:
 - `failed`: the target has a key-backed adapter, but this host is missing a
   binary, secret, repo file, or provider preflight.
 
-Blocked targets are still in Phase 1 scope. They are not counted as supported
-until their key-backed adapter work lands.
+Blocked targets are still tracked by Phase 1, but they are not counted as
+supported until their key-backed adapter work lands. Phase 1 does not require
+materializing secret profiles for blocked targets before the first useful AWS
+runner is available.
+
+`doctor --all` exit semantics:
+
+- exit 0 when every target is classified and no target is `failed`;
+- exit 1 when any target is `failed`;
+- exit 2 when the doctor command itself cannot complete classification, such
+  as malformed YAML, unreadable state root, or invalid JSON output.
+
+`blocked` targets do not make `doctor --all` fail. They are expected while
+key-backed adapter work is still in progress, and the output must include the
+blocking reason.
 
 ### Phase 1 Credential Profiles
 
@@ -247,8 +305,8 @@ Initial credential families:
 | `gemini` | `GEMINI_API_KEY`, `SUPERPOWERS_ROOT`, `GEMINI_AUTH_TYPE=gemini-api-key` |
 | `kimi` | `KIMI_MODEL_API_KEY`, optional `KIMI_MODEL_NAME`, `SUPERPOWERS_ROOT` |
 | `pi` | `PI_PROVIDER`, `PI_MODEL`, `PI_API_KEY`, optional provider extras, `SUPERPOWERS_ROOT` |
-| `copilot` | provider-mode `COPILOT_PROVIDER_*`, `SUPERPOWERS_ROOT` |
-| `opencode` | explicit provider key env and pinned model, `SUPERPOWERS_ROOT` |
+| `copilot` | provider-mode `COPILOT_PROVIDER_BASE_URL`, `COPILOT_PROVIDER_TYPE`, and either `COPILOT_PROVIDER_API_KEY` or `COPILOT_PROVIDER_BEARER_TOKEN`; `SUPERPOWERS_ROOT` |
+| `opencode` | `OPENAI_API_KEY`, pinned model `openai/gpt-5.5`, `SUPERPOWERS_ROOT` |
 | `codex` | key-backed Codex mode to be implemented and verified; no ChatGPT subscription auth |
 | `antigravity` | key-backed Antigravity mode to be implemented and verified; no Code Assist browser/keyring auth |
 
@@ -256,6 +314,14 @@ For `codex` and `antigravity`, the implementation must verify the current CLI
 auth surface before choosing exact env names or flags. Until that is done,
 `doctor codex` and `doctor antigravity` should return `blocked`, not silently
 fall back to personal login state.
+
+On the AWS host, `doctor copilot` is `ready` only in provider mode. Copilot
+GitHub-token auth, `gh auth token`, and personal Copilot login state are
+`blocked` unless a later phase introduces a dedicated eval identity with an
+explicit credential contract.
+
+On the AWS host, `doctor gemini` must hard-block `GEMINI_AUTH_TYPE=oauth-personal`.
+Only `GEMINI_AUTH_TYPE=gemini-api-key` is Phase-1-ready.
 
 ## Secrets Runtime
 
@@ -271,11 +337,30 @@ Recommended ownership:
 - mode `0640`
 
 Managed Quorum commands copy the selected target profile into a per-job env
-file with mode `0600`, preferably under a tmpfs location. The per-job env file
-is deleted when the job finishes.
+file with mode `0600` outside `/opt/quorum/results`, preferably under tmpfs.
+The per-job env file is deleted when the job finishes, fails, or is
+interrupted. Secret rotation during a running job does not affect that job
+because it uses the copied per-job env file.
+
+Secret-bearing env/profile files must never live under a run directory, batch
+directory, copied Coding-Agent config directory, or other artifact path under
+`/opt/quorum/results`. Current per-target env files such as `.claude-env`,
+`.gemini-env`, `.copilot-env`, and `pi.env` must be moved out of result
+artifacts or replaced with non-secret launch references before the target is
+counted as supported on the AWS host.
 
 Live child processes receive an allowlisted environment, not the invoking
 shell's full `os.environ`.
+
+This applies to every live-eval surface, not only the final Coding-Agent
+launcher:
+
+- scenario `setup.sh`;
+- scenario `checks.sh`;
+- target auth preflights;
+- Gauntlet invocation;
+- child `quorum run` processes launched by `run-all`;
+- Coding-Agent launchers.
 
 Allowed env classes:
 
@@ -290,10 +375,14 @@ Disallowed Phase 1 runtime dependencies:
 
 - `~/.codex/auth.json` ChatGPT subscription auth;
 - `~/.gemini/oauth_creds.json`;
+- `GEMINI_AUTH_TYPE=oauth-personal`;
 - browser cookies;
 - macOS keychain or Linux keyring state;
 - a developer's personal GitHub/Copilot login;
 - credentials embedded in proxy URLs.
+
+Job JSON records env profile names only. It must not record secret file paths,
+secret values, or shell snippets that could reveal credentials.
 
 ## Managed Job Model
 
@@ -313,12 +402,19 @@ job-20260612T190000Z-a1b2
 Initial states:
 
 - `planned`: metadata written, locks not yet acquired.
-- `running`: supervisor is active and locks are held.
-- `succeeded`: child command exited successfully.
-- `failed`: child command exited with a nonzero managed-command failure.
+- `running`: supervised worker is active and locks are held.
+- `succeeded`: managed command completed and wrote its expected artifacts.
+- `failed`: managed command failed to complete, such as setup failure, child
+  process crash, lock failure, or missing expected artifacts.
 - `interrupted`: supervisor observed interruption or child termination.
 - `orphaned`: metadata exists, but the recorded supervisor is gone and the
   final child state cannot be determined.
+
+Job state is about managed-command execution, not eval success. A batch with
+failing or indeterminate cells can still be a `succeeded` job if the managed
+command completed normally and wrote the expected batch artifacts. Verdict
+rollup is recorded separately. `result_rollup` must preserve existing
+`results.jsonl` semantics, including skipped reasons such as `rate-limited`.
 
 Phase 1 should fail fast on lock conflict. It should not implement a queue.
 Queued/waiting states belong to a later platform phase.
@@ -361,6 +457,7 @@ Minimum `job.json` schema:
     "pid": 12345
   },
   "children": [],
+  "result_rollup": null,
   "started_at": "2026-06-12T19:00:00Z",
   "finished_at": null,
   "final_exit_code": null
@@ -375,10 +472,21 @@ and `verdict.json` readers should not need to understand job records.
 Use a host-native supervisor for Phase 1, preferably `tmux` because the eval
 workflow already uses terminal sessions and it is easy for agents to inspect.
 
+Concrete Phase 1 shape:
+
+1. The initiating CLI writes the `planned` job record and starts a supervised
+   worker command, such as an internal `quorum managed-worker <job-id>` entry
+   point.
+2. The supervised worker materializes per-job env files, acquires lock file
+   descriptors, updates `job.json` to `running`, invokes `quorum run` or
+   `quorum run-all`, records child ids and rollup, and releases locks on exit.
+3. The initiating CLI streams the durable log while connected, but it does not
+   own the lock file descriptors.
+
 Requirements:
 
-- the supervisor process, not the initiating CLI process, holds lock file
-  descriptors for the lifetime of the child run;
+- the supervised worker process, not the initiating CLI process, holds lock
+  file descriptors for the lifetime of the child run;
 - stdout and stderr from the child command append to the durable job log;
 - the initiating CLI can stream the log while connected;
 - SSH disconnect does not terminate the child run;
@@ -397,7 +505,8 @@ Host-global locks live under:
 
 Use `fcntl.flock` or an equivalent open-file-descriptor lock. JSON sidecars may
 be written for diagnostics, but the open descriptor is the source of truth so
-killed supervisors release locks automatically.
+killed supervised workers release locks automatically. Conflict reporting must
+ignore stale sidecars when the underlying lock is no longer held.
 
 Acquire locks in deterministic order:
 
@@ -435,6 +544,12 @@ On conflict, Quorum exits nonzero and reports:
 
 No queueing is required in Phase 1.
 
+Raw `quorum run` and `quorum run-all` remain available as low-level primitives,
+but they are not the supported AWS-host live-run interface. The AWS runbook
+should direct operators and agents to `doctor`, `smoke`, `column`, and
+`batch`. Raw live commands are an explicit escape hatch and can bypass
+host-global locks.
+
 ## Commands
 
 ### `quorum doctor`
@@ -453,7 +568,7 @@ uv run quorum doctor <target> --json
 Checks:
 
 - repo path and `SUPERPOWERS_ROOT`;
-- target YAML loads and required Superpowers files exist;
+- target YAML metadata loads and required Superpowers files exist;
 - target binary exists;
 - host state root and output root are writable;
 - required secret profile exists;
@@ -461,7 +576,16 @@ Checks:
 - target auth mode is not personal login state;
 - target-specific preflight passes when safe to run.
 
-`doctor` should redact secret values in all output.
+`doctor` should redact secret values in all output. When `doctor` performs a
+live provider preflight, it must acquire the same provider or target locks that
+the corresponding managed live command would acquire, or skip that preflight
+with a clear conflict message.
+
+Current `load_coding_agent_config()` validates `required_env` against ambient
+`os.environ`. `doctor` must not use ambient shell env for readiness. It should
+either load target YAML metadata without enforcing `required_env`, or
+materialize the sanitized target env first and then load the full config under
+that env.
 
 ### `quorum smoke`
 
@@ -526,10 +650,15 @@ Behavior:
 
 - profile is configured in Quorum, not in shell aliases;
 - target list contains only doctor-ready targets;
+- day-one completion requires `claude` plus at least one non-Anthropic
+  key-backed target in `sentinel-default`; a one-target run is acceptable only
+  as an infra smoke and does not complete Phase 1;
 - default tier is `sentinel`;
 - profile is small enough for routine team use;
 - acquires `global:broad-batch` plus target/provider locks;
-- invokes one or more existing `run-all` child commands;
+- starts with provider-diverse child `run-all` commands at `--tier sentinel
+  --jobs 1`;
+- may raise profile concurrency only after AWS dry-run measurements justify it;
 - records child batch ids in `job.json`;
 - prints job id, child batch ids, rollup, and `quorum show` commands.
 
@@ -572,8 +701,9 @@ Shape:
 uv run quorum tail <job-id>
 ```
 
-It should resolve full ids and unambiguous prefixes. It does not need to tail
-raw target transcripts in Phase 1.
+It should resolve full ids and unambiguous prefixes. Ambiguous prefixes fail
+with a list of matching job ids. It does not need to tail raw target
+transcripts in Phase 1.
 
 ## Branch And Root Metadata
 
@@ -596,6 +726,13 @@ are Phase 2 work. Phase 1 can still run against an operator-prepared
 `SUPERPOWERS_ROOT`; it records the path, branch, SHA, and dirty state rather
 than creating the checkout itself.
 
+Managed commands must record active shared checkout paths in job metadata.
+Quorum cannot prevent an operator from running raw `git` commands by hand, but
+the Phase 1 runbook must forbid `git checkout`, `git pull`, branch switches, or
+other mutations of a shared evals or Superpowers checkout while an active job
+references it. `doctor` and managed commands should warn when active jobs
+reference the current checkout.
+
 ## Results And Artifacts
 
 Phase 1 keeps using the existing Quorum result layout under:
@@ -610,13 +747,19 @@ Phase 1 should avoid making future cleanup impossible:
 
 - job metadata records child run and batch ids;
 - managed commands print artifact paths;
-- target env files are excluded from copied artifacts when possible;
+- target env files are kept outside result artifacts;
 - secret-bearing diagnostics are redacted;
+- managed commands run a lightweight pattern-based secret-leak scan over job
+  logs, job JSON, verdict JSON, Gauntlet transcripts, target logs, exported
+  sessions, and run artifacts before marking a target supported on the AWS
+  host;
 - `quorum show` remains the verdict front door.
 
 Disk pressure is handled manually in Phase 1. `doctor --all` should warn when
 free space under `/opt/quorum` is below a conservative threshold, initially 100
-GB.
+GB. If a managed job encounters disk-full or log-write errors mid-run, it marks
+the job `failed`, preserves whatever child ids are known, and reports the
+operator recovery command in the durable log.
 
 ## Data Flow
 
@@ -625,13 +768,14 @@ Managed smoke, column, and sentinel batch follow this flow:
 1. Resolve host paths and state root.
 2. Run `doctor` checks for selected targets.
 3. Create `job.json` in `planned` state.
-4. Build sanitized per-target env profiles.
-5. Acquire required locks.
-6. Start the supervisor.
-7. Supervisor updates `job.json` to `running` and holds lock descriptors.
-8. Supervisor invokes existing `quorum run` or `quorum run-all`.
+4. Start the supervisor with an internal managed-worker command.
+5. Managed worker builds sanitized per-target env profiles outside results.
+6. Managed worker acquires required locks.
+7. Managed worker updates `job.json` to `running` and holds lock descriptors.
+8. Managed worker invokes existing `quorum run` or `quorum run-all`.
 9. Child writes normal run/batch artifacts under `/opt/quorum/results`.
-10. Supervisor records child ids, final state, exit code, and finish time.
+10. Managed worker records child ids, command state, verdict rollup, exit code,
+    and finish time using atomic `job.json` writes.
 11. Initiating CLI streams the durable log while connected.
 
 ## Error Handling
@@ -642,8 +786,13 @@ Managed command failures:
 
 - missing secret profile: fail before job launch;
 - blocked key-backed adapter: fail before job launch;
-- lock conflict: fail before job launch with owner/log details;
-- child `run` / `run-all` nonzero exit: mark job `failed`;
+- lock conflict: fail before child `quorum run` / `quorum run-all` launch with
+  owner/log details;
+- child `run` / `run-all` process crash, missing expected artifacts, or
+  managed-command failure: mark job `failed`;
+- child `run` returns a non-passing verdict or `run-all` records failing cells:
+  mark job `succeeded` if artifacts were written correctly, and record the
+  eval verdict rollup separately;
 - SSH disconnect: no state change; supervisor continues;
 - supervisor gone before final state: `status` marks job `orphaned`;
 - malformed `job.json`: `status` reports the file path and continues listing
@@ -668,10 +817,16 @@ Add unit tests for:
 - job id allocation and `job.json` schema;
 - job state transitions;
 - durable log path creation;
+- atomic `job.json` writes and recovery from malformed job records;
 - lock acquisition, release, deterministic ordering, and conflict reporting;
+- fake-supervisor behavior proving the managed worker, not the initiating CLI,
+  holds locks through the child lifetime;
 - target-to-provider lock mapping;
 - `doctor` ready/blocked/failed output;
+- `doctor --all` exit codes when targets are blocked versus failed;
 - secret redaction;
+- secret-bearing env files staying outside result artifacts;
+- generic secret-leak scan coverage;
 - smoke scenario mapping, including draft bootstrap scenarios;
 - `column` command expansion over existing `run-all`;
 - `sentinel-default` profile expansion;
@@ -691,19 +846,26 @@ Before Phase 1 is considered usable:
 2. The host appears in Tailscale as `quorum-evals`.
 3. SSM Session Manager can reach the instance.
 4. `/opt/quorum` is mounted from the persistent encrypted data volume.
-5. Data volume has `prevent_destroy` and backup tags.
-6. Required binaries are installed.
-7. Repos are cloned at expected branches.
-8. `uv sync --extra dev` succeeds in the eval repo.
-9. `uv run quorum doctor --all` reports ready, blocked, or failed for every
+5. Steady-state boot mounts the data volume and does not auto-format it.
+6. Data volume has `prevent_destroy`, backup policy coverage, and at least one
+   recent snapshot.
+7. Eval users cannot reach IMDS.
+8. Eval users have no sudo, wheel, or Docker socket access.
+9. Tailscale SSH maps only to non-root operator accounts.
+10. Required binaries are installed.
+11. Repos are cloned at expected branches.
+12. `uv sync --extra dev` succeeds in the eval repo.
+13. `uv run quorum doctor --all` reports ready, blocked, or failed for every
    target with no unclassified target.
-10. At least one key-backed target smoke passes.
-11. At least one target column starts and writes a batch artifact.
-12. `sentinel-default` completes with its configured ready target set.
-13. A disconnected SSH session does not kill the managed job.
-14. A second SSH session can run `status`, `tail`, and `show`.
-15. A deliberate lock conflict exits clearly and does not start a second live
+14. At least one key-backed target smoke passes.
+15. At least one target column starts and writes a batch artifact.
+16. `sentinel-default` completes with `claude` and at least one non-Anthropic
+   key-backed target.
+17. A disconnected SSH session does not kill the managed job.
+18. A second SSH session can run `status`, `tail`, and `show`.
+19. A deliberate lock conflict exits clearly and does not start a second live
    run.
+20. Secret-leak scan passes for job metadata, logs, and result artifacts.
 
 Record dry-run measurements:
 
@@ -722,9 +884,13 @@ Phase 1 is complete when:
 
 - Terminus provisions `quorum-evals` through Terraform.
 - `/opt/quorum` host layout exists on persistent EBS.
-- host-managed secret profiles exist for every target family.
-- `doctor --all` classifies every target and at least the intended day-one
-  target set is `ready`.
+- IMDS is blocked for eval users and eval child processes.
+- eval operators have no sudo, wheel, or Docker socket access.
+- data volume mount is fail-closed and backup policy coverage is verified.
+- host-managed secret profiles exist for the day-one ready target set.
+- `doctor --all` classifies every target, reports blocked targets with
+  actionable reasons, and marks at least `claude` plus one non-Anthropic
+  key-backed target as `ready`.
 - key-backed adapter work lands for any target counted as supported.
 - `smoke <target>`, `column <target>`, and `batch --profile sentinel-default`
   run as managed jobs.
@@ -732,7 +898,8 @@ Phase 1 is complete when:
 - `status` and `tail` recover job state from a fresh SSH session.
 - host-global locks prevent target/provider conflicts across sessions.
 - job metadata records owner, command, repo SHAs, dirty states, locks, log
-  path, out root, child ids, and final state.
+  path, out root, child ids, final command state, and verdict rollup.
+- secret-bearing env files stay outside result artifacts and leak scans pass.
 - results remain inspectable through `quorum show`.
 - dry-run measurements are captured and used to adjust default parallelism.
 

--- a/docs/superpowers/specs/2026-06-12-quorum-aws-eval-runner-phase-1-design.md
+++ b/docs/superpowers/specs/2026-06-12-quorum-aws-eval-runner-phase-1-design.md
@@ -5,6 +5,10 @@
 **Tracker:** PRI-2205
 **Parent spec:** `docs/superpowers/specs/2026-06-12-quorum-aws-eval-runner-design.md`
 
+This Phase 1 spec is the normative implementation contract for the first
+shared AWS runner. The parent spec is the broader roadmap and should not be
+read as permission to pull later platform work into Phase 1.
+
 ---
 
 ## Goal
@@ -23,6 +27,20 @@ The outcome is a remote Quorum workstation, not a full eval platform:
 Phase 1 should be platform-shaped without being a platform service. The command
 surface should survive later queue, API, UI, Slack, or disposable-worker
 backends, but those backends are not built now.
+
+Phase 1 has two delivery milestones:
+
+- **Phase 1a: first useful remote runner.** One Terminus host can run at least
+  one ready key-backed target through managed `smoke` and sentinel `column`
+  commands, survive SSH disconnect, enforce host locks, and recover through
+  `status`, `tail`, and `show`.
+- **Phase 1b: shared sentinel campaign.** `batch --profile sentinel-default`
+  runs the configured ready target set, starting with `claude` plus at least one
+  non-Anthropic key-backed target when that target is honestly `ready`.
+
+Blocked targets should not delay Phase 1a. They must be classified with stable
+reasons and excluded from supported target counts until their key-backed path
+actually works.
 
 ## Non-goals
 
@@ -48,6 +66,11 @@ The local repository already has the primitive run surface:
 - `quorum show` renders run and batch verdicts from local artifacts.
 
 Phase 1 should wrap those primitives rather than replace them.
+
+On the AWS host, those live primitives must not remain an accidental side door.
+Raw `quorum run` and `quorum run-all` should either be invoked by the managed
+worker under the same state, lock, and sanitized-env contract, or fail closed
+with an instruction to use `smoke`, `column`, or `batch`.
 
 Important current behavior:
 
@@ -131,14 +154,25 @@ Use the existing `machine-westworld` module for the named EC2 instance:
 - Security group: outbound only, no inbound application ports.
 - Access: Tailscale SSH and SSM Session Manager.
 - Managed policies: SSM managed instance support.
-- IAM: SSM read for `/quorum-evals/*` and no broader secret prefixes.
+- IAM: SSM read for `/quorum-evals/*` and no broader secret prefixes, using
+  exact `us-west-1` account-scoped parameter ARNs rather than wildcard
+  region/account ARNs.
 - IAM: `kms:Decrypt` must be scoped to SSM use, matching the existing
-  Brainstorm/Claw Eng pattern.
+  Brainstorm/Claw Eng pattern. The service root should include
+  `kms:ViaService = ssm.us-west-1.amazonaws.com` and parameter encryption
+  context constraints where the account KMS policy supports them.
 - IMDS: eval users and eval child processes must not be able to reach
   `169.254.169.254` or the IPv6 IMDS endpoint if IPv6 metadata is enabled.
   The existing `machine-westworld` module enables IMDSv2, so the service root
   or bootstrap must add an explicit host firewall, unit sandbox, or equivalent
   control and verify it in the dry run.
+
+SSM Session Manager is break-glass and bootstrap access, not the normal
+operator path. The runbook must define who can start sessions or send commands,
+require MFA/timeboxed access where available, enable encrypted session logging,
+and scope allowed SSM documents/actions to bootstrap, secret sync, and
+emergency recovery. Normal live eval operation uses Tailscale SSH into non-root
+operator accounts.
 
 Add the data volume in the service root, following the existing Brainstorm and
 monitoring EBS patterns:
@@ -152,10 +186,17 @@ monitoring EBS patterns:
 - Steady-state userdata is mount-only and must never auto-format an attached
   data volume. Blank-volume initialization is an explicit one-shot operator or
   SSM action.
+- Bootstrap writes a volume identity manifest under `/opt/quorum/state` with
+  the expected EBS volume id and filesystem UUID. Steady-state boot and Quorum
+  host-mode commands refuse to run if `/opt/quorum` is not the expected mounted
+  volume.
 - DLM or AWS Backup policy is created for the data volume, not only tags.
 - Dry-run verification checks that the backup policy is enabled and at least
   one recent snapshot exists before the host is considered durable.
-- The runbook includes replacement-host restore steps for `/opt/quorum`.
+- The runbook includes replacement-host restore steps for `/opt/quorum` and a
+  restore drill: create a temporary volume from a snapshot, mount it read-only
+  or on a scratch host, verify `/opt/quorum/state` and representative results,
+  and run `quorum show` against restored artifacts.
 
 SSM parameter inventory for Phase 1:
 
@@ -172,6 +213,9 @@ SSM parameter inventory for Phase 1:
 /quorum-evals/targets/copilot/COPILOT_PROVIDER_TYPE
 /quorum-evals/targets/copilot/COPILOT_PROVIDER_API_KEY
 /quorum-evals/targets/copilot/COPILOT_PROVIDER_BEARER_TOKEN
+/quorum-evals/targets/copilot/hooks/ANTHROPIC_API_KEY
+/quorum-evals/targets/copilot/hooks/OPENAI_API_KEY
+/quorum-evals/targets/copilot/hooks/OPENAI_BASE_URL
 /quorum-evals/targets/opencode/OPENAI_API_KEY
 ```
 
@@ -194,9 +238,11 @@ The host keeps mutable eval state under `/opt/quorum`:
 ├── worktrees/
 ├── results/
 ├── state/
+│   ├── cooldowns/
 │   ├── jobs/
 │   ├── locks/
-│   └── logs/
+│   ├── logs/
+│   └── volume-identity.json
 └── secrets-runtime/
 ```
 
@@ -215,6 +261,34 @@ Set `QUORUM_STATE_ROOT=/opt/quorum/state` in the host Quorum environment. The
 managed-command implementation should prefer that env var when present and
 fall back to local state only outside the host.
 
+Shared filesystem permissions are part of the Phase 1 contract:
+
+- `/opt/quorum`, `/opt/quorum/state`, `/opt/quorum/results`, and their
+  non-secret children are `root:quorum-operators` with setgid directories and a
+  default umask of `0027`.
+- shared mutable directories that operators write through Quorum, including
+  `/opt/quorum/state/jobs`, `/opt/quorum/state/logs`,
+  `/opt/quorum/state/locks`, `/opt/quorum/state/cooldowns`, and
+  `/opt/quorum/results`, use mode `2770`.
+- ordinary readable artifacts use modes like `0640` for files and `0750` for
+  directories unless a stricter target-specific path requires less access.
+- lock files are pre-created by bootstrap or forced to `0660` on creation so
+  different operators can open the same path for `flock` diagnostics and
+  conflict checks.
+- job JSON, durable command logs, lock sidecars, batch summaries, and result
+  metadata are readable by `quorum-operators` so a second trusted operator can
+  recover a job with `status`, `tail`, and `show`.
+- raw transcripts and run artifacts are also inside the trusted
+  `quorum-operators` boundary in Phase 1; they must never be world-readable or
+  exposed outside Tailscale/SSM without an explicit later archive/promotion
+  flow.
+- `/opt/quorum/secrets-runtime` is root-only and is not readable by
+  `quorum-operators`.
+
+Phase 1 is a trusted-maintainer host, not a sandbox against malicious eval code.
+The permissions above support auditability and handoff between trusted
+operators; they do not claim strong per-run secret isolation.
+
 ## User And Process Model
 
 Team members should have separate Unix accounts. Phase 1 jobs run as the
@@ -230,9 +304,15 @@ Operator accounts should not have:
 - Docker socket access.
 
 Bootstrap owns creation of the `quorum-operators` group, operator account
-membership, `/opt/quorum` directory permissions, and `/opt/quorum/secrets-runtime`
-permissions. Bootstrap must not add eval operators to `sudo`, `wheel`, or
-`docker`.
+membership, `/opt/quorum` directory permissions, and
+`/opt/quorum/secrets-runtime` permissions. Bootstrap must not add eval
+operators to `sudo`, `wheel`, or `docker`.
+
+Shared root checkouts under `/opt/quorum/repos` should not be writable by eval
+operator accounts. Repo updates happen through an explicit bootstrap/sync
+action that first checks for active jobs referencing the checkout. Operator
+prepared writable worktrees can live under `/opt/quorum/worktrees/<user>/`, but
+managed commands must record and lock those paths while jobs are active.
 
 Tailscale must advertise a dedicated `tag:quorum-evals` identity. The Tailscale
 ACL must allow SSH only to non-root operator accounts on this host. Root access
@@ -290,6 +370,19 @@ runner is available.
 key-backed adapter work is still in progress, and the output must include the
 blocking reason.
 
+`doctor <target>` exit semantics:
+
+- exit 0 when the target is `ready`;
+- exit 1 when the target is `failed`;
+- exit 2 when the doctor command itself cannot complete;
+- exit 3 when the target is `blocked`.
+
+`doctor --json` and `doctor --all --json` must use stable machine-readable
+states and reason codes. Initial reason codes include
+`missing-binary`, `missing-secret`, `placeholder-secret`, `missing-repo-file`,
+`personal-auth`, `unsupported-key-backed-mode`, `preflight-failed`,
+`cooldown-active`, and `config-error`.
+
 ### Phase 1 Credential Profiles
 
 Use SSM SecureString parameters under `/quorum-evals/*`. Terraform owns the
@@ -305,10 +398,19 @@ Initial credential families:
 | `gemini` | `GEMINI_API_KEY`, `SUPERPOWERS_ROOT`, `GEMINI_AUTH_TYPE=gemini-api-key` |
 | `kimi` | `KIMI_MODEL_API_KEY`, optional `KIMI_MODEL_NAME`, `SUPERPOWERS_ROOT` |
 | `pi` | `PI_PROVIDER`, `PI_MODEL`, `PI_API_KEY`, optional provider extras, `SUPERPOWERS_ROOT` |
-| `copilot` | provider-mode `COPILOT_PROVIDER_BASE_URL`, `COPILOT_PROVIDER_TYPE`, and either `COPILOT_PROVIDER_API_KEY` or `COPILOT_PROVIDER_BEARER_TOKEN`; `SUPERPOWERS_ROOT` |
-| `opencode` | `OPENAI_API_KEY`, pinned model `openai/gpt-5.5`, `SUPERPOWERS_ROOT` |
+| `copilot` | provider-mode `COPILOT_PROVIDER_BASE_URL`, `COPILOT_PROVIDER_TYPE`, and either `COPILOT_PROVIDER_API_KEY` or `COPILOT_PROVIDER_BEARER_TOKEN`; any Superpowers hook/provider credentials required by the checked-in Copilot path, currently including Anthropic/OpenAI hook env; `SUPERPOWERS_ROOT` |
+| `opencode` | `OPENAI_API_KEY`, pinned model `openai/gpt-5.5`, narrowed launcher and capture env, `SUPERPOWERS_ROOT` |
 | `codex` | key-backed Codex mode to be implemented and verified; no ChatGPT subscription auth |
 | `antigravity` | key-backed Antigravity mode to be implemented and verified; no Code Assist browser/keyring auth |
+
+Readiness has two credential surfaces:
+
+- the target CLI/provider credentials needed by the Coding-Agent under test;
+- any Superpowers hook/provider credentials needed by the target integration.
+
+Both surfaces must come from host-managed profiles. Each credential is passed
+only to the process that needs it. A target is `blocked` when the checked-in
+launcher or capture path would require unrelated ambient provider credentials.
 
 For `codex` and `antigravity`, the implementation must verify the current CLI
 auth surface before choosing exact env names or flags. Until that is done,
@@ -319,6 +421,12 @@ On the AWS host, `doctor copilot` is `ready` only in provider mode. Copilot
 GitHub-token auth, `gh auth token`, and personal Copilot login state are
 `blocked` unless a later phase introduces a dedicated eval identity with an
 explicit credential contract.
+
+On the AWS host, `doctor opencode` is `ready` only after the OpenCode launcher
+and session export allowlist are narrowed to the selected OpenAI profile plus
+non-secret runtime env. The current broad OpenCode allowances for Anthropic,
+OpenRouter, Gemini, Google, and AWS env must be removed or blocked before
+OpenCode counts as supported.
 
 On the AWS host, `doctor gemini` must hard-block `GEMINI_AUTH_TYPE=oauth-personal`.
 Only `GEMINI_AUTH_TYPE=gemini-api-key` is Phase-1-ready.
@@ -331,16 +439,28 @@ The host materializes restricted target env files under:
 /opt/quorum/secrets-runtime/<target>.env
 ```
 
-Recommended ownership:
+Source profile ownership:
 
-- `root:quorum-operators`
-- mode `0640`
+- directory: `root:root`, mode `0700`;
+- source profile files: `root:root`, mode `0600`;
+- eval operator accounts and live eval child processes cannot read source
+  profiles directly.
 
-Managed Quorum commands copy the selected target profile into a per-job env
-file with mode `0600` outside `/opt/quorum/results`, preferably under tmpfs.
-The per-job env file is deleted when the job finishes, fails, or is
-interrupted. Secret rotation during a running job does not affect that job
-because it uses the copied per-job env file.
+Managed Quorum commands use a narrow root-owned materializer, SSM action, or
+equivalent bootstrap helper to copy only the selected target's required values
+into a per-job env file. The per-job env file is owned by the invoking operator,
+mode `0600`, outside `/opt/quorum/results`, and preferably under a job-scoped
+tmpfs directory such as `/run/quorum/secrets/<job-id>/`.
+
+The per-job env directory is deleted when the job finishes, fails, or is
+interrupted. `status` and `doctor` must flag stale per-job env directories when
+the recorded supervisor is gone. Secret rotation during a running job does not
+affect that job because it uses the copied per-job env file; the job metadata
+records only the profile name and version or last-sync timestamp.
+
+Phase 1 includes a narrow secret-runtime cleanup action or runbook step for
+stale per-job env directories. This is separate from general result cleanup,
+which remains deferred.
 
 Secret-bearing env/profile files must never live under a run directory, batch
 directory, copied Coding-Agent config directory, or other artifact path under
@@ -361,6 +481,13 @@ launcher:
 - Gauntlet invocation;
 - child `quorum run` processes launched by `run-all`;
 - Coding-Agent launchers.
+
+Implement this as an explicit sanitized run environment, not ad hoc subprocess
+kwargs. The implementation should introduce a shared `RunEnvironment` or
+equivalent value and thread it through `run_batch`, child `quorum run`
+invocation, `run_scenario`, `setup.sh`, `checks.sh`, target preflights,
+Gauntlet, launcher seeding, and session export/capture helpers. Tests must use
+poison env variables to prove unallowlisted values do not reach those surfaces.
 
 Allowed env classes:
 
@@ -407,8 +534,8 @@ Initial states:
 - `failed`: managed command failed to complete, such as setup failure, child
   process crash, lock failure, or missing expected artifacts.
 - `interrupted`: supervisor observed interruption or child termination.
-- `orphaned`: metadata exists, but the recorded supervisor is gone and the
-  final child state cannot be determined.
+- `orphaned`: derived status when metadata exists, the recorded supervisor is
+  gone or stale, and the final child state cannot be determined.
 
 Job state is about managed-command execution, not eval success. A batch with
 failing or indeterminate cells can still be a `succeeded` job if the managed
@@ -454,10 +581,21 @@ Minimum `job.json` schema:
   "supervisor": {
     "kind": "tmux",
     "name": "quorum-job-20260612T190000Z-a1b2",
-    "pid": 12345
+    "pid": 12345,
+    "pid_started_at": "2026-06-12T19:00:01Z",
+    "last_heartbeat_at": "2026-06-12T19:05:01Z",
+    "worker_command": ["quorum", "managed-worker", "job-20260612T190000Z-a1b2"]
   },
-  "children": [],
+  "children": [
+    {
+      "kind": "batch",
+      "id": "batch-20260612T190010Z-a1b2",
+      "state": "running",
+      "path": "/opt/quorum/results/batches/batch-20260612T190010Z-a1b2"
+    }
+  ],
   "result_rollup": null,
+  "tainted": false,
   "started_at": "2026-06-12T19:00:00Z",
   "finished_at": null,
   "final_exit_code": null
@@ -466,6 +604,16 @@ Minimum `job.json` schema:
 
 The schema is intentionally additive. Existing `batch.json`, `results.jsonl`,
 and `verdict.json` readers should not need to understand job records.
+
+The worker updates `children` as soon as a child run or batch directory is
+allocated, before waiting for the child to complete. Child states are
+`starting`, `running`, `finalizing`, `complete`, `failed`, or `unknown`. This
+lets `status` and handoffs point at partial artifacts after crashes.
+
+The worker owns terminal state writes. `status` may present `orphaned` as a
+derived view when the heartbeat is stale and the supervisor is gone, but it must
+not race a finishing worker by blindly overwriting a terminal state. Any durable
+orphan-state write needs an atomic compare-and-swap from a still-running state.
 
 ## Supervisor
 
@@ -490,7 +638,8 @@ Requirements:
 - stdout and stderr from the child command append to the durable job log;
 - the initiating CLI can stream the log while connected;
 - SSH disconnect does not terminate the child run;
-- `status` can detect whether the supervisor is still alive.
+- `status` can detect whether the supervisor is still alive;
+- the worker writes a heartbeat while the child command is active.
 
 `systemd-run --user` or transient system services are acceptable only if they
 meet the same lock and log requirements without adding a custom daemon.
@@ -508,17 +657,28 @@ be written for diagnostics, but the open descriptor is the source of truth so
 killed supervised workers release locks automatically. Conflict reporting must
 ignore stale sidecars when the underlying lock is no longer held.
 
+Target, provider, and global locks are exclusive. Checkout locks are shared for
+live eval jobs and exclusive for repo sync, branch switching, or other checkout
+maintenance. A maintenance action must fail fast while active jobs hold a shared
+lease for that checkout path.
+
 Acquire locks in deterministic order:
 
 1. global locks;
-2. provider locks;
-3. target locks.
+2. checkout locks;
+3. provider locks;
+4. target locks.
+
+Live jobs and repo maintenance use the same order. Maintenance commands acquire
+checkout locks exclusively; live jobs acquire them shared.
 
 Initial locks:
 
 | Lock | Purpose |
 | --- | --- |
 | `global:broad-batch` | Prevent overlapping broad campaigns. |
+| `checkout:evals:<hash>` | Prevent mutation of an evals checkout while active jobs reference it. |
+| `checkout:superpowers:<hash>` | Prevent mutation of a Superpowers checkout while active jobs reference it. |
 | `provider:anthropic` | Conservative Claude-family coordination. |
 | `provider:openai` | Codex/OpenCode/OpenAI-backed provider coordination. |
 | `provider:google` | Gemini/Antigravity coordination. |
@@ -533,6 +693,8 @@ Phase 1 locking policy:
 - `column <target>`: `target:<target>` plus provider lock.
 - `batch sentinel-default`: `global:broad-batch` plus selected target/provider
   locks.
+- all managed live commands: shared checkout locks for the evals and
+  Superpowers paths recorded in job metadata.
 
 On conflict, Quorum exits nonzero and reports:
 
@@ -544,11 +706,23 @@ On conflict, Quorum exits nonzero and reports:
 
 No queueing is required in Phase 1.
 
-Raw `quorum run` and `quorum run-all` remain available as low-level primitives,
-but they are not the supported AWS-host live-run interface. The AWS runbook
-should direct operators and agents to `doctor`, `smoke`, `column`, and
-`batch`. Raw live commands are an explicit escape hatch and can bypass
-host-global locks.
+Cooldowns are also fail-fast state, not a queue. When Quorum detects a known
+provider or target quota/rate-limit marker, it writes
+`/opt/quorum/state/cooldowns/<provider-or-target>.json` with source job, reason,
+expiry, and recovery guidance. `doctor`, `smoke`, `column`, and `batch` fail
+fast while an active cooldown applies and print the source job, expiry, and
+next recovery command.
+
+Raw `quorum run` and `quorum run-all` remain low-level primitives for local
+development and for the managed worker to call internally. On the AWS host,
+when `QUORUM_STATE_ROOT=/opt/quorum/state` or host mode is otherwise active,
+raw live commands must fail closed unless invoked by the managed worker. The
+error should point agents to `smoke`, `column`, or `batch`.
+
+An emergency raw-command path, if implemented, must be explicit and noisy:
+`--unsafe-bypass-host-locks --reason <text>`, restricted to root or a
+break-glass SSM path, recorded in durable state/status, and excluded from normal
+Phase 1 operator docs.
 
 ## Commands
 
@@ -602,7 +776,8 @@ Behavior:
 - runs as a managed job;
 - validates `doctor <target>` first;
 - acquires target/provider locks;
-- uses `jobs=1`;
+- invokes direct `quorum run` for the mapped smoke scenario rather than
+  `run-all`;
 - includes draft smoke scenarios deliberately when the target's smoke scenario
   is still draft;
 - writes the job log;
@@ -614,12 +789,13 @@ is configured. Targets with bootstrap scenarios use those scenarios.
 
 ### `quorum column`
 
-Purpose: run all runnable scenarios for one target.
+Purpose: run the standard column for one target.
 
 Shape:
 
 ```bash
 uv run quorum column <target>
+uv run quorum column <target> --tier full --confirm-long-haul
 ```
 
 Behavior:
@@ -629,6 +805,10 @@ Behavior:
 - prints runnable, skipped, draft, and long-time cell counts;
 - acquires target/provider locks;
 - invokes existing `run-all` with `--coding-agents <target>`;
+- defaults to `--tier sentinel`;
+- requires an explicit non-default tier and `--confirm-long-haul` when the
+  effective matrix includes scenarios above the long-haul threshold, initially
+  20 minutes;
 - defaults to `--jobs 1` when the target YAML has `max_concurrency: 1`;
 - defaults uncapped targets to `--jobs 1` before measurement;
 - may raise the configured uncapped default after the AWS dry run confirms the
@@ -650,14 +830,17 @@ Behavior:
 
 - profile is configured in Quorum, not in shell aliases;
 - target list contains only doctor-ready targets;
-- day-one completion requires `claude` plus at least one non-Anthropic
-  key-backed target in `sentinel-default`; a one-target run is acceptable only
-  as an infra smoke and does not complete Phase 1;
+- Phase 1a may run a one-target `claude` sentinel column as the first useful
+  remote-runner milestone;
+- Phase 1b requires `claude` plus at least one non-Anthropic key-backed target
+  in `sentinel-default`;
 - default tier is `sentinel`;
 - profile is small enough for routine team use;
 - acquires `global:broad-batch` plus target/provider locks;
-- starts with provider-diverse child `run-all` commands at `--tier sentinel
-  --jobs 1`;
+- starts with an explicit manifest of provider-diverse child `run-all` commands,
+  one target per child at `--tier sentinel --jobs 1`;
+- records each child target list, provider lock, `jobs`, expected capped lanes,
+  computed max live cells, batch id, state, and artifact path;
 - may raise profile concurrency only after AWS dry-run measurements justify it;
 - records child batch ids in `job.json`;
 - prints job id, child batch ids, rollup, and `quorum show` commands.
@@ -688,8 +871,16 @@ Reports:
 - log path;
 - child run or batch ids when known.
 
-`status` should mark jobs orphaned when job metadata exists but the recorded
-supervisor is gone and the final state was not written.
+`status --json` returns a stable object with `schema_version`, `generated_at`,
+`state_root`, `jobs`, `active_locks`, `cooldowns`, and `malformed_records`.
+Jobs are sorted newest first by job id and may be limited by a future `--limit`
+flag. Malformed job records are reported with file path and parse error instead
+of aborting the whole status command.
+
+`status` should report jobs as orphaned when job metadata exists but the
+heartbeat is stale, the recorded supervisor is gone, and the final state was not
+written. Orphaned is a status view unless an atomic compare-and-swap safely
+updates the job record.
 
 ### `quorum tail`
 
@@ -704,6 +895,11 @@ uv run quorum tail <job-id>
 It should resolve full ids and unambiguous prefixes. Ambiguous prefixes fail
 with a list of matching job ids. It does not need to tail raw target
 transcripts in Phase 1.
+
+If the input is a child run id or batch id, `tail` should resolve it back to the
+owning job through job metadata when possible. If multiple jobs reference the
+same child id because of malformed or copied state, it fails with the matching
+job ids.
 
 ## Branch And Root Metadata
 
@@ -726,12 +922,12 @@ are Phase 2 work. Phase 1 can still run against an operator-prepared
 `SUPERPOWERS_ROOT`; it records the path, branch, SHA, and dirty state rather
 than creating the checkout itself.
 
-Managed commands must record active shared checkout paths in job metadata.
-Quorum cannot prevent an operator from running raw `git` commands by hand, but
-the Phase 1 runbook must forbid `git checkout`, `git pull`, branch switches, or
-other mutations of a shared evals or Superpowers checkout while an active job
-references it. `doctor` and managed commands should warn when active jobs
-reference the current checkout.
+Managed commands must record active shared checkout paths in job metadata and
+hold shared checkout locks for the evals and Superpowers roots. Repo sync,
+branch switching, `git pull`, or other mutation of a shared checkout must go
+through a Quorum-aware maintenance command or runbook step that first acquires
+the exclusive checkout lock. `doctor`, managed commands, and maintenance steps
+warn or fail clearly when active jobs reference the current checkout.
 
 ## Results And Artifacts
 
@@ -749,17 +945,24 @@ Phase 1 should avoid making future cleanup impossible:
 - managed commands print artifact paths;
 - target env files are kept outside result artifacts;
 - secret-bearing diagnostics are redacted;
-- managed commands run a lightweight pattern-based secret-leak scan over job
-  logs, job JSON, verdict JSON, Gauntlet transcripts, target logs, exported
-  sessions, and run artifacts before marking a target supported on the AWS
-  host;
+- every managed job runs a lightweight secret-leak scan during finalization over
+  job logs, job JSON, verdict JSON, Gauntlet transcripts, target logs, exported
+  sessions, and run artifacts before it can be marked `succeeded`;
+- the scan checks exact selected secret values plus high-signal token patterns.
+  On a match, the job is `failed`, `tainted: true`, and the artifact paths are
+  preserved for trusted-operator triage without printing the matched secret;
 - `quorum show` remains the verdict front door.
 
 Disk pressure is handled manually in Phase 1. `doctor --all` should warn when
 free space under `/opt/quorum` is below a conservative threshold, initially 100
 GB. If a managed job encounters disk-full or log-write errors mid-run, it marks
 the job `failed`, preserves whatever child ids are known, and reports the
-operator recovery command in the durable log.
+operator recovery command in the durable log when it can.
+
+Before child launch, managed commands must create and fsync the initial
+`job.json` and durable log, verify conservative free space, and keep a small
+reserved recovery file or stderr fallback so ENOSPC failures still leave an
+operator breadcrumb.
 
 ## Data Flow
 
@@ -767,16 +970,21 @@ Managed smoke, column, and sentinel batch follow this flow:
 
 1. Resolve host paths and state root.
 2. Run `doctor` checks for selected targets.
-3. Create `job.json` in `planned` state.
+3. Create and fsync `job.json` in `planned` state and create the durable log.
 4. Start the supervisor with an internal managed-worker command.
-5. Managed worker builds sanitized per-target env profiles outside results.
+5. Managed worker asks the root-owned materializer for selected per-job env
+   profiles outside results.
 6. Managed worker acquires required locks.
 7. Managed worker updates `job.json` to `running` and holds lock descriptors.
 8. Managed worker invokes existing `quorum run` or `quorum run-all`.
 9. Child writes normal run/batch artifacts under `/opt/quorum/results`.
-10. Managed worker records child ids, command state, verdict rollup, exit code,
-    and finish time using atomic `job.json` writes.
-11. Initiating CLI streams the durable log while connected.
+10. Managed worker records child ids as soon as child artifact directories are
+    allocated, using atomic `job.json` writes.
+11. Managed worker scans artifacts for selected secrets and high-signal token
+    patterns.
+12. Managed worker records command state, verdict rollup, taint state, exit
+    code, and finish time using atomic `job.json` writes.
+13. Initiating CLI streams the durable log while connected.
 
 ## Error Handling
 
@@ -786,15 +994,20 @@ Managed command failures:
 
 - missing secret profile: fail before job launch;
 - blocked key-backed adapter: fail before job launch;
+- active cooldown: fail before job launch with source job and expiry;
 - lock conflict: fail before child `quorum run` / `quorum run-all` launch with
   owner/log details;
+- raw live `run` / `run-all` on the AWS host outside the managed worker: fail
+  closed with the supported managed command to use;
 - child `run` / `run-all` process crash, missing expected artifacts, or
   managed-command failure: mark job `failed`;
+- secret-leak scan match: mark job `failed` and `tainted: true`;
 - child `run` returns a non-passing verdict or `run-all` records failing cells:
   mark job `succeeded` if artifacts were written correctly, and record the
   eval verdict rollup separately;
 - SSH disconnect: no state change; supervisor continues;
-- supervisor gone before final state: `status` marks job `orphaned`;
+- stale heartbeat and supervisor gone before final state: `status` reports the
+  job as `orphaned`;
 - malformed `job.json`: `status` reports the file path and continues listing
   other jobs.
 
@@ -814,19 +1027,31 @@ uv run pytest
 Add unit tests for:
 
 - state-root discovery;
+- AWS host-mode raw `run` / `run-all` fail-closed behavior;
+- shared directory and lock-file mode enforcement;
 - job id allocation and `job.json` schema;
 - job state transitions;
+- heartbeat and stale-worker detection;
 - durable log path creation;
 - atomic `job.json` writes and recovery from malformed job records;
 - lock acquisition, release, deterministic ordering, and conflict reporting;
+- shared/exclusive checkout locks;
+- cooldown read/write and fail-fast reporting;
 - fake-supervisor behavior proving the managed worker, not the initiating CLI,
   holds locks through the child lifetime;
+- early child run/batch registration for crash recovery;
 - target-to-provider lock mapping;
 - `doctor` ready/blocked/failed output;
-- `doctor --all` exit codes when targets are blocked versus failed;
+- `doctor <target>` and `doctor --all` exit codes when targets are ready,
+  blocked, failed, or unclassifiable;
 - secret redaction;
+- root-only source profiles and selected-target per-job materialization;
+- stale per-job env detection and cleanup;
 - secret-bearing env files staying outside result artifacts;
+- poison-env tests for setup, checks, preflights, Gauntlet, child `quorum run`,
+  launchers, and capture helpers;
 - generic secret-leak scan coverage;
+- tainted job finalization;
 - smoke scenario mapping, including draft bootstrap scenarios;
 - `column` command expansion over existing `run-all`;
 - `sentinel-default` profile expansion;
@@ -844,28 +1069,44 @@ Before Phase 1 is considered usable:
 1. Terraform plan shows no unrelated replacement of existing Terminus
    resources.
 2. The host appears in Tailscale as `quorum-evals`.
-3. SSM Session Manager can reach the instance.
-4. `/opt/quorum` is mounted from the persistent encrypted data volume.
-5. Steady-state boot mounts the data volume and does not auto-format it.
-6. Data volume has `prevent_destroy`, backup policy coverage, and at least one
+3. Tailscale ACL validation proves `tag:quorum-evals` allows only non-root
+   operator SSH and denies root.
+4. SSM Session Manager can reach the instance through the documented
+   break-glass path, with encrypted session logging enabled.
+5. `/opt/quorum` is mounted from the persistent encrypted data volume.
+6. Steady-state boot mounts the data volume by expected identity and does not
+   auto-format it.
+7. Data volume has `prevent_destroy`, backup policy coverage, and at least one
    recent snapshot.
-7. Eval users cannot reach IMDS.
-8. Eval users have no sudo, wheel, or Docker socket access.
-9. Tailscale SSH maps only to non-root operator accounts.
-10. Required binaries are installed.
-11. Repos are cloned at expected branches.
-12. `uv sync --extra dev` succeeds in the eval repo.
-13. `uv run quorum doctor --all` reports ready, blocked, or failed for every
+8. A restore drill mounts a snapshot and `quorum show` can inspect
+   representative restored artifacts.
+9. Eval users cannot reach IMDS.
+10. Eval users have no sudo, wheel, or Docker socket access.
+11. Source secret profiles are root-only; a live eval child can read only its
+   selected per-job env file.
+12. Required binaries are installed.
+13. Repos are cloned at expected branches.
+14. `uv sync --extra dev` succeeds in the eval repo.
+15. `uv run quorum doctor --all` reports ready, blocked, or failed for every
    target with no unclassified target.
-14. At least one key-backed target smoke passes.
-15. At least one target column starts and writes a batch artifact.
-16. `sentinel-default` completes with `claude` and at least one non-Anthropic
-   key-backed target.
-17. A disconnected SSH session does not kill the managed job.
-18. A second SSH session can run `status`, `tail`, and `show`.
-19. A deliberate lock conflict exits clearly and does not start a second live
+16. Raw `uv run quorum run` and `uv run quorum run-all` fail closed on the AWS
+   host outside the managed worker.
+17. At least one key-backed target smoke passes.
+18. At least one sentinel target column starts and writes a batch artifact.
+19. A disconnected SSH session does not kill the managed job.
+20. A second SSH session can run `status`, `tail`, and `show`.
+21. A deliberate lock conflict exits clearly and does not start a second live
    run.
-20. Secret-leak scan passes for job metadata, logs, and result artifacts.
+22. Secret-leak scan passes for job metadata, logs, and result artifacts.
+
+Before Phase 1b is considered complete:
+
+1. `sentinel-default` completes with `claude` and at least one non-Anthropic
+   key-backed target.
+2. The profile manifest records each child target, provider lock, batch id,
+   computed max live cells, and artifact path.
+3. The AWS dry-run captures enough measurements to decide whether any
+   configured concurrency should rise above one live cell per provider.
 
 Record dry-run measurements:
 
@@ -880,27 +1121,41 @@ Record dry-run measurements:
 
 ## Phase 1 Exit Criteria
 
-Phase 1 is complete when:
+Phase 1a is usable when:
 
 - Terminus provisions `quorum-evals` through Terraform.
 - `/opt/quorum` host layout exists on persistent EBS.
 - IMDS is blocked for eval users and eval child processes.
 - eval operators have no sudo, wheel, or Docker socket access.
-- data volume mount is fail-closed and backup policy coverage is verified.
-- host-managed secret profiles exist for the day-one ready target set.
+- data volume mount is fail-closed, backup policy coverage is verified, and a
+  restore drill has passed.
+- SSM break-glass is scoped and logged; Tailscale SSH maps only to non-root
+  operator accounts.
+- host-managed source secret profiles are root-only and selected per-job env
+  materialization works.
+- host-managed secret profiles exist for at least one day-one ready target.
 - `doctor --all` classifies every target, reports blocked targets with
-  actionable reasons, and marks at least `claude` plus one non-Anthropic
-  key-backed target as `ready`.
+  actionable reason codes, and marks at least one key-backed target as `ready`.
 - key-backed adapter work lands for any target counted as supported.
-- `smoke <target>`, `column <target>`, and `batch --profile sentinel-default`
-  run as managed jobs.
+- `smoke <target>` and sentinel `column <target>` run as managed jobs.
 - managed jobs survive SSH disconnect.
 - `status` and `tail` recover job state from a fresh SSH session.
 - host-global locks prevent target/provider conflicts across sessions.
+- raw live `run` / `run-all` fail closed on the AWS host outside the managed
+  worker.
 - job metadata records owner, command, repo SHAs, dirty states, locks, log
-  path, out root, child ids, final command state, and verdict rollup.
+  path, out root, child ids, heartbeats, final command state, taint state, and
+  verdict rollup.
 - secret-bearing env files stay outside result artifacts and leak scans pass.
 - results remain inspectable through `quorum show`.
+
+Phase 1b is complete when:
+
+- `batch --profile sentinel-default` runs as a managed job.
+- `sentinel-default` includes `claude` plus at least one non-Anthropic
+  key-backed target that is `doctor`-ready.
+- the batch profile manifest and job metadata expose child batches, locks,
+  computed max live cells, result rollup, and `quorum show` commands.
 - dry-run measurements are captured and used to adjust default parallelism.
 
 ## Deferred To Later Phases

--- a/quorum/checks.py
+++ b/quorum/checks.py
@@ -21,6 +21,7 @@ import os
 import re
 import subprocess
 import tempfile
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -65,6 +66,7 @@ def run_phase(
     quorum_bin: Path,
     tool_calls_path: Path | None = None,
     run_dir: Path | None = None,
+    env_base: Mapping[str, str] | None = None,
 ) -> tuple[list[CheckRecord], int]:
     """Source checks.sh, call <phase>, return (records, script_exit_code).
 
@@ -77,9 +79,10 @@ def run_phase(
     # or `command-succeeds 'go test'` need brew / pyenv / nvm tools that don't
     # live in /usr/bin or /bin. Prepend quorum_bin so the check vocabulary
     # wins lookups, then layer our own overrides on top.
+    base_env = dict(env_base) if env_base is not None else dict(os.environ)
     env = {
-        **os.environ,
-        "PATH": f"{quorum_bin}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+        **base_env,
+        "PATH": f"{quorum_bin}:{base_env.get('PATH', '/usr/bin:/bin')}",
         "QUORUM_RECORD_SINK": str(sink),
     }
     if tool_calls_path is not None:

--- a/quorum/cli.py
+++ b/quorum/cli.py
@@ -9,6 +9,14 @@ from pathlib import Path
 
 import click
 
+from quorum.doctor import (
+    DoctorPaths,
+    DoctorStatus,
+    TargetDoctorResult,
+    is_doctor_command_error,
+    run_all_doctors,
+    run_target_doctor,
+)
 from quorum.managed_state import discover_managed_paths
 from quorum.run_all import run_batch
 from quorum.runner import run_scenario
@@ -299,6 +307,107 @@ def show(
             err=True,
         )
         sys.exit(2)
+
+
+@main.command("doctor")
+@click.argument("target", required=False)
+@click.option(
+    "--all",
+    "all_targets",
+    is_flag=True,
+    help="Check every configured Coding-Agent target.",
+)
+@click.option("--json", "mode_json", is_flag=True, help="Print stable JSON for automation.")
+@click.option(
+    "--scenarios-root",
+    default=_DEFAULT_SCENARIOS_ROOT,
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+)
+@click.option(
+    "--coding-agents-dir",
+    default=_DEFAULT_CODING_AGENTS_DIR,
+    type=click.Path(file_okay=False, path_type=Path),
+)
+def doctor(
+    target: str | None,
+    all_targets: bool,
+    mode_json: bool,
+    scenarios_root: Path,
+    coding_agents_dir: Path,
+) -> None:
+    """Check whether Coding-Agent targets are runnable without launching live evals."""
+    if all_targets and target is not None:
+        click.echo("error: pass either TARGET or --all, not both", err=True)
+        sys.exit(1)
+    if not all_targets and target is None:
+        click.echo("error: pass TARGET or --all", err=True)
+        sys.exit(1)
+
+    env = dict(os.environ)
+    paths = DoctorPaths(
+        coding_agents_dir=coding_agents_dir.resolve(),
+        scenarios_root=scenarios_root.resolve(),
+        profile_root=Path(env["QUORUM_TARGET_PROFILE_ROOT"]).resolve()
+        if env.get("QUORUM_TARGET_PROFILE_ROOT")
+        else None,
+        managed_paths=discover_managed_paths(env),
+    )
+    if all_targets:
+        results = run_all_doctors(paths, env)
+        if mode_json:
+            click.echo(
+                json.dumps(
+                    [result.to_dict() for result in results],
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+        else:
+            click.echo(_render_doctor_table(results), nl=False)
+        sys.exit(_doctor_results_exit_code(results))
+
+    assert target is not None
+    result = run_target_doctor(target, paths, env)
+    if mode_json:
+        click.echo(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+    else:
+        click.echo(_render_doctor_table([result]), nl=False)
+    sys.exit(_doctor_exit_code(result))
+
+
+def _doctor_exit_code(result: TargetDoctorResult) -> int:
+    if is_doctor_command_error(result):
+        return 2
+    status = result.status
+    if status is DoctorStatus.READY:
+        return 0
+    if status is DoctorStatus.BLOCKED:
+        return 3
+    return 1
+
+
+def _doctor_results_exit_code(results: list[TargetDoctorResult]) -> int:
+    if any(is_doctor_command_error(result) for result in results):
+        return 2
+    if any(result.status is DoctorStatus.FAILED for result in results):
+        return 1
+    return 0
+
+
+def _render_doctor_table(results: list[TargetDoctorResult]) -> str:
+    lines = ["target  status   check                  message"]
+    for result in results:
+        first = True
+        for check in result.checks:
+            target_text = result.target if first else ""
+            status_text = result.status.value if first else ""
+            lines.append(
+                f"{target_text:<7} {status_text:<8} {check.name:<22} {check.message}"
+            )
+            if check.remediation:
+                lines.append(f"{'':<7} {'':<8} {'remediation':<22} {check.remediation}")
+            first = False
+    return "\n".join(lines) + "\n"
 
 
 @main.command("run-all")

--- a/quorum/cli.py
+++ b/quorum/cli.py
@@ -721,11 +721,12 @@ def managed_worker(job_id: str) -> None:
 def _render_managed_status_table(jobs: list[dict[str, object]]) -> str:
     if not jobs:
         return "no managed jobs\n"
-    lines = ["job id                       state        updated               command"]
+    lines = ["job id                       state        taint    updated               command"]
     for job in jobs:
         command = _render_managed_command(job)
+        taint = "tainted" if job.get("tainted") else ""
         lines.append(
-            f"{str(job['id']):<28} {str(job['state']):<12} "
+            f"{str(job['id']):<28} {str(job['state']):<12} {taint:<8} "
             f"{str(job['updated_at']):<21} {command}"
         )
     return "\n".join(lines) + "\n"
@@ -739,6 +740,11 @@ def _render_managed_job_detail(job: dict[str, object]) -> str:
         f"updated_at: {job['updated_at']}",
         "command: " + _render_managed_command(job),
     ]
+    if job.get("tainted"):
+        lines.append("tainted: true")
+        taint_reason = job.get("taint_reason")
+        if taint_reason is not None:
+            lines.append(f"taint_reason: {taint_reason}")
     for field in ("owner", "started_at", "finished_at", "final_exit_code", "failure_reason"):
         value = job.get(field)
         if value is not None:

--- a/quorum/cli.py
+++ b/quorum/cli.py
@@ -3,13 +3,24 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 
 import click
 
+from quorum.managed_state import discover_managed_paths
 from quorum.run_all import run_batch
 from quorum.runner import run_scenario
+from quorum.runtime_env import (
+    TargetProfile,
+    TargetProfileError,
+    assert_raw_command_allowed,
+    build_managed_env,
+    is_managed_host,
+    is_trusted_managed_worker,
+    load_target_profile,
+)
 from quorum.scaffold import (
     ScaffoldError,
     check_scenario,
@@ -28,6 +39,29 @@ from quorum.show import (
 _DEFAULT_SCENARIOS_ROOT = Path("scenarios")
 _DEFAULT_CODING_AGENTS_DIR = Path("coding-agents")
 _DEFAULT_OUT_ROOT = Path("results")
+_KIMI_PREFLIGHT_RUNTIME_KEYS = (
+    "QUORUM_KIMI_PREFLIGHT_SENTINEL",
+    "QUORUM_KIMI_PREFLIGHT_TOKEN",
+)
+
+
+def _managed_env_base_for_target(target: str | None) -> dict[str, str] | None:
+    if not is_managed_host(os.environ):
+        return None
+    paths = discover_managed_paths(os.environ)
+    profile = TargetProfile(target=target or "batch", path=None, env={})
+    profile_root = os.environ.get("QUORUM_TARGET_PROFILE_ROOT")
+    if target is not None and profile_root:
+        profile = load_target_profile(Path(profile_root), target)
+    runtime_vars = (
+        {name: os.environ[name] for name in _KIMI_PREFLIGHT_RUNTIME_KEYS if os.environ.get(name)}
+        if target == "kimi"
+        else {}
+    )
+    env_base = build_managed_env(os.environ, paths, profile, runtime_vars=runtime_vars)
+    if target is None and is_trusted_managed_worker(os.environ):
+        env_base["QUORUM_MANAGED_WORKER_TOKEN"] = os.environ["QUORUM_MANAGED_WORKER_TOKEN"]
+    return env_base
 
 
 @click.group()
@@ -62,6 +96,16 @@ def run(
     out_root: Path,
 ) -> None:
     """Run one scenario against one Coding-Agent."""
+    try:
+        assert_raw_command_allowed("run", os.environ)
+    except PermissionError as e:
+        click.echo(str(e), err=True)
+        sys.exit(2)
+    try:
+        env_base = _managed_env_base_for_target(coding_agent)
+    except TargetProfileError as e:
+        click.echo(f"error: {e}", err=True)
+        sys.exit(2)
     # Resolve every path to absolute at the CLI boundary. subprocess.run
     # with cwd= resolves relative executable paths against that cwd, not
     # quorum's cwd — relative paths here would silently misresolve
@@ -75,6 +119,7 @@ def run(
         coding_agent=coding_agent,
         coding_agents_dir=coding_agents_dir,
         out_root=out_root,
+        env_base=env_base,
     )
     # Machine-readable line for `quorum run-all` to parse. Printed
     # unconditionally — color/mode flags don't affect it.
@@ -331,6 +376,16 @@ def run_all_cmd(
     Use --tier to restrict to a named tier (sentinel/full/adhoc).
     Use --include-drafts to include status: draft scenarios (excluded by default).
     """
+    try:
+        assert_raw_command_allowed("run-all", os.environ)
+    except PermissionError as e:
+        click.echo(str(e), err=True)
+        sys.exit(2)
+    try:
+        env_base = _managed_env_base_for_target(None)
+    except TargetProfileError as e:
+        click.echo(f"error: {e}", err=True)
+        sys.exit(2)
     agent_filter = (
         [a.strip() for a in coding_agents_csv.split(",") if a.strip()]
         if coding_agents_csv
@@ -351,6 +406,7 @@ def run_all_cmd(
             use_cursor=not no_cursor,
             tier=tier,
             include_drafts=include_drafts,
+            env_base=env_base,
         )
     except ValueError as e:
         click.echo(f"error: {e}", err=True)

--- a/quorum/cli.py
+++ b/quorum/cli.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import json
 import os
 import sys
+from collections.abc import Mapping
 from pathlib import Path
+from typing import cast
 
 import click
 
@@ -17,7 +19,8 @@ from quorum.doctor import (
     run_all_doctors,
     run_target_doctor,
 )
-from quorum.managed_state import discover_managed_paths
+from quorum.managed_commands import run_managed_worker, status_summary, tail_job
+from quorum.managed_state import discover_managed_paths, job_to_json, read_job
 from quorum.run_all import run_batch
 from quorum.runner import run_scenario
 from quorum.runtime_env import (
@@ -408,6 +411,116 @@ def _render_doctor_table(results: list[TargetDoctorResult]) -> str:
                 lines.append(f"{'':<7} {'':<8} {'remediation':<22} {check.remediation}")
             first = False
     return "\n".join(lines) + "\n"
+
+
+@main.command("status")
+@click.argument("job_id", required=False)
+@click.option("--json", "mode_json", is_flag=True, help="Print stable JSON for automation.")
+@click.option("--limit", default=20, type=click.IntRange(min=1), help="Maximum jobs to show.")
+@click.option(
+    "--active-only",
+    is_flag=True,
+    help="Hide terminal jobs and show only planned/running jobs.",
+)
+def managed_status(
+    job_id: str | None,
+    mode_json: bool,
+    limit: int,
+    active_only: bool,
+) -> None:
+    """Show managed Quorum job status."""
+    paths = discover_managed_paths(os.environ)
+    if job_id is not None:
+        try:
+            job = read_job(paths, job_id)
+        except (FileNotFoundError, ValueError) as e:
+            click.echo(f"error: {e}", err=True)
+            sys.exit(1)
+        if mode_json:
+            click.echo(json.dumps(job_to_json(job), indent=2, sort_keys=True))
+        else:
+            click.echo(_render_managed_job_detail(job_to_json(job)), nl=False)
+        return
+
+    jobs = status_summary(paths, limit=limit, include_finished=not active_only)
+    payload = [job_to_json(job) for job in jobs]
+    if mode_json:
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        click.echo(_render_managed_status_table(payload), nl=False)
+
+
+@main.command("tail")
+@click.argument("job_id")
+@click.option("--child", "child_id", help="Tail one child record's underlying log.")
+@click.option("--follow", is_flag=True, help="Follow appended bytes until the job is terminal.")
+def managed_tail(job_id: str, child_id: str | None, follow: bool) -> None:
+    """Tail managed Quorum job events and logs."""
+    paths = discover_managed_paths(os.environ)
+    try:
+        for line in tail_job(job_id, child_id=child_id, follow=follow, paths=paths):
+            click.echo(line, nl=False)
+    except (FileNotFoundError, ValueError) as e:
+        click.echo(f"error: {e}", err=True)
+        sys.exit(1)
+
+
+@main.command("managed-worker", hidden=True)
+@click.argument("job_id")
+def managed_worker(job_id: str) -> None:
+    """Internal managed Quorum worker entrypoint."""
+    if os.environ.get("QUORUM_MANAGED_WORKER") != "1":
+        click.echo("error: managed-worker must be launched by a managed supervisor", err=True)
+        sys.exit(2)
+    paths = discover_managed_paths(os.environ)
+    sys.exit(run_managed_worker(job_id, paths, dict(os.environ)))
+
+
+def _render_managed_status_table(jobs: list[dict[str, object]]) -> str:
+    if not jobs:
+        return "no managed jobs\n"
+    lines = ["job id                       state        updated               command"]
+    for job in jobs:
+        command = _render_managed_command(job)
+        lines.append(
+            f"{str(job['id']):<28} {str(job['state']):<12} "
+            f"{str(job['updated_at']):<21} {command}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _render_managed_job_detail(job: dict[str, object]) -> str:
+    lines = [
+        f"id: {job['id']}",
+        f"state: {job['state']}",
+        f"created_at: {job['created_at']}",
+        f"updated_at: {job['updated_at']}",
+        "command: " + _render_managed_command(job),
+    ]
+    for field in ("owner", "started_at", "finished_at", "final_exit_code", "failure_reason"):
+        value = job.get(field)
+        if value is not None:
+            lines.append(f"{field}: {value}")
+    children = job.get("children")
+    if isinstance(children, list):
+        lines.append("children:")
+        if children:
+            for child in children:
+                if isinstance(child, Mapping):
+                    child_record = cast(Mapping[str, object], child)
+                    child_id = child_record.get("id") or child_record.get("child_id") or "unknown"
+                    child_state = child_record.get("state") or "unknown"
+                    lines.append(f"  - {child_id}: {child_state}")
+        else:
+            lines.append("  (none)")
+    return "\n".join(lines) + "\n"
+
+
+def _render_managed_command(job: Mapping[str, object]) -> str:
+    command = job.get("command")
+    if isinstance(command, list):
+        return " ".join(str(part) for part in command)
+    return ""
 
 
 @main.command("run-all")

--- a/quorum/cli.py
+++ b/quorum/cli.py
@@ -19,7 +19,16 @@ from quorum.doctor import (
     run_all_doctors,
     run_target_doctor,
 )
-from quorum.managed_commands import run_managed_worker, status_summary, tail_job
+from quorum.managed_commands import (
+    InlineSupervisor,
+    Supervisor,
+    TmuxSupervisor,
+    create_job,
+    run_managed_worker,
+    start_job,
+    status_summary,
+    tail_job,
+)
 from quorum.managed_state import discover_managed_paths, job_to_json, read_job
 from quorum.run_all import run_batch
 from quorum.runner import run_scenario
@@ -411,6 +420,239 @@ def _render_doctor_table(results: list[TargetDoctorResult]) -> str:
                 lines.append(f"{'':<7} {'':<8} {'remediation':<22} {check.remediation}")
             first = False
     return "\n".join(lines) + "\n"
+
+
+@main.command("smoke")
+@click.argument("target")
+@click.option(
+    "--scenarios-root",
+    default=_DEFAULT_SCENARIOS_ROOT,
+    hidden=True,
+    type=click.Path(file_okay=False, path_type=Path),
+)
+@click.option(
+    "--coding-agents-dir",
+    default=_DEFAULT_CODING_AGENTS_DIR,
+    hidden=True,
+    type=click.Path(file_okay=False, path_type=Path),
+)
+def managed_smoke(target: str, scenarios_root: Path, coding_agents_dir: Path) -> None:
+    """Run the managed smoke scenario for one target."""
+    args = _managed_path_args(
+        scenarios_root=scenarios_root,
+        coding_agents_dir=coding_agents_dir,
+    )
+    _start_managed_cli_job(
+        kind="smoke",
+        target=target,
+        args=args,
+        coding_agents=[target],
+        tier=None,
+        include_drafts=True,
+    )
+
+
+@main.command("column")
+@click.argument("target")
+@click.option("--jobs", default=1, type=click.IntRange(min=1), help="Worker pool size.")
+@click.option(
+    "--tier",
+    type=click.Choice(["sentinel", "full", "adhoc"]),
+    default="sentinel",
+    help="Scenario tier to run. Default: sentinel.",
+)
+@click.option(
+    "--include-drafts",
+    "include_drafts",
+    is_flag=True,
+    default=False,
+    help="Include status: draft scenarios.",
+)
+@click.option(
+    "--scenarios-root",
+    default=_DEFAULT_SCENARIOS_ROOT,
+    hidden=True,
+    type=click.Path(file_okay=False, path_type=Path),
+)
+@click.option(
+    "--coding-agents-dir",
+    default=_DEFAULT_CODING_AGENTS_DIR,
+    hidden=True,
+    type=click.Path(file_okay=False, path_type=Path),
+)
+def managed_column(
+    target: str,
+    jobs: int,
+    tier: str,
+    include_drafts: bool,
+    scenarios_root: Path,
+    coding_agents_dir: Path,
+) -> None:
+    """Run a managed sentinel column for one target."""
+    args = ["--jobs", str(jobs)]
+    if tier != "sentinel":
+        args.extend(["--tier", tier])
+    if include_drafts:
+        args.append("--include-drafts")
+    args.extend(
+        _managed_path_args(
+            scenarios_root=scenarios_root,
+            coding_agents_dir=coding_agents_dir,
+        )
+    )
+    _start_managed_cli_job(
+        kind="column",
+        target=target,
+        args=args,
+        coding_agents=[target],
+        tier=tier,
+        include_drafts=include_drafts,
+    )
+
+
+@main.command("batch")
+@click.option("--coding-agent", "coding_agent", help="Single Coding-Agent target.")
+@click.option("--coding-agents", "coding_agents_csv", help="CSV Coding-Agent target filter.")
+@click.option(
+    "--all-ready-targets",
+    is_flag=True,
+    help="Expand to targets whose doctor status is ready.",
+)
+@click.option("--jobs", default=1, type=click.IntRange(min=1), help="Worker pool size.")
+@click.option(
+    "--tier",
+    type=click.Choice(["sentinel", "full", "adhoc"]),
+    default="sentinel",
+    help="Scenario tier to run. Default: sentinel.",
+)
+@click.option(
+    "--include-drafts",
+    "include_drafts",
+    is_flag=True,
+    default=False,
+    help="Include status: draft scenarios.",
+)
+@click.option(
+    "--scenarios-root",
+    default=_DEFAULT_SCENARIOS_ROOT,
+    hidden=True,
+    type=click.Path(file_okay=False, path_type=Path),
+)
+@click.option(
+    "--coding-agents-dir",
+    default=_DEFAULT_CODING_AGENTS_DIR,
+    hidden=True,
+    type=click.Path(file_okay=False, path_type=Path),
+)
+def managed_batch(
+    coding_agent: str | None,
+    coding_agents_csv: str | None,
+    all_ready_targets: bool,
+    jobs: int,
+    tier: str,
+    include_drafts: bool,
+    scenarios_root: Path,
+    coding_agents_dir: Path,
+) -> None:
+    """Run a managed batch over explicit or doctor-ready targets."""
+    selectors = [bool(coding_agent), bool(coding_agents_csv), all_ready_targets]
+    if sum(selectors) != 1:
+        click.echo(
+            "error: pass --coding-agent, --coding-agents, or --all-ready-targets",
+            err=True,
+        )
+        sys.exit(2)
+
+    targets: list[str]
+    if all_ready_targets:
+        targets = _doctor_ready_targets(
+            scenarios_root=scenarios_root,
+            coding_agents_dir=coding_agents_dir,
+        )
+    elif coding_agent is not None:
+        targets = [str(coding_agent)]
+    else:
+        targets = [str(a.strip()) for a in (coding_agents_csv or "").split(",") if a.strip()]
+    if not targets:
+        click.echo("error: no ready targets resolved", err=True)
+        sys.exit(2)
+
+    args = ["--coding-agents", ",".join(targets)]
+    if jobs != 1:
+        args.extend(["--jobs", str(jobs)])
+    if tier != "sentinel":
+        args.extend(["--tier", tier])
+    if include_drafts:
+        args.append("--include-drafts")
+    args.extend(
+        _managed_path_args(
+            scenarios_root=scenarios_root,
+            coding_agents_dir=coding_agents_dir,
+        )
+    )
+    _start_managed_cli_job(
+        kind="batch",
+        target=None,
+        args=args,
+        coding_agents=targets,
+        tier=tier,
+        include_drafts=include_drafts,
+    )
+
+
+def _managed_path_args(*, scenarios_root: Path, coding_agents_dir: Path) -> list[str]:
+    args: list[str] = []
+    if scenarios_root != _DEFAULT_SCENARIOS_ROOT:
+        args.extend(["--scenarios-root", str(scenarios_root)])
+    if coding_agents_dir != _DEFAULT_CODING_AGENTS_DIR:
+        args.extend(["--coding-agents-dir", str(coding_agents_dir)])
+    return args
+
+
+def _start_managed_cli_job(
+    *,
+    kind: str,
+    target: str | None,
+    args: list[str],
+    coding_agents: list[str],
+    tier: str | None,
+    include_drafts: bool | None,
+) -> None:
+    paths = discover_managed_paths(os.environ)
+    job = create_job(
+        kind,
+        target,
+        args,
+        paths,
+        owner=None,
+        coding_agents=coding_agents,
+        tier=tier,
+        include_drafts=include_drafts,
+    )
+    result = start_job(job, paths, _managed_supervisor(os.environ))
+    click.echo(f"job id: {result.job_id}")
+    click.echo(f"status: quorum status {result.job_id}")
+    click.echo(f"tail: quorum tail {result.job_id}")
+
+
+def _managed_supervisor(env: Mapping[str, str]) -> Supervisor:
+    if env.get("QUORUM_MANAGED_SUPERVISOR") == "inline":
+        return InlineSupervisor(env=env)
+    return TmuxSupervisor(env=env)
+
+
+def _doctor_ready_targets(*, scenarios_root: Path, coding_agents_dir: Path) -> list[str]:
+    env = dict(os.environ)
+    paths = DoctorPaths(
+        coding_agents_dir=coding_agents_dir.resolve(),
+        scenarios_root=scenarios_root.resolve(),
+        profile_root=Path(env["QUORUM_TARGET_PROFILE_ROOT"]).resolve()
+        if env.get("QUORUM_TARGET_PROFILE_ROOT")
+        else None,
+        managed_paths=discover_managed_paths(env),
+    )
+    results = run_all_doctors(paths, env)
+    return [result.target for result in results if result.status is DoctorStatus.READY]
 
 
 @main.command("status")

--- a/quorum/coding_agent_config.py
+++ b/quorum/coding_agent_config.py
@@ -106,11 +106,11 @@ def load_coding_agent_config(
     if missing:
         raise CodingAgentConfigError(f"{path}: missing required fields: {missing}")
 
-    name = raw["name"]
+    name = _required_string(path, raw, "name")
     if name != path.stem:
         raise CodingAgentConfigError(f"{path}: name must match file stem; got name {name!r}")
 
-    runtime_family = raw.get("runtime_family", name)
+    runtime_family = _optional_string(path, raw, "runtime_family") or name
     if runtime_family not in KNOWN_RUNTIME_FAMILIES:
         raise CodingAgentConfigError(
             f"{path}: unknown runtime_family {runtime_family!r}; "
@@ -127,18 +127,23 @@ def load_coding_agent_config(
     if runtime_family != "claude" and runtime_family != name:
         raise CodingAgentConfigError(f"{path}: non-Claude variants are not supported in v1")
 
-    required_env = tuple(raw["required_env"])
+    binary = _required_string(path, raw, "binary")
+    agent_config_env = _required_string(path, raw, "agent_config_env")
+    session_log_dir = _required_string(path, raw, "session_log_dir")
+    session_log_glob = _required_string(path, raw, "session_log_glob")
+    normalizer = _required_string(path, raw, "normalizer")
+    max_time = _optional_string(path, raw, "max_time")
+    required_env = _required_string_sequence(path, raw, "required_env")
     missing_env = [v for v in required_env if not host_env.get(v)]
     if missing_env:
         raise CodingAgentConfigError(f"{path}: required env vars not set: {missing_env}")
 
-    normalizer = raw["normalizer"]
     if normalizer not in NORMALIZERS:
         raise CodingAgentConfigError(
             f"{path}: unknown normalizer {normalizer!r}; known: {sorted(NORMALIZERS)}"
         )
 
-    project_prompt_raw = raw.get("project_prompt")
+    project_prompt_raw = _optional_string(path, raw, "project_prompt")
     project_prompt: Path | None = None
     if project_prompt_raw:
         candidate = (path.parent / project_prompt_raw).resolve()
@@ -149,13 +154,46 @@ def load_coding_agent_config(
     return CodingAgentConfig(
         name=name,
         runtime_family=runtime_family,
-        binary=raw["binary"],
-        agent_config_env=raw["agent_config_env"],
-        session_log_dir=raw["session_log_dir"],
-        session_log_glob=raw["session_log_glob"],
+        binary=binary,
+        agent_config_env=agent_config_env,
+        session_log_dir=session_log_dir,
+        session_log_glob=session_log_glob,
         normalizer=normalizer,
         required_env=required_env,
         model=model,
-        max_time=raw.get("max_time"),
+        max_time=max_time,
         project_prompt=project_prompt,
     )
+
+
+def _required_string(path: Path, raw: Mapping[str, object], key: str) -> str:
+    value = raw[key]
+    if not isinstance(value, str):
+        raise CodingAgentConfigError(f"{path}: {key} must be a string")
+    if not value.strip():
+        raise CodingAgentConfigError(f"{path}: {key} must not be blank")
+    return value
+
+
+def _optional_string(path: Path, raw: Mapping[str, object], key: str) -> str | None:
+    value = raw.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise CodingAgentConfigError(f"{path}: {key} must be a string")
+    if not value.strip():
+        raise CodingAgentConfigError(f"{path}: {key} must not be blank")
+    return value
+
+
+def _required_string_sequence(
+    path: Path,
+    raw: Mapping[str, object],
+    key: str,
+) -> tuple[str, ...]:
+    value = raw[key]
+    if not isinstance(value, list | tuple):
+        raise CodingAgentConfigError(f"{path}: {key} must be a list of strings")
+    if not all(isinstance(item, str) and item.strip() for item in value):
+        raise CodingAgentConfigError(f"{path}: {key} must be a list of non-blank strings")
+    return tuple(str(item) for item in value)

--- a/quorum/coding_agent_config.py
+++ b/quorum/coding_agent_config.py
@@ -16,6 +16,7 @@ no-op if no placeholders are present).
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from string import Template
@@ -80,8 +81,13 @@ def ensure_superpowers_root_default(eval_repo_root: Path = PROJECT_ROOT) -> None
         os.environ["SUPERPOWERS_ROOT"] = str(default)
 
 
-def load_coding_agent_config(path: Path) -> CodingAgentConfig:
-    ensure_superpowers_root_default()
+def load_coding_agent_config(
+    path: Path,
+    env: Mapping[str, str] | None = None,
+) -> CodingAgentConfig:
+    if env is None:
+        ensure_superpowers_root_default()
+    host_env = os.environ if env is None else env
 
     raw = yaml.safe_load(path.read_text())
     if not isinstance(raw, dict):
@@ -122,7 +128,7 @@ def load_coding_agent_config(path: Path) -> CodingAgentConfig:
         raise CodingAgentConfigError(f"{path}: non-Claude variants are not supported in v1")
 
     required_env = tuple(raw["required_env"])
-    missing_env = [v for v in required_env if not os.environ.get(v)]
+    missing_env = [v for v in required_env if not host_env.get(v)]
     if missing_env:
         raise CodingAgentConfigError(f"{path}: required env vars not set: {missing_env}")
 

--- a/quorum/doctor.py
+++ b/quorum/doctor.py
@@ -1,0 +1,804 @@
+"""Side-effect-free readiness checks for quorum Coding-Agent targets."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import stat
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+import yaml
+
+from quorum.coding_agent_config import (
+    CodingAgentConfig,
+    CodingAgentConfigError,
+    load_coding_agent_config,
+)
+from quorum.managed_state import ManagedPaths, discover_managed_paths
+from quorum.run_all import build_matrix
+from quorum.runtime_env import (
+    TargetProfile,
+    TargetProfileError,
+    build_managed_env,
+    is_managed_host,
+    load_target_profile,
+)
+
+DEFAULT_PROFILE_ROOT = Path("/etc/quorum/target-profiles.d")
+DEFAULT_PROFILE_OWNER_UID = 0
+DEFAULT_PROFILE_FILE_MODE = 0o600
+DEFAULT_PROFILE_DIR_MODE = 0o700
+_NON_SECRET_REQUIRED_ENV = frozenset(
+    {
+        "SUPERPOWERS_ROOT",
+        "PATH",
+        "HOME",
+        "TMPDIR",
+        "LANG",
+        "LC_ALL",
+    }
+)
+_MANAGED_PROFILE_REQUIRED_ENV = {
+    "claude": ("ANTHROPIC_API_KEY",),
+    "claude-haiku": ("ANTHROPIC_API_KEY",),
+    "claude-sonnet": ("ANTHROPIC_API_KEY",),
+    "gemini": ("GEMINI_API_KEY",),
+    "kimi": ("KIMI_MODEL_API_KEY",),
+    "opencode": ("OPENAI_API_KEY",),
+    "pi": ("PI_PROVIDER", "PI_MODEL", "PI_API_KEY"),
+    "copilot": ("COPILOT_PROVIDER_BASE_URL", "COPILOT_PROVIDER_TYPE"),
+}
+_MANAGED_PROFILE_ALTERNATIVES = {
+    "copilot": (("COPILOT_PROVIDER_API_KEY", "COPILOT_PROVIDER_BEARER_TOKEN"),),
+}
+_MANAGED_UNSUPPORTED_TARGETS = {
+    "codex": "key-backed Codex mode has not been implemented and verified",
+    "antigravity": "key-backed Antigravity mode has not been implemented and verified",
+    "opencode": (
+        "OpenCode managed env narrowing is not yet accepted; block until launcher "
+        "and export allowlists are restricted to the selected OpenAI profile"
+    ),
+}
+_SUPERPOWERS_REQUIRED_FILES = {
+    "claude": (".claude-plugin/plugin.json", "skills/using-superpowers/SKILL.md"),
+    "gemini": (
+        "GEMINI.md",
+        "skills/using-superpowers/SKILL.md",
+        "skills/using-superpowers/references/gemini-tools.md",
+    ),
+    "kimi": (
+        ".kimi-plugin/plugin.json",
+        "skills/using-superpowers/SKILL.md",
+        "skills/brainstorming/SKILL.md",
+    ),
+    "copilot": (
+        ".claude-plugin/plugin.json",
+        "hooks/hooks.json",
+        "hooks/run-hook.cmd",
+        "hooks/session-start",
+        "skills/using-superpowers/SKILL.md",
+        "skills/brainstorming/SKILL.md",
+        "skills/using-superpowers/references/copilot-tools.md",
+    ),
+    "opencode": (
+        ".opencode/plugins/superpowers.js",
+        "skills/using-superpowers/SKILL.md",
+        "skills/brainstorming/SKILL.md",
+    ),
+    "pi": (
+        "skills/using-superpowers/SKILL.md",
+        "skills/using-superpowers/references/pi-tools.md",
+    ),
+}
+_COPILOT_HOOK_ENV_NAMES = frozenset({"ANTHROPIC_API_KEY", "OPENAI_API_KEY"})
+_COPILOT_HOOK_ENV_FILES = ("hooks/hooks.json", "hooks/run-hook.cmd", "hooks/session-start")
+_ENV_REFERENCE_RE = re.compile(r"\b[A-Z][A-Z0-9_]*\b")
+
+
+class DoctorStatus(Enum):
+    READY = "ready"
+    BLOCKED = "blocked"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class DoctorCheck:
+    name: str
+    status: DoctorStatus
+    message: str
+    remediation: str | None = None
+    reason: str | None = None
+
+    def to_dict(self) -> dict[str, str]:
+        data = {
+            "name": self.name,
+            "status": self.status.value,
+            "message": self.message,
+        }
+        if self.reason:
+            data["reason"] = self.reason
+        if self.remediation:
+            data["remediation"] = self.remediation
+        return data
+
+
+@dataclass(frozen=True)
+class DoctorPaths:
+    coding_agents_dir: Path = Path("coding-agents")
+    scenarios_root: Path = Path("scenarios")
+    profile_root: Path | None = None
+    managed_paths: ManagedPaths | None = None
+    profile_owner_uid: int | None = None
+
+
+@dataclass(frozen=True)
+class TargetDoctorResult:
+    target: str
+    status: DoctorStatus
+    checks: list[DoctorCheck]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "target": self.target,
+            "status": self.status.value,
+            "checks": [check.to_dict() for check in self.checks],
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), sort_keys=True)
+
+
+def run_target_doctor(
+    target: str,
+    paths: DoctorPaths,
+    env: Mapping[str, str],
+) -> TargetDoctorResult:
+    checks: list[DoctorCheck] = []
+    profile: TargetProfile | None = None
+    cfg: CodingAgentConfig | None = None
+    config_path = paths.coding_agents_dir / f"{target}.yaml"
+
+    if not config_path.is_file():
+        checks.append(
+            DoctorCheck(
+                "coding-agent-config",
+                DoctorStatus.FAILED,
+                f"coding-agent config not found: {config_path}",
+                remediation=f"add {config_path} or choose a configured target",
+                reason="missing-repo-file",
+            )
+        )
+        return TargetDoctorResult(target=target, status=_rollup(checks), checks=checks)
+
+    required_env_names = _read_required_env_names(config_path)
+    try:
+        cfg = load_coding_agent_config(config_path, env=_doctor_config_env(env, required_env_names))
+    except (CodingAgentConfigError, OSError, TypeError, yaml.YAMLError) as exc:
+        checks.append(
+            DoctorCheck(
+                "coding-agent-config",
+                DoctorStatus.FAILED,
+                f"coding-agent config failed to load: {exc}",
+                remediation=f"fix {config_path}",
+                reason="config-error",
+            )
+        )
+        return TargetDoctorResult(target=target, status=_rollup(checks), checks=checks)
+    checks.append(
+        DoctorCheck(
+            "coding-agent-config",
+            DoctorStatus.READY,
+            f"loaded {config_path}",
+        )
+    )
+
+    managed = is_managed_host(env)
+    target_env: Mapping[str, str] = env
+
+    if managed and target in _MANAGED_UNSUPPORTED_TARGETS:
+        checks.append(
+            DoctorCheck(
+                "target-profile",
+                DoctorStatus.READY,
+                "target profile is not required until key-backed mode is verified",
+            )
+        )
+        checks.append(_check_required_credentials(target, cfg, None, target_env, managed=managed))
+        return TargetDoctorResult(target=target, status=_rollup(checks), checks=checks)
+
+    profile_root = _profile_root(paths, env)
+    if managed:
+        try:
+            profile = load_target_profile(profile_root, target)
+        except TargetProfileError as exc:
+            reason = "missing-secret" if "not found" in str(exc) else "config-error"
+            checks.append(
+                DoctorCheck(
+                    "target-profile",
+                    DoctorStatus.FAILED,
+                    str(exc),
+                    remediation=(
+                        f"create {profile_root / f'{target}.env'} with required credentials"
+                    ),
+                    reason=reason,
+                )
+            )
+            return TargetDoctorResult(target=target, status=_rollup(checks), checks=checks)
+        else:
+            checks.append(
+                DoctorCheck(
+                    "target-profile",
+                    DoctorStatus.READY,
+                    f"loaded {profile.path}",
+                )
+            )
+            checks.append(_check_profile_permissions(profile.path, paths.profile_owner_uid))
+            managed_paths = paths.managed_paths or discover_managed_paths(env)
+            try:
+                target_env = build_managed_env(
+                    env,
+                    managed_paths,
+                    profile,
+                    runtime_vars={},
+                )
+            except Exception as exc:
+                checks.append(
+                    DoctorCheck(
+                        "sanitized-env",
+                        DoctorStatus.FAILED,
+                        f"could not build sanitized target env: {exc}",
+                        remediation="fix target profile or managed root configuration",
+                        reason="config-error",
+                    )
+                )
+            else:
+                checks.append(
+                    DoctorCheck(
+                        "sanitized-env",
+                        DoctorStatus.READY,
+                        "sanitized target env materialized from profile and allowlisted base env",
+                    )
+                )
+    else:
+        checks.append(
+            DoctorCheck(
+                "target-profile",
+                DoctorStatus.READY,
+                "managed host mode inactive; target profile is not required",
+            )
+        )
+
+    checks.extend(_check_managed_paths(paths, env, managed=managed))
+    checks.append(_check_required_credentials(target, cfg, profile, target_env, managed=managed))
+    checks.append(_check_binary(cfg, target_env, managed=managed))
+    checks.append(_check_context(paths.coding_agents_dir, cfg))
+    checks.append(_check_home_skeleton(paths.coding_agents_dir, cfg))
+    checks.append(_check_superpowers_files(target, cfg, target_env, managed=managed))
+    checks.append(_check_sentinel(paths, target))
+
+    return TargetDoctorResult(target=target, status=_rollup(checks), checks=checks)
+
+
+def run_all_doctors(paths: DoctorPaths, env: Mapping[str, str]) -> list[TargetDoctorResult]:
+    if not paths.coding_agents_dir.is_dir():
+        return [
+            TargetDoctorResult(
+                target="*",
+                status=DoctorStatus.FAILED,
+                checks=[
+                    DoctorCheck(
+                        "coding-agent-config",
+                        DoctorStatus.FAILED,
+                        f"coding-agents directory not found: {paths.coding_agents_dir}",
+                        remediation="pass --coding-agents-dir pointing at a checkout",
+                        reason="config-error",
+                    )
+                ],
+            )
+        ]
+    targets = sorted(path.stem for path in paths.coding_agents_dir.glob("*.yaml"))
+    return [run_target_doctor(target, paths, env) for target in targets]
+
+
+def _rollup(checks: list[DoctorCheck]) -> DoctorStatus:
+    if any(check.status is DoctorStatus.FAILED for check in checks):
+        return DoctorStatus.FAILED
+    if any(check.status is DoctorStatus.BLOCKED for check in checks):
+        return DoctorStatus.BLOCKED
+    return DoctorStatus.READY
+
+
+def is_doctor_command_error(result: TargetDoctorResult) -> bool:
+    """Return true when doctor could not complete classification for a target."""
+    command_error_checks = {"artifact-root", "coding-agent-config", "state-root"}
+    return any(
+        check.status is DoctorStatus.FAILED
+        and check.reason == "config-error"
+        and check.name in command_error_checks
+        for check in result.checks
+    )
+
+
+def _profile_root(paths: DoctorPaths, env: Mapping[str, str]) -> Path:
+    if paths.profile_root is not None:
+        return paths.profile_root
+    if env.get("QUORUM_TARGET_PROFILE_ROOT"):
+        return Path(env["QUORUM_TARGET_PROFILE_ROOT"])
+    return DEFAULT_PROFILE_ROOT
+
+
+def _read_required_env_names(config_path: Path) -> tuple[str, ...]:
+    try:
+        raw = yaml.safe_load(config_path.read_text()) or {}
+    except (OSError, yaml.YAMLError):
+        return ()
+    if not isinstance(raw, Mapping):
+        return ()
+    required = raw.get("required_env", ())
+    if not isinstance(required, list | tuple):
+        return ()
+    return tuple(str(name) for name in required)
+
+
+def _doctor_config_env(
+    env: Mapping[str, str],
+    required_env_names: tuple[str, ...],
+) -> dict[str, str]:
+    cfg_env = dict(env)
+    for name in required_env_names:
+        cfg_env[name] = f"__quorum_doctor_placeholder_{name}__"
+    return cfg_env
+
+
+def _check_profile_permissions(
+    profile_path: Path | None,
+    profile_owner_uid: int | None,
+) -> DoctorCheck:
+    if profile_path is None:
+        return DoctorCheck(
+            "profile-permissions",
+            DoctorStatus.FAILED,
+            "target profile path was not available after profile load",
+            reason="config-error",
+        )
+    expected_owner_uid = (
+        DEFAULT_PROFILE_OWNER_UID if profile_owner_uid is None else profile_owner_uid
+    )
+    try:
+        profile_stat = profile_path.stat()
+        profile_dir_stat = profile_path.parent.stat()
+    except OSError as exc:
+        return DoctorCheck(
+            "profile-permissions",
+            DoctorStatus.FAILED,
+            f"target profile metadata could not be read: {exc}",
+            remediation=f"fix profile path permissions for {profile_path}",
+            reason="config-error",
+        )
+
+    if profile_dir_stat.st_uid != expected_owner_uid:
+        return DoctorCheck(
+            "profile-permissions",
+            DoctorStatus.FAILED,
+            (
+                f"target profile directory owner uid {profile_dir_stat.st_uid} "
+                f"does not match expected uid {expected_owner_uid}: {profile_path.parent}"
+            ),
+            remediation=f"chown root:root {profile_path.parent}",
+            reason="config-error",
+        )
+    dir_mode = stat.S_IMODE(profile_dir_stat.st_mode)
+    if dir_mode != DEFAULT_PROFILE_DIR_MODE:
+        return DoctorCheck(
+            "profile-permissions",
+            DoctorStatus.FAILED,
+            (
+                f"target profile directory mode {dir_mode:04o} "
+                f"does not match {DEFAULT_PROFILE_DIR_MODE:04o}: {profile_path.parent}"
+            ),
+            remediation=f"chmod {DEFAULT_PROFILE_DIR_MODE:04o} {profile_path.parent}",
+            reason="config-error",
+        )
+
+    if profile_stat.st_uid != expected_owner_uid:
+        return DoctorCheck(
+            "profile-permissions",
+            DoctorStatus.FAILED,
+            (
+                f"target profile owner uid {profile_stat.st_uid} "
+                f"does not match expected uid {expected_owner_uid}: {profile_path}"
+            ),
+            remediation=f"chown root:root {profile_path}",
+            reason="config-error",
+        )
+    file_mode = stat.S_IMODE(profile_stat.st_mode)
+    if file_mode != DEFAULT_PROFILE_FILE_MODE:
+        return DoctorCheck(
+            "profile-permissions",
+            DoctorStatus.FAILED,
+            (
+                f"target profile mode {file_mode:04o} "
+                f"does not match {DEFAULT_PROFILE_FILE_MODE:04o}: {profile_path}"
+            ),
+            remediation=f"chmod {DEFAULT_PROFILE_FILE_MODE:04o} {profile_path}",
+            reason="config-error",
+        )
+    return DoctorCheck(
+        "profile-permissions",
+        DoctorStatus.READY,
+        f"target profile owner and permissions are private: {profile_path}",
+    )
+
+
+def _check_managed_paths(
+    paths: DoctorPaths,
+    env: Mapping[str, str],
+    *,
+    managed: bool,
+) -> list[DoctorCheck]:
+    if not managed:
+        return []
+
+    managed_paths = paths.managed_paths or discover_managed_paths(env)
+    return [
+        _check_path_writable("artifact-root", managed_paths.artifact_root),
+        _check_path_writable("state-root", managed_paths.state_root),
+    ]
+
+
+def _check_path_writable(name: str, path: Path) -> DoctorCheck:
+    probe = path if path.exists() else _nearest_existing_parent(path)
+    if probe is None:
+        return DoctorCheck(
+            name,
+            DoctorStatus.FAILED,
+            f"no existing parent found for {path}",
+            remediation=f"create a writable parent for {path}",
+            reason="config-error",
+        )
+    if path.is_symlink():
+        return DoctorCheck(
+            name,
+            DoctorStatus.FAILED,
+            f"{path} is a symlink, not a managed directory",
+            remediation=f"replace {path} with a writable directory",
+            reason="config-error",
+        )
+    if path.exists() and not path.is_dir():
+        return DoctorCheck(
+            name,
+            DoctorStatus.FAILED,
+            f"{path} exists but is not a directory",
+            remediation=f"replace {path} with a writable directory",
+            reason="config-error",
+        )
+    if probe.is_symlink():
+        return DoctorCheck(
+            name,
+            DoctorStatus.FAILED,
+            f"nearest existing parent for {path} is a symlink: {probe}",
+            remediation=f"replace {probe} with a writable directory",
+            reason="config-error",
+        )
+    if not probe.is_dir():
+        return DoctorCheck(
+            name,
+            DoctorStatus.FAILED,
+            f"nearest existing parent for {path} is not a directory: {probe}",
+            remediation=f"replace {probe} with a writable directory",
+            reason="config-error",
+        )
+    if not os.access(probe, os.W_OK | os.X_OK):
+        return DoctorCheck(
+            name,
+            DoctorStatus.FAILED,
+            f"{path} is not writable by this user",
+            remediation=f"grant write access to {path}",
+            reason="config-error",
+        )
+    if path.exists():
+        return DoctorCheck(name, DoctorStatus.READY, f"{path} is writable")
+    return DoctorCheck(name, DoctorStatus.READY, f"{path} can be created")
+
+
+def _nearest_existing_parent(path: Path) -> Path | None:
+    current = path
+    while not current.exists() and not current.is_symlink():
+        parent = current.parent
+        if parent == current:
+            return None
+        current = parent
+    return current
+
+
+def _check_required_credentials(
+    target: str,
+    cfg: CodingAgentConfig,
+    profile: TargetProfile | None,
+    env: Mapping[str, str],
+    *,
+    managed: bool,
+) -> DoctorCheck:
+    if managed:
+        if target in _MANAGED_UNSUPPORTED_TARGETS:
+            return DoctorCheck(
+                "required-credentials",
+                DoctorStatus.BLOCKED,
+                _MANAGED_UNSUPPORTED_TARGETS[target],
+                remediation="verify a key-backed CLI auth contract before enabling this target",
+                reason="unsupported-key-backed-mode",
+            )
+        profile_env = profile.env if profile is not None else {}
+        personal_auth = _check_personal_auth(target, profile_env)
+        if personal_auth is not None:
+            return personal_auth
+        required_profile_vars = sorted({
+            name for name in cfg.required_env if name not in _NON_SECRET_REQUIRED_ENV
+        } | set(_MANAGED_PROFILE_REQUIRED_ENV.get(target, ())))
+        missing = [name for name in required_profile_vars if not profile_env.get(name)]
+        alternatives_groups = _managed_profile_alternatives(target, env)
+        for alternatives in alternatives_groups:
+            if not any(profile_env.get(name) for name in alternatives):
+                missing.append(" or ".join(alternatives))
+        if missing:
+            return DoctorCheck(
+                "required-credentials",
+                DoctorStatus.FAILED,
+                f"target profile is missing required credential variables: {', '.join(missing)}",
+                remediation="add the missing variables to the target profile",
+                reason="missing-secret",
+            )
+        placeholders = [
+            name
+            for name in required_profile_vars
+            if _looks_like_placeholder_secret(profile_env.get(name, ""))
+        ]
+        for alternatives in alternatives_groups:
+            placeholders.extend(
+                name
+                for name in alternatives
+                if profile_env.get(name) and _looks_like_placeholder_secret(profile_env[name])
+            )
+        if placeholders:
+            placeholder_names = ", ".join(placeholders)
+            return DoctorCheck(
+                "required-credentials",
+                DoctorStatus.FAILED,
+                f"target profile contains placeholder credential variables: {placeholder_names}",
+                remediation="replace placeholder values with real host-managed credentials",
+                reason="placeholder-secret",
+            )
+        missing_base = [
+            name
+            for name in cfg.required_env
+            if name in _NON_SECRET_REQUIRED_ENV and not env.get(name) and not profile_env.get(name)
+        ]
+        if missing_base:
+            return DoctorCheck(
+                "required-credentials",
+                DoctorStatus.FAILED,
+                f"environment is missing required operational variables: {', '.join(missing_base)}",
+                remediation="set the missing variables in the managed base environment",
+                reason="config-error",
+            )
+    else:
+        missing = [name for name in cfg.required_env if not env.get(name)]
+        if missing:
+            return DoctorCheck(
+                "required-credentials",
+                DoctorStatus.BLOCKED,
+                f"environment is missing required variables: {', '.join(missing)}",
+                remediation="export the missing variables before running quorum",
+                reason="missing-secret",
+            )
+    return DoctorCheck(
+        "required-credentials",
+        DoctorStatus.READY,
+        "required variables are available",
+    )
+
+
+def _check_personal_auth(target: str, profile_env: Mapping[str, str]) -> DoctorCheck | None:
+    if target == "gemini":
+        auth_type = (profile_env.get("GEMINI_AUTH_TYPE") or "gemini-api-key").strip()
+        if not auth_type:
+            auth_type = "gemini-api-key"
+        if auth_type == "oauth-personal":
+            return DoctorCheck(
+                "required-credentials",
+                DoctorStatus.BLOCKED,
+                "GEMINI_AUTH_TYPE=oauth-personal is personal auth and is not supported",
+                remediation="use GEMINI_AUTH_TYPE=gemini-api-key with GEMINI_API_KEY",
+                reason="personal-auth",
+            )
+        if auth_type != "gemini-api-key":
+            return DoctorCheck(
+                "required-credentials",
+                DoctorStatus.FAILED,
+                f"unsupported GEMINI_AUTH_TYPE: {auth_type}",
+                remediation="set GEMINI_AUTH_TYPE=gemini-api-key or omit it",
+                reason="config-error",
+            )
+
+    if target == "copilot":
+        personal_names = ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
+        present = [name for name in personal_names if profile_env.get(name)]
+        if present:
+            present_names = ", ".join(present)
+            return DoctorCheck(
+                "required-credentials",
+                DoctorStatus.BLOCKED,
+                f"Copilot GitHub-token auth is not supported on managed hosts: {present_names}",
+                remediation="use provider mode with COPILOT_PROVIDER_* credentials",
+                reason="personal-auth",
+            )
+
+    return None
+
+
+def _managed_profile_alternatives(
+    target: str,
+    env: Mapping[str, str],
+) -> tuple[tuple[str, ...], ...]:
+    alternatives = list(_MANAGED_PROFILE_ALTERNATIVES.get(target, ()))
+    if target == "copilot":
+        required_hook_env = _copilot_hook_env_references(env.get("SUPERPOWERS_ROOT", ""))
+        if required_hook_env:
+            alternatives.append(tuple(required_hook_env))
+    return tuple(alternatives)
+
+
+def _copilot_hook_env_references(superpowers_root: str) -> tuple[str, ...]:
+    if not superpowers_root:
+        return ()
+    root = Path(superpowers_root).expanduser()
+    refs: set[str] = set()
+    for rel in _COPILOT_HOOK_ENV_FILES:
+        path = root / rel
+        try:
+            if not path.is_file() or path.stat().st_size > 512_000:
+                continue
+            refs.update(_ENV_REFERENCE_RE.findall(path.read_text(errors="ignore")))
+        except OSError:
+            continue
+    return tuple(sorted(refs & _COPILOT_HOOK_ENV_NAMES))
+
+
+def _looks_like_placeholder_secret(value: str) -> bool:
+    normalized = value.strip().lower()
+    return normalized in {
+        "changeme",
+        "change-me",
+        "dummy",
+        "example",
+        "placeholder",
+        "redacted",
+        "replace-me",
+        "todo",
+    } or normalized.startswith("__quorum_doctor_placeholder_")
+
+
+def _check_binary(
+    cfg: CodingAgentConfig,
+    env: Mapping[str, str],
+    *,
+    managed: bool,
+) -> DoctorCheck:
+    path_value = env.get("PATH") or os.defpath
+    found = shutil.which(cfg.binary, path=path_value)
+    if found is None:
+        return DoctorCheck(
+            "local-tool",
+            DoctorStatus.FAILED if managed else DoctorStatus.BLOCKED,
+            f"required local tool is not on PATH: {cfg.binary}",
+            remediation=f"install {cfg.binary} or add it to PATH",
+            reason="missing-binary",
+        )
+    return DoctorCheck("local-tool", DoctorStatus.READY, f"found {cfg.binary} at {found}")
+
+
+def _check_context(coding_agents_dir: Path, cfg: CodingAgentConfig) -> DoctorCheck:
+    context = coding_agents_dir / f"{cfg.runtime_family}-context"
+    if not context.is_dir():
+        return DoctorCheck(
+            "context-directory",
+            DoctorStatus.FAILED,
+            f"required context directory missing: {context}",
+            remediation=f"add {context}",
+            reason="missing-repo-file",
+        )
+    return DoctorCheck("context-directory", DoctorStatus.READY, f"found {context}")
+
+
+def _check_home_skeleton(coding_agents_dir: Path, cfg: CodingAgentConfig) -> DoctorCheck:
+    skeleton = coding_agents_dir / f"{cfg.runtime_family}-home-skeleton"
+    if skeleton.exists() and not skeleton.is_dir():
+        return DoctorCheck(
+            "home-skeleton",
+            DoctorStatus.FAILED,
+            f"home skeleton path is not a directory: {skeleton}",
+            remediation=f"replace {skeleton} with a directory or remove it",
+            reason="config-error",
+        )
+    if skeleton.is_dir():
+        return DoctorCheck("home-skeleton", DoctorStatus.READY, f"found {skeleton}")
+    return DoctorCheck(
+        "home-skeleton",
+        DoctorStatus.READY,
+        f"no home skeleton required for runtime family {cfg.runtime_family}",
+    )
+
+
+def _check_superpowers_files(
+    target: str,
+    cfg: CodingAgentConfig,
+    env: Mapping[str, str],
+    *,
+    managed: bool,
+) -> DoctorCheck:
+    required = _SUPERPOWERS_REQUIRED_FILES.get(target) or _SUPERPOWERS_REQUIRED_FILES.get(
+        cfg.runtime_family,
+        ("skills/using-superpowers/SKILL.md",),
+    )
+    root_text = env.get("SUPERPOWERS_ROOT", "")
+    if not root_text:
+        return DoctorCheck(
+            "superpowers-files",
+            DoctorStatus.FAILED if managed else DoctorStatus.BLOCKED,
+            "SUPERPOWERS_ROOT is not set",
+            remediation="set SUPERPOWERS_ROOT to the Superpowers checkout",
+            reason="missing-repo-file",
+        )
+    root = Path(root_text).expanduser()
+    missing = [rel for rel in required if not (root / rel).is_file()]
+    if missing:
+        return DoctorCheck(
+            "superpowers-files",
+            DoctorStatus.FAILED,
+            "SUPERPOWERS_ROOT is missing required files: " + ", ".join(missing),
+            remediation=f"point SUPERPOWERS_ROOT at a complete Superpowers checkout: {root}",
+            reason="missing-repo-file",
+        )
+    return DoctorCheck(
+        "superpowers-files",
+        DoctorStatus.READY,
+        f"required Superpowers files found under {root}",
+    )
+
+
+def _check_sentinel(paths: DoctorPaths, target: str) -> DoctorCheck:
+    try:
+        entries = build_matrix(
+            scenarios_root=paths.scenarios_root,
+            coding_agents_dir=paths.coding_agents_dir,
+            agent_filter=[target],
+            tier_filter="sentinel",
+            include_drafts=False,
+        )
+    except ValueError as exc:
+        return DoctorCheck(
+            "sentinel-scenario",
+            DoctorStatus.FAILED,
+            f"could not build sentinel matrix: {exc}",
+            remediation="fix scenario metadata or coding-agent configuration",
+            reason="config-error",
+        )
+    runnable = [entry.scenario for entry in entries if entry.runnable]
+    if not runnable:
+        return DoctorCheck(
+            "sentinel-scenario",
+            DoctorStatus.FAILED,
+            f"no runnable sentinel scenario found for target {target}",
+            remediation="add a ready quorum_tier: sentinel scenario for this target",
+            reason="missing-repo-file",
+        )
+    return DoctorCheck(
+        "sentinel-scenario",
+        DoctorStatus.READY,
+        f"runnable sentinel scenario available: {runnable[0]}",
+    )

--- a/quorum/kimi.py
+++ b/quorum/kimi.py
@@ -40,8 +40,11 @@ _SENSITIVE_ENV_NAME_PARTS = ("KEY", "TOKEN", "SECRET", "PASSWORD")
 _MIN_SENSITIVE_VALUE_LEN = 6
 
 
-def resolve_kimi_binary(binary: str) -> str:
-    resolved = shutil.which(binary)
+def resolve_kimi_binary(binary: str, env: Mapping[str, str] | None = None) -> str:
+    if env is None:
+        resolved = shutil.which(binary)
+    else:
+        resolved = shutil.which(binary, path=env.get("PATH", os.defpath))
     if resolved is None:
         raise KimiConfigError(f"{binary!r} not found on PATH; cannot run Kimi evals")
     return resolved

--- a/quorum/locks.py
+++ b/quorum/locks.py
@@ -1,0 +1,400 @@
+from __future__ import annotations
+
+import errno
+import fcntl
+import getpass
+import json
+import os
+import re
+import socket
+import tempfile
+from collections.abc import Mapping, Sequence
+from contextlib import suppress
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import IO, cast
+
+from quorum.managed_state import ManagedPaths
+
+_SCHEMA_VERSION = 1
+_LOCK_PREFIX_ORDER = {"global": 0, "checkout": 1, "provider": 2, "target": 3}
+_REQUIRES_LOCK_DETAIL = {"provider", "target"}
+_JOB_ID_RE = re.compile(r"^job-\d{8}T\d{6}Z-[0-9a-f]{4}$")
+_SAFE_NAME_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyz"
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "0123456789"
+    "._:-"
+    "-"
+)
+
+
+@dataclass(frozen=True)
+class LockRequest:
+    name: str
+    exclusive: bool = True
+
+
+@dataclass(frozen=True)
+class LockHolder:
+    lock_name: str
+    job_id: str
+    pid: int
+    hostname: str
+    started_at: datetime
+    command: list[str]
+    user: str | None = None
+
+    def to_json(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "schema_version": _SCHEMA_VERSION,
+            "lock_name": self.lock_name,
+            "job_id": self.job_id,
+            "pid": self.pid,
+            "hostname": self.hostname,
+            "started_at": _format_datetime(self.started_at),
+            "command": self.command,
+        }
+        if self.user is not None:
+            payload["user"] = self.user
+        return payload
+
+
+@dataclass(frozen=True)
+class ManagedLock:
+    name: str
+    path: Path
+    sidecar_path: Path
+    exclusive: bool
+    _file: IO[str]
+
+
+@dataclass(frozen=True)
+class Cooldown:
+    provider: str
+    reason: str
+    until: datetime
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "provider": self.provider,
+            "reason": self.reason,
+            "until": _format_datetime(self.until),
+        }
+
+
+class LockConflict(RuntimeError):
+    def __init__(
+        self,
+        *,
+        lock_name: str,
+        lock_path: Path,
+        holder: LockHolder | None,
+        requested_job_id: str,
+        command: Sequence[str],
+        wait: bool,
+    ) -> None:
+        super().__init__(f"lock conflict for {lock_name}")
+        self.lock_name = lock_name
+        self.lock_path = lock_path
+        self.holder = holder
+        self.requested_job_id = requested_job_id
+        self.command = list(command)
+        self.wait = wait
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "error": "lock-conflict",
+            "lock_name": self.lock_name,
+            "lock_path": str(self.lock_path),
+            "holder": self.holder.to_json() if self.holder is not None else None,
+            "requested_job_id": self.requested_job_id,
+            "command": self.command,
+            "wait": self.wait,
+        }
+
+
+def acquire_locks(
+    paths: ManagedPaths,
+    requests: Sequence[LockRequest],
+    job_id: str,
+    command: Sequence[str],
+    wait: bool = False,
+) -> list[ManagedLock]:
+    _validate_job_id(job_id)
+    held: list[ManagedLock] = []
+    try:
+        for request in sorted(requests, key=_lock_request_sort_key):
+            held.append(_acquire_one(paths, request, job_id, command, wait=wait))
+    except BaseException:
+        release_locks(held)
+        raise
+    return held
+
+
+def release_locks(held: Sequence[ManagedLock]) -> None:
+    for lock in reversed(held):
+        try:
+            lock.sidecar_path.unlink(missing_ok=True)
+        finally:
+            try:
+                fcntl.flock(lock._file.fileno(), fcntl.LOCK_UN)
+            finally:
+                lock._file.close()
+
+
+def read_lock_holder(paths: ManagedPaths, lock_name: str) -> LockHolder | None:
+    for sidecar_path in _sidecar_paths(paths, lock_name):
+        try:
+            return _lock_holder_from_json(json.loads(sidecar_path.read_text()))
+        except (FileNotFoundError, TypeError, ValueError, json.JSONDecodeError):
+            continue
+    return None
+
+
+def write_cooldown(paths: ManagedPaths, provider: str, reason: str, until: datetime) -> None:
+    cooldown = Cooldown(
+        provider=_validate_cooldown_name(provider),
+        reason=reason,
+        until=_to_utc(until),
+    )
+    paths.cooldowns_dir.mkdir(parents=True, exist_ok=True)
+    _write_json_atomic(paths.cooldowns_dir / f"{cooldown.provider}.json", cooldown.to_json())
+
+
+def read_active_cooldowns(paths: ManagedPaths, now: datetime) -> list[Cooldown]:
+    active: list[Cooldown] = []
+    current = _to_utc(now)
+    if not paths.cooldowns_dir.exists():
+        return active
+
+    for path in sorted(paths.cooldowns_dir.glob("*.json")):
+        provider = path.name.removesuffix(".json")
+        try:
+            _validate_cooldown_name(provider)
+            cooldown = _cooldown_from_json(json.loads(path.read_text()))
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            continue
+        if cooldown.until <= current:
+            path.unlink(missing_ok=True)
+            continue
+        active.append(cooldown)
+
+    active.sort(key=lambda cooldown: cooldown.provider)
+    return active
+
+
+def _acquire_one(
+    paths: ManagedPaths,
+    request: LockRequest,
+    job_id: str,
+    command: Sequence[str],
+    *,
+    wait: bool,
+) -> ManagedLock:
+    lock_name = _validate_lock_name(request.name)
+    paths.locks_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = paths.locks_dir / f"{lock_name}.lock"
+    sidecar_path = _holder_sidecar_path(paths, lock_name, job_id)
+    file = _open_lock_file(lock_path)
+    flags = fcntl.LOCK_EX if request.exclusive else fcntl.LOCK_SH
+    if not wait:
+        flags |= fcntl.LOCK_NB
+
+    try:
+        fcntl.flock(file.fileno(), flags)
+    except OSError as exc:
+        file.close()
+        if exc.errno in {errno.EACCES, errno.EAGAIN}:
+            raise LockConflict(
+                lock_name=lock_name,
+                lock_path=lock_path,
+                holder=read_lock_holder(paths, lock_name),
+                requested_job_id=job_id,
+                command=command,
+                wait=wait,
+            ) from exc
+        raise
+
+    holder = LockHolder(
+        lock_name=lock_name,
+        job_id=job_id,
+        pid=os.getpid(),
+        hostname=socket.gethostname(),
+        started_at=datetime.now(UTC),
+        command=list(command),
+        user=getpass.getuser(),
+    )
+    try:
+        _write_json_atomic(sidecar_path, holder.to_json())
+    except BaseException:
+        try:
+            fcntl.flock(file.fileno(), fcntl.LOCK_UN)
+        finally:
+            file.close()
+        raise
+    return ManagedLock(
+        name=lock_name,
+        path=lock_path,
+        sidecar_path=sidecar_path,
+        exclusive=request.exclusive,
+        _file=file,
+    )
+
+
+def _open_lock_file(path: Path) -> IO[str]:
+    fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o660)
+    with suppress(OSError):
+        os.chmod(path, 0o660)
+    return os.fdopen(fd, "r+")
+
+
+def _lock_request_sort_key(request: LockRequest) -> tuple[int, str]:
+    name = _validate_lock_name(request.name)
+    prefix = name.split(":", maxsplit=1)[0]
+    return (_LOCK_PREFIX_ORDER[prefix], name)
+
+
+def _lock_path(paths: ManagedPaths, lock_name: str) -> Path:
+    return paths.locks_dir / f"{_validate_lock_name(lock_name)}.lock"
+
+
+def _sidecar_path(paths: ManagedPaths, lock_name: str) -> Path:
+    return _lock_path(paths, lock_name).with_suffix(".json")
+
+
+def _holder_sidecar_path(paths: ManagedPaths, lock_name: str, job_id: str) -> Path:
+    return paths.locks_dir / f"{_validate_lock_name(lock_name)}.{_validate_job_id(job_id)}.json"
+
+
+def _sidecar_paths(paths: ManagedPaths, lock_name: str) -> list[Path]:
+    base = _sidecar_path(paths, lock_name)
+    if not paths.locks_dir.exists():
+        return []
+    return sorted([base, *paths.locks_dir.glob(f"{_validate_lock_name(lock_name)}.job-*.json")])
+
+
+def _write_json_atomic(destination: Path, payload: Mapping[str, object]) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    data = json.dumps(dict(payload), indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+        dir=destination.parent,
+        text=True,
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w") as tmp:
+            tmp.write(data)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        os.replace(tmp_path, destination)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def _validate_lock_name(name: str) -> str:
+    if not _is_safe_name(name):
+        raise ValueError(f"invalid lock name: {name}")
+    parts = name.split(":")
+    prefix = parts[0]
+    if prefix not in _LOCK_PREFIX_ORDER:
+        raise ValueError(f"invalid lock name: {name}")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise ValueError(f"invalid lock name: {name}")
+    if prefix in _REQUIRES_LOCK_DETAIL and len(parts) == 1:
+        raise ValueError(f"invalid lock name: {name}")
+    return name
+
+
+def _validate_cooldown_name(name: str) -> str:
+    if not _is_safe_name(name):
+        raise ValueError(f"invalid cooldown name: {name}")
+    return name
+
+
+def _is_safe_name(name: str) -> bool:
+    if not name or name in {".", ".."}:
+        return False
+    if any(char not in _SAFE_NAME_CHARS for char in name):
+        return False
+    if ".." in name.split(":"):
+        return False
+    return not Path(name).is_absolute()
+
+
+def _validate_job_id(job_id: str) -> str:
+    if _JOB_ID_RE.fullmatch(job_id) is None:
+        raise ValueError(f"invalid managed job id: {job_id}")
+    return job_id
+
+
+def _lock_holder_from_json(data: object) -> LockHolder:
+    if not isinstance(data, dict):
+        raise ValueError("lock holder JSON must be an object")
+    raw = cast(dict[str, object], data)
+    return LockHolder(
+        lock_name=_validate_lock_name(_required_str(raw.get("lock_name"), "lock_name")),
+        job_id=_validate_job_id(_required_str(raw.get("job_id"), "job_id")),
+        pid=_required_int(raw.get("pid"), "pid"),
+        hostname=_required_str(raw.get("hostname"), "hostname"),
+        started_at=_parse_datetime(raw.get("started_at")),
+        command=_string_list(raw.get("command"), "command"),
+        user=_optional_str(raw.get("user"), "user"),
+    )
+
+
+def _cooldown_from_json(data: object) -> Cooldown:
+    if not isinstance(data, dict):
+        raise ValueError("cooldown JSON must be an object")
+    raw = cast(dict[str, object], data)
+    provider = _validate_cooldown_name(_required_str(raw.get("provider"), "provider"))
+    return Cooldown(
+        provider=provider,
+        reason=_required_str(raw.get("reason"), "reason"),
+        until=_parse_datetime(raw.get("until")),
+    )
+
+
+def _required_str(value: object, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    return value
+
+
+def _optional_str(value: object, field_name: str) -> str | None:
+    if value is None:
+        return None
+    return _required_str(value, field_name)
+
+
+def _required_int(value: object, field_name: str) -> int:
+    if not isinstance(value, int):
+        raise ValueError(f"{field_name} must be an integer")
+    return value
+
+
+def _string_list(value: object, field_name: str) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"{field_name} must be a list of strings")
+    return cast(list[str], value)
+
+
+def _parse_datetime(value: object) -> datetime:
+    if not isinstance(value, str):
+        raise ValueError("datetime value must be a string")
+    return _to_utc(datetime.fromisoformat(value.replace("Z", "+00:00")))
+
+
+def _format_datetime(value: datetime) -> str:
+    return _to_utc(value).isoformat().replace("+00:00", "Z")
+
+
+def _to_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)

--- a/quorum/managed_commands.py
+++ b/quorum/managed_commands.py
@@ -37,6 +37,14 @@ from quorum.managed_state import (
 from quorum.run_all import ChildResult, MatrixEntry, run_batch
 from quorum.runner import ANTIGRAVITY_RATE_LIMIT_MARKER, _allocate_run_dir, run_scenario_in_dir
 from quorum.runtime_env import TargetProfile, build_managed_env, load_target_profile
+from quorum.secret_scan import (
+    SecretPattern,
+    SecretScanResult,
+    build_secret_patterns,
+    scan_job_artifacts,
+    scan_path_for_secrets,
+    taint_job_on_secret_match,
+)
 
 TERMINAL_STATES = frozenset({"succeeded", "failed", "interrupted"})
 ACTIVE_STATES = frozenset({"planned", "running"})
@@ -63,6 +71,7 @@ PROVIDER_BY_TARGET = {
     "pi": "pi",
 }
 RATE_LIMIT_SKIP_SENTINEL = "agy-rate-limit-skip"
+ABORT_SKIP_SENTINEL = "batch-abort-skip"
 TMUX_WORKER_ENV_ALLOWLIST = (
     "PATH",
     "HOME",
@@ -151,6 +160,11 @@ class TmuxSupervisor:
             supervisor={"kind": "tmux", "session": session},
             exit_code=None,
         )
+
+
+class _SecretScanTainted(RuntimeError):
+    def __init__(self) -> None:
+        super().__init__("secret-like material detected in managed artifacts")
 
 
 def create_job(
@@ -292,6 +306,7 @@ def run_managed_worker(job_id: str, paths: ManagedPaths, env: Mapping[str, str])
     worker_env = dict(env)
     worker_env["QUORUM_MANAGED_WORKER"] = "1"
     job = mark_job_state(paths, job_id, "running")
+    secret_patterns = _secret_patterns_for_job(job, worker_env)
     append_event(
         paths,
         job.id,
@@ -322,6 +337,26 @@ def run_managed_worker(job_id: str, paths: ManagedPaths, env: Mapping[str, str])
             failure_reason="worker interrupted",
         )
         return 130
+    except _SecretScanTainted:
+        append_event(
+            paths,
+            job.id,
+            {
+                "event": "worker-tainted",
+                "job_id": job.id,
+                "exit_code": 1,
+            },
+        )
+        current = read_job(paths, job.id)
+        if current.state == "running":
+            mark_job_state(
+                paths,
+                job.id,
+                "failed",
+                final_exit_code=1,
+                failure_reason="secret-like material detected in managed artifacts",
+            )
+        return 1
     except BaseException as exc:
         exit_code = _exit_code(exc)
         failure_reason = _failure_reason(exc)
@@ -335,16 +370,19 @@ def run_managed_worker(job_id: str, paths: ManagedPaths, env: Mapping[str, str])
                 "failure_reason": failure_reason,
             },
         )
-        mark_job_state(
+        failed = mark_job_state(
             paths,
             job.id,
             "failed",
             final_exit_code=exit_code,
             failure_reason=failure_reason,
         )
+        _taint_job_if_secret_match(paths, failed.id, secret_patterns)
         return exit_code
 
     if exit_code == 0:
+        if _fail_job_if_secret_match(paths, job.id, secret_patterns):
+            return 1
         append_event(
             paths,
             job.id,
@@ -375,6 +413,7 @@ def run_managed_worker(job_id: str, paths: ManagedPaths, env: Mapping[str, str])
         final_exit_code=exit_code,
         failure_reason=failure_reason,
     )
+    _taint_job_if_secret_match(paths, job.id, secret_patterns)
     return exit_code
 
 
@@ -413,6 +452,7 @@ def tail_job(
 def _execute_smoke(job: ManagedJob, paths: ManagedPaths, env: Mapping[str, str]) -> int:
     target = _single_target(job)
     opts = _parse_managed_options(job.command[2:])
+    secret_patterns = _secret_patterns_for_job(job, env)
     scenarios_root = Path(_str_option(opts, "scenarios_root", "scenarios"))
     coding_agents_dir = Path(_str_option(opts, "coding_agents_dir", "coding-agents"))
     out_root = Path(_str_option(opts, "out_root", str(paths.artifact_root)))
@@ -462,6 +502,7 @@ def _execute_smoke(job: ManagedJob, paths: ManagedPaths, env: Mapping[str, str])
             },
         )
         _update_job(paths, job.id, result_rollup=_rollup_children(read_job(paths, job.id).children))
+        _raise_if_artifact_secret_match(paths, job.id, [run_dir], secret_patterns)
         return 0
     finally:
         release_locks(held)
@@ -497,8 +538,10 @@ def _execute_batch_like(
     _fail_on_active_cooldowns(paths, job, targets)
     held = _acquire_job_locks(paths, job, locks)
     state_lock = threading.Lock()
+    abort_event = threading.Event()
     current_batch: dict[str, str] = {}
     batch_out_root = Path(str(opts.get("out_root") or paths.artifact_root)).resolve()
+    secret_patterns = _secret_patterns_for_job(job, env)
     try:
         _update_job(paths, job.id, locks=[lock.name for lock in held])
 
@@ -536,15 +579,18 @@ def _execute_batch_like(
             )
 
         def on_child_finished(child_id: str, result: ChildResult) -> None:
-            _record_child_finished(
+            tainted = _record_child_finished(
                 paths,
                 job.id,
                 child_id,
                 result,
                 artifact_root=batch_out_root,
                 batch=current_batch,
+                secret_patterns=secret_patterns,
                 lock=state_lock,
             )
+            if tainted:
+                abort_event.set()
 
         batch_dir = run_batch(
             scenarios_root=Path(str(opts.get("scenarios_root") or "scenarios")).resolve(),
@@ -565,6 +611,7 @@ def _execute_batch_like(
             on_batch_allocated=on_batch_allocated,
             on_child_started=on_child_started,
             on_child_finished=on_child_finished,
+            abort_event=abort_event,
         )
         _upsert_child(
             paths,
@@ -579,6 +626,10 @@ def _execute_batch_like(
             lock=state_lock,
         )
         _update_job(paths, job.id, result_rollup=_rollup_children(read_job(paths, job.id).children))
+        if _taint_job_if_artifact_secret_match(paths, job.id, [batch_dir], secret_patterns):
+            abort_event.set()
+        if abort_event.is_set():
+            raise _SecretScanTainted()
         return 0
     finally:
         release_locks(held)
@@ -590,6 +641,104 @@ def _run_executor(job: ManagedJob, paths: ManagedPaths, env: Mapping[str, str]) 
     if executor is None:
         raise NotImplementedError(f"managed job kind {kind!r} is not implemented yet")
     return executor(job, paths, env)
+
+
+def _secret_patterns_for_job(job: ManagedJob, env: Mapping[str, str]) -> list[SecretPattern]:
+    patterns = build_secret_patterns(TargetProfile(target="managed", path=None, env={}))
+    profile_root = env.get("QUORUM_TARGET_PROFILE_ROOT")
+    if profile_root:
+        for target in _targets_for_secret_scan(job):
+            try:
+                profile = load_target_profile(Path(profile_root), target)
+            except runtime_env.TargetProfileError:
+                continue
+            patterns.extend(build_secret_patterns(profile))
+    return _dedupe_secret_patterns(patterns)
+
+
+def _targets_for_secret_scan(job: ManagedJob) -> list[str]:
+    targets = list(job.coding_agents)
+    if not targets:
+        targets = _targets_from_options_or_job(_parse_managed_options(job.command[2:]), job)
+    return sorted(set(targets))
+
+
+def _dedupe_secret_patterns(patterns: Sequence[SecretPattern]) -> list[SecretPattern]:
+    deduped: list[SecretPattern] = []
+    seen: set[tuple[str, bytes]] = set()
+    for pattern in patterns:
+        key = (pattern.name, pattern.regex.pattern)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(pattern)
+    return deduped
+
+
+def _taint_job_if_secret_match(
+    paths: ManagedPaths,
+    job_id: str,
+    patterns: Sequence[SecretPattern],
+) -> bool:
+    job = read_job(paths, job_id)
+    result = scan_job_artifacts(job, patterns, paths)
+    taint_job_on_secret_match(paths, job, result)
+    return result.found
+
+
+def _fail_job_if_secret_match(
+    paths: ManagedPaths,
+    job_id: str,
+    patterns: Sequence[SecretPattern],
+) -> bool:
+    if not _taint_job_if_secret_match(paths, job_id, patterns):
+        return False
+    append_event(
+        paths,
+        job_id,
+        {
+            "event": "worker-tainted",
+            "job_id": job_id,
+            "exit_code": 1,
+        },
+    )
+    mark_job_state(
+        paths,
+        job_id,
+        "failed",
+        final_exit_code=1,
+        failure_reason="secret-like material detected in managed artifacts",
+    )
+    return True
+
+
+def _taint_job_if_artifact_secret_match(
+    paths: ManagedPaths,
+    job_id: str,
+    artifact_paths: Sequence[Path],
+    patterns: Sequence[SecretPattern],
+) -> bool:
+    matches = []
+    for artifact_path in artifact_paths:
+        matches.extend(scan_path_for_secrets(artifact_path, patterns).matches)
+    if not matches:
+        return False
+    taint_job_on_secret_match(
+        paths,
+        read_job(paths, job_id),
+        SecretScanResult(matches=matches),
+    )
+    return True
+
+
+def _raise_if_artifact_secret_match(
+    paths: ManagedPaths,
+    job_id: str,
+    artifact_paths: Sequence[Path],
+    patterns: Sequence[SecretPattern],
+) -> None:
+    if _taint_job_if_artifact_secret_match(paths, job_id, artifact_paths, patterns):
+        raise _SecretScanTainted()
 
 
 def _parse_managed_options(args: Sequence[str]) -> dict[str, str | bool]:
@@ -753,8 +902,9 @@ def _record_child_finished(
     *,
     artifact_root: Path,
     batch: Mapping[str, str],
+    secret_patterns: Sequence[SecretPattern],
     lock: threading.Lock,
-) -> None:
+) -> bool:
     skipped_reason = _skipped_reason(result)
     if skipped_reason is not None:
         _upsert_child(
@@ -770,7 +920,7 @@ def _record_child_finished(
             },
             lock=lock,
         )
-        return
+        return False
 
     final = _final_for_child_result(result, artifact_root)
     child: dict[str, object] = {
@@ -808,11 +958,21 @@ def _record_child_finished(
             },
             lock=lock,
         )
+    if result.run_id is not None:
+        return _taint_job_if_artifact_secret_match(
+            paths,
+            job_id,
+            [artifact_root / result.run_id],
+            secret_patterns,
+        )
+    return False
 
 
 def _skipped_reason(result: ChildResult) -> str | None:
     if result.error == RATE_LIMIT_SKIP_SENTINEL:
         return "rate-limited"
+    if result.error == ABORT_SKIP_SENTINEL:
+        return "aborted"
     prefix = "skipped:"
     if isinstance(result.error, str) and result.error.startswith(prefix):
         return result.error[len(prefix) :] or "skipped"

--- a/quorum/managed_commands.py
+++ b/quorum/managed_commands.py
@@ -1,16 +1,28 @@
 from __future__ import annotations
 
 import getpass
+import json
 import os
 import socket
 import subprocess
+import threading
 import time
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, replace
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol, cast
 
+from quorum import runtime_env
+from quorum.locks import (
+    LockConflict,
+    LockRequest,
+    ManagedLock,
+    acquire_locks,
+    read_active_cooldowns,
+    release_locks,
+    write_cooldown,
+)
 from quorum.managed_state import (
     ManagedJob,
     ManagedPaths,
@@ -22,10 +34,52 @@ from quorum.managed_state import (
     read_job,
     write_job_atomic,
 )
+from quorum.run_all import ChildResult, MatrixEntry, run_batch
+from quorum.runner import ANTIGRAVITY_RATE_LIMIT_MARKER, _allocate_run_dir, run_scenario_in_dir
+from quorum.runtime_env import TargetProfile, build_managed_env, load_target_profile
 
 TERMINAL_STATES = frozenset({"succeeded", "failed", "interrupted"})
 ACTIVE_STATES = frozenset({"planned", "running"})
 WORKER_EXECUTORS: dict[str, Callable[[ManagedJob, ManagedPaths, Mapping[str, str]], int]] = {}
+SMOKE_SCENARIO_FALLBACK = "00-quorum-smoke-hello-world"
+TARGET_SMOKE_SCENARIOS = {
+    "antigravity": "antigravity-superpowers-bootstrap",
+    "copilot": "copilot-superpowers-bootstrap",
+    "gemini": "gemini-superpowers-bootstrap",
+    "kimi": "kimi-superpowers-bootstrap",
+    "opencode": "opencode-superpowers-bootstrap",
+    "pi": "pi-superpowers-bootstrap",
+}
+PROVIDER_BY_TARGET = {
+    "antigravity": "gemini",
+    "claude": "anthropic",
+    "claude-haiku": "anthropic",
+    "claude-sonnet": "anthropic",
+    "codex": "openai",
+    "copilot": "github-copilot",
+    "gemini": "gemini",
+    "kimi": "kimi",
+    "opencode": "openai",
+    "pi": "pi",
+}
+RATE_LIMIT_SKIP_SENTINEL = "agy-rate-limit-skip"
+TMUX_WORKER_ENV_ALLOWLIST = (
+    "PATH",
+    "HOME",
+    "TMPDIR",
+    "LANG",
+    "LC_ALL",
+    "QUORUM_MANAGED_HOST",
+    "QUORUM_TARGET_PROFILE_ROOT",
+    "SUPERPOWERS_ROOT",
+)
+WORKER_TOKEN_WRAPPER = (
+    'if [ -r "$1" ]; then '
+    'QUORUM_MANAGED_WORKER_TOKEN="$(cat "$1")"; '
+    "export QUORUM_MANAGED_WORKER_TOKEN; "
+    "fi; "
+    'shift; exec "$@"'
+)
 
 
 @dataclass(frozen=True)
@@ -69,6 +123,7 @@ class InlineSupervisor:
 @dataclass(frozen=True)
 class TmuxSupervisor:
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run
+    env: Mapping[str, str] | None = None
 
     def start(
         self,
@@ -104,6 +159,12 @@ def create_job(
     args: Sequence[str],
     paths: ManagedPaths,
     owner: str | None,
+    *,
+    coding_agents: Sequence[str] | None = None,
+    tier: str | None = None,
+    include_drafts: bool | None = None,
+    scenario_filter: str | None = None,
+    extra: Mapping[str, object] | None = None,
 ) -> ManagedJob:
     now = datetime.now(UTC)
     job_id = new_job_id(now, kind, target)
@@ -120,9 +181,15 @@ def create_job(
         host=socket.gethostname(),
         command=command,
         managed_command=kind,
-        coding_agents=[target] if target else [],
+        coding_agents=(
+            list(coding_agents) if coding_agents is not None else ([target] if target else [])
+        ),
+        tier=tier,
+        include_drafts=include_drafts,
+        scenario_filter=scenario_filter,
         out_root=str(paths.artifact_root),
         log_path=str(paths.state_root / "logs" / f"{job_id}.log"),
+        extra=dict(extra or {}),
     )
     write_job_atomic(paths, job)
     append_event(
@@ -140,7 +207,12 @@ def create_job(
 
 
 def start_job(job: ManagedJob, paths: ManagedPaths, supervisor: Supervisor) -> StartResult:
-    command = _worker_command(job.id, paths)
+    command = _worker_command(
+        job.id,
+        paths,
+        env=_worker_command_env(supervisor),
+        read_worker_token=isinstance(supervisor, TmuxSupervisor),
+    )
     supervisor_info = _supervisor_info(supervisor, job.id)
     write_job_atomic(
         paths,
@@ -338,6 +410,180 @@ def tail_job(
     yield from _tail_sources(sources, managed_paths, job_id, follow)
 
 
+def _execute_smoke(job: ManagedJob, paths: ManagedPaths, env: Mapping[str, str]) -> int:
+    target = _single_target(job)
+    opts = _parse_managed_options(job.command[2:])
+    scenarios_root = Path(_str_option(opts, "scenarios_root", "scenarios"))
+    coding_agents_dir = Path(_str_option(opts, "coding_agents_dir", "coding-agents"))
+    out_root = Path(_str_option(opts, "out_root", str(paths.artifact_root)))
+    scenario_dir = _smoke_scenario_dir(scenarios_root, target)
+    run_dir = _allocate_run_dir(
+        out_root=out_root,
+        scenario_name=scenario_dir.name,
+        coding_agent=target,
+    )
+    child_id = "child-0001"
+    locks = _lock_requests_for_targets([target])
+    _fail_on_active_cooldowns(paths, job, [target])
+    held = _acquire_job_locks(paths, job, locks)
+    try:
+        _update_job(paths, job.id, locks=[lock.name for lock in held])
+        _upsert_child(
+            paths,
+            job.id,
+            {
+                "id": child_id,
+                "kind": "run",
+                "target": target,
+                "coding_agent": target,
+                "scenario": scenario_dir.name,
+                "run_id": run_dir.name,
+                "run_dir": str(run_dir),
+                "state": "running",
+            },
+        )
+        _run_dir, verdict = run_scenario_in_dir(
+            run_dir=run_dir,
+            scenario_dir=scenario_dir,
+            coding_agent=target,
+            coding_agents_dir=coding_agents_dir,
+            out_root=out_root,
+            env_base=_managed_env_for_target(target, paths, env),
+        )
+        _upsert_child(
+            paths,
+            job.id,
+            {
+                "id": child_id,
+                "run_id": run_dir.name,
+                "run_dir": str(run_dir),
+                "state": "finished",
+                "final": verdict.final,
+            },
+        )
+        _update_job(paths, job.id, result_rollup=_rollup_children(read_job(paths, job.id).children))
+        return 0
+    finally:
+        release_locks(held)
+
+
+def _execute_column(job: ManagedJob, paths: ManagedPaths, env: Mapping[str, str]) -> int:
+    target = _single_target(job)
+    opts = _parse_managed_options(job.command[2:])
+    opts.setdefault("jobs", "1")
+    opts["coding_agents"] = target
+    opts.setdefault("tier", "sentinel")
+    return _execute_batch_like(job, paths, env, opts, targets=[target])
+
+
+def _execute_batch(job: ManagedJob, paths: ManagedPaths, env: Mapping[str, str]) -> int:
+    opts = _parse_managed_options(job.command[2:])
+    targets = _targets_from_options_or_job(opts, job)
+    opts.setdefault("tier", "sentinel")
+    return _execute_batch_like(job, paths, env, opts, targets=targets)
+
+
+def _execute_batch_like(
+    job: ManagedJob,
+    paths: ManagedPaths,
+    env: Mapping[str, str],
+    opts: Mapping[str, str | bool],
+    *,
+    targets: Sequence[str],
+) -> int:
+    if not targets:
+        raise ValueError("managed batch requires at least one target")
+    locks = _lock_requests_for_targets(targets, broad_batch=len(targets) != 1)
+    _fail_on_active_cooldowns(paths, job, targets)
+    held = _acquire_job_locks(paths, job, locks)
+    state_lock = threading.Lock()
+    current_batch: dict[str, str] = {}
+    batch_out_root = Path(str(opts.get("out_root") or paths.artifact_root)).resolve()
+    try:
+        _update_job(paths, job.id, locks=[lock.name for lock in held])
+
+        def on_batch_allocated(batch_dir: Path) -> None:
+            current_batch["batch_id"] = batch_dir.name
+            current_batch["batch_dir"] = str(batch_dir)
+            _upsert_child(
+                paths,
+                job.id,
+                {
+                    "id": "batch",
+                    "kind": "batch",
+                    "batch_id": batch_dir.name,
+                    "batch_dir": str(batch_dir),
+                    "state": "running",
+                },
+                lock=state_lock,
+            )
+
+        def on_child_started(child_id: str, entry: MatrixEntry, command: list[str]) -> None:
+            _upsert_child(
+                paths,
+                job.id,
+                {
+                    "id": child_id,
+                    "kind": "run",
+                    "target": entry.coding_agent,
+                    "coding_agent": entry.coding_agent,
+                    "scenario": entry.scenario,
+                    "command": command,
+                    **current_batch,
+                    "state": "running",
+                },
+                lock=state_lock,
+            )
+
+        def on_child_finished(child_id: str, result: ChildResult) -> None:
+            _record_child_finished(
+                paths,
+                job.id,
+                child_id,
+                result,
+                artifact_root=batch_out_root,
+                batch=current_batch,
+                lock=state_lock,
+            )
+
+        batch_dir = run_batch(
+            scenarios_root=Path(str(opts.get("scenarios_root") or "scenarios")).resolve(),
+            coding_agents_dir=Path(str(opts.get("coding_agents_dir") or "coding-agents")).resolve(),
+            out_root=batch_out_root,
+            jobs=int(str(opts.get("jobs") or "1")),
+            agent_filter=list(targets),
+            scenario_filter=_csv_option(opts.get("scenarios")),
+            tier=str(opts.get("tier") or "sentinel"),
+            include_drafts=bool(opts.get("include_drafts")),
+            use_cursor=False,
+            env_base=_managed_env_for_target(
+                _batch_env_target(targets),
+                paths,
+                env,
+                include_worker_token=True,
+            ),
+            on_batch_allocated=on_batch_allocated,
+            on_child_started=on_child_started,
+            on_child_finished=on_child_finished,
+        )
+        _upsert_child(
+            paths,
+            job.id,
+            {
+                "id": "batch",
+                "kind": "batch",
+                "batch_id": batch_dir.name,
+                "batch_dir": str(batch_dir),
+                "state": "finished",
+            },
+            lock=state_lock,
+        )
+        _update_job(paths, job.id, result_rollup=_rollup_children(read_job(paths, job.id).children))
+        return 0
+    finally:
+        release_locks(held)
+
+
 def _run_executor(job: ManagedJob, paths: ManagedPaths, env: Mapping[str, str]) -> int:
     kind = job.managed_command or (job.command[1] if len(job.command) > 1 else "")
     executor = WORKER_EXECUTORS.get(kind)
@@ -346,18 +592,407 @@ def _run_executor(job: ManagedJob, paths: ManagedPaths, env: Mapping[str, str]) 
     return executor(job, paths, env)
 
 
-def _worker_command(job_id: str, paths: ManagedPaths) -> list[str]:
-    return [
+def _parse_managed_options(args: Sequence[str]) -> dict[str, str | bool]:
+    opts: dict[str, str | bool] = {}
+    idx = 0
+    while idx < len(args):
+        arg = args[idx]
+        if arg == "--include-drafts":
+            opts["include_drafts"] = True
+            idx += 1
+            continue
+        if arg.startswith("--"):
+            key = arg[2:].replace("-", "_")
+            if idx + 1 >= len(args):
+                raise ValueError(f"{arg} requires a value")
+            opts[key] = args[idx + 1]
+            idx += 2
+            continue
+        idx += 1
+    return opts
+
+
+def _single_target(job: ManagedJob) -> str:
+    if job.coding_agents:
+        return job.coding_agents[0]
+    if len(job.command) >= 3:
+        return job.command[2]
+    raise ValueError(f"managed {job.managed_command} job has no target")
+
+
+def _targets_from_options_or_job(
+    opts: Mapping[str, str | bool],
+    job: ManagedJob,
+) -> list[str]:
+    if opts.get("coding_agent"):
+        return [str(opts["coding_agent"])]
+    if opts.get("coding_agents"):
+        return _csv_option(opts["coding_agents"]) or []
+    return list(job.coding_agents)
+
+
+def _csv_option(value: object) -> list[str] | None:
+    if not isinstance(value, str) or not value:
+        return None
+    items = [item.strip() for item in value.split(",") if item.strip()]
+    return items or None
+
+
+def _str_option(opts: Mapping[str, str | bool], key: str, default: str) -> str:
+    value = opts.get(key)
+    return value if isinstance(value, str) else default
+
+
+def _smoke_scenario_dir(scenarios_root: Path, target: str) -> Path:
+    preferred = TARGET_SMOKE_SCENARIOS.get(target)
+    if preferred is not None and (scenarios_root / preferred / "story.md").exists():
+        return scenarios_root / preferred
+    fallback = scenarios_root / SMOKE_SCENARIO_FALLBACK
+    if not (fallback / "story.md").exists():
+        raise FileNotFoundError(f"smoke scenario not found: {fallback}")
+    return fallback
+
+
+def _managed_env_for_target(
+    target: str | None,
+    paths: ManagedPaths,
+    env: Mapping[str, str],
+    *,
+    include_worker_token: bool = False,
+) -> dict[str, str]:
+    profile_root = env.get("QUORUM_TARGET_PROFILE_ROOT")
+    if target is not None and profile_root:
+        profile = load_target_profile(Path(profile_root), target)
+    else:
+        profile = TargetProfile(target=target or "batch", path=None, env={})
+    managed_env = build_managed_env(env, paths, profile, runtime_vars={})
+    if include_worker_token and env.get("QUORUM_MANAGED_WORKER_TOKEN"):
+        managed_env["QUORUM_MANAGED_WORKER_TOKEN"] = env["QUORUM_MANAGED_WORKER_TOKEN"]
+    return managed_env
+
+
+def _batch_env_target(targets: Sequence[str]) -> str | None:
+    return targets[0] if len(targets) == 1 else None
+
+
+def _lock_requests_for_targets(
+    targets: Sequence[str],
+    *,
+    broad_batch: bool = False,
+) -> list[LockRequest]:
+    requests: list[LockRequest] = [LockRequest("global:active")]
+    if broad_batch:
+        requests.append(LockRequest("global:broad-batch"))
+    for target in sorted(set(targets)):
+        requests.append(LockRequest(f"provider:{_provider_for_target(target)}"))
+        requests.append(LockRequest(f"target:{target}"))
+    return requests
+
+
+def _acquire_job_locks(
+    paths: ManagedPaths,
+    job: ManagedJob,
+    requests: Sequence[LockRequest],
+) -> list[ManagedLock]:
+    try:
+        return acquire_locks(paths, requests, job.id, job.command)
+    except LockConflict as exc:
+        append_event(
+            paths,
+            job.id,
+            {
+                "event": "lock-conflict",
+                "job_id": job.id,
+                "lock_name": exc.lock_name,
+                "conflict": exc.to_json(),
+            },
+        )
+        raise
+
+
+def _provider_for_target(target: str) -> str:
+    return PROVIDER_BY_TARGET.get(target, target)
+
+
+def _fail_on_active_cooldowns(
+    paths: ManagedPaths,
+    job: ManagedJob,
+    targets: Sequence[str],
+) -> None:
+    providers = {_provider_for_target(target) for target in targets}
+    active = [
+        cooldown
+        for cooldown in read_active_cooldowns(paths, datetime.now(UTC))
+        if cooldown.provider in providers
+    ]
+    if not active:
+        return
+    cooldown = active[0]
+    append_event(
+        paths,
+        job.id,
+        {
+            "event": "cooldown-active",
+            "job_id": job.id,
+            "provider": cooldown.provider,
+            "reason": cooldown.reason,
+            "until": cooldown.until,
+        },
+    )
+    raise RuntimeError(
+        f"active provider cooldown for {cooldown.provider} until "
+        f"{cooldown.until.isoformat()}: {cooldown.reason}"
+    )
+
+
+def _record_child_finished(
+    paths: ManagedPaths,
+    job_id: str,
+    child_id: str,
+    result: ChildResult,
+    *,
+    artifact_root: Path,
+    batch: Mapping[str, str],
+    lock: threading.Lock,
+) -> None:
+    skipped_reason = _skipped_reason(result)
+    if skipped_reason is not None:
+        _upsert_child(
+            paths,
+            job_id,
+            {
+                "id": child_id,
+                "kind": "run",
+                **batch,
+                "state": "skipped",
+                "skipped": skipped_reason,
+                "error": result.error,
+            },
+            lock=lock,
+        )
+        return
+
+    final = _final_for_child_result(result, artifact_root)
+    child: dict[str, object] = {
+        "id": child_id,
+        "kind": "run",
+        **batch,
+        "state": "finished",
+    }
+    if result.run_id is not None:
+        child["run_id"] = result.run_id
+        child["run_dir"] = str(artifact_root / result.run_id)
+    if result.error is not None:
+        child["error"] = result.error
+    if final is not None:
+        child["final"] = final
+    _upsert_child(paths, job_id, child, lock=lock)
+    if result.run_id is not None and _is_antigravity_rate_limit(artifact_root / result.run_id):
+        until = datetime.now(UTC) + timedelta(minutes=30)
+        write_cooldown(
+            paths,
+            "gemini",
+            "Code Assist rate limit",
+            until,
+        )
+        _append_job_cooldown(
+            paths,
+            job_id,
+            {
+                "provider": "gemini",
+                "reason": "Code Assist rate limit",
+                "source_child_id": child_id,
+                "source_job_id": job_id,
+                "source_run_id": result.run_id,
+                "until": until.isoformat().replace("+00:00", "Z"),
+            },
+            lock=lock,
+        )
+
+
+def _skipped_reason(result: ChildResult) -> str | None:
+    if result.error == RATE_LIMIT_SKIP_SENTINEL:
+        return "rate-limited"
+    prefix = "skipped:"
+    if isinstance(result.error, str) and result.error.startswith(prefix):
+        return result.error[len(prefix) :] or "skipped"
+    return None
+
+
+def _final_for_child_result(result: ChildResult, artifact_root: Path) -> str | None:
+    if result.error is not None:
+        return None
+    if result.run_id is None:
+        return "unknown"
+    verdict = _read_run_verdict(artifact_root / result.run_id)
+    if verdict is None:
+        return "unknown"
+    final = verdict.get("final")
+    if isinstance(final, str) and final in {"pass", "fail", "indeterminate"}:
+        return final
+    return "unknown"
+
+
+def _is_antigravity_rate_limit(run_dir: Path) -> bool:
+    verdict = _read_run_verdict(run_dir)
+    if not verdict:
+        return False
+    error_obj = verdict.get("error")
+    if not isinstance(error_obj, dict):
+        return False
+    error = cast(dict[str, object], error_obj)
+    message = error.get("message")
+    return isinstance(message, str) and ANTIGRAVITY_RATE_LIMIT_MARKER in message
+
+
+def _read_run_verdict(run_dir: Path) -> dict[str, object] | None:
+    try:
+        payload = json.loads((run_dir / "verdict.json").read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return cast(dict[str, object], payload) if isinstance(payload, dict) else None
+
+
+def _append_job_cooldown(
+    paths: ManagedPaths,
+    job_id: str,
+    cooldown: Mapping[str, object],
+    *,
+    lock: threading.Lock,
+) -> ManagedJob:
+    with lock:
+        job = read_job(paths, job_id)
+        extra = dict(job.extra)
+        existing = extra.get("cooldowns")
+        cooldowns = list(existing) if isinstance(existing, list) else []
+        cooldowns.append(dict(cooldown))
+        extra["cooldowns"] = cooldowns
+        return _update_job(paths, job_id, extra=extra)
+
+
+def _rollup_children(children: Sequence[Mapping[str, object]]) -> Mapping[str, object]:
+    finals = [
+        str(child.get("final"))
+        for child in children
+        if child.get("kind") != "batch" and child.get("state") != "skipped"
+    ]
+    passed = finals.count("pass")
+    failed = finals.count("fail")
+    indeterminate = finals.count("indeterminate")
+    unknown = len([final for final in finals if final not in {"pass", "fail", "indeterminate"}])
+    if failed:
+        final = "fail"
+    elif indeterminate or unknown or not finals:
+        final = "indeterminate"
+    else:
+        final = "pass"
+    rollup: dict[str, object] = {
+        "final": final,
+        "total": len(finals),
+        "passed": passed,
+        "failed": failed,
+    }
+    if indeterminate:
+        rollup["indeterminate"] = indeterminate
+    if unknown:
+        rollup["unknown"] = unknown
+    skipped = len(
+        [
+            child
+            for child in children
+            if child.get("kind") != "batch" and child.get("state") == "skipped"
+        ]
+    )
+    if skipped:
+        rollup["skipped"] = skipped
+    return rollup
+
+
+def _upsert_child(
+    paths: ManagedPaths,
+    job_id: str,
+    child: Mapping[str, object],
+    *,
+    lock: threading.Lock | None = None,
+) -> ManagedJob:
+    if lock is None:
+        return _upsert_child_unlocked(paths, job_id, child)
+    with lock:
+        return _upsert_child_unlocked(paths, job_id, child)
+
+
+def _upsert_child_unlocked(
+    paths: ManagedPaths,
+    job_id: str,
+    child: Mapping[str, object],
+) -> ManagedJob:
+    job = read_job(paths, job_id)
+    child_id = child.get("id")
+    children = [dict(existing) for existing in job.children]
+    for idx, existing in enumerate(children):
+        if existing.get("id") == child_id:
+            existing.update(dict(child))
+            children[idx] = existing
+            break
+    else:
+        children.append(dict(child))
+    return _update_job(paths, job_id, children=children)
+
+
+def _update_job(paths: ManagedPaths, job_id: str, **updates: Any) -> ManagedJob:
+    job = read_job(paths, job_id)
+    updated = replace(job, updated_at=datetime.now(UTC), **updates)
+    write_job_atomic(paths, updated)
+    return updated
+
+
+def _worker_command(
+    job_id: str,
+    paths: ManagedPaths,
+    *,
+    env: Mapping[str, str] | None = None,
+    read_worker_token: bool = False,
+) -> list[str]:
+    command = [
         "env",
-        "QUORUM_MANAGED_WORKER=1",
-        f"QUORUM_STATE_ROOT={paths.state_root}",
-        f"QUORUM_ARTIFACT_ROOT={paths.artifact_root}",
+        *_worker_env_assignments(paths, env),
         "uv",
         "run",
         "quorum",
         "managed-worker",
         job_id,
     ]
+    if not read_worker_token:
+        return command
+    return [
+        "sh",
+        "-c",
+        WORKER_TOKEN_WRAPPER,
+        "quorum-managed-worker-token",
+        str(runtime_env.MANAGED_WORKER_TOKEN_PATH),
+        *command,
+    ]
+
+
+def _worker_command_env(supervisor: Supervisor) -> Mapping[str, str] | None:
+    if isinstance(supervisor, TmuxSupervisor):
+        return supervisor.env if supervisor.env is not None else os.environ
+    return None
+
+
+def _worker_env_assignments(paths: ManagedPaths, env: Mapping[str, str] | None) -> list[str]:
+    assignments = [
+        "QUORUM_MANAGED_WORKER=1",
+        f"QUORUM_STATE_ROOT={paths.state_root}",
+        f"QUORUM_ARTIFACT_ROOT={paths.artifact_root}",
+    ]
+    if env is None:
+        return assignments
+    for name in TMUX_WORKER_ENV_ALLOWLIST:
+        value = env.get(name)
+        if value:
+            assignments.append(f"{name}={value}")
+    return assignments
 
 
 def _job_log_path(job: ManagedJob, paths: ManagedPaths) -> Path:
@@ -505,3 +1140,12 @@ def _read_available_lines(sources: Sequence[Path], offsets: dict[Path, int]) -> 
         except FileNotFoundError:
             continue
         yield from lines
+
+
+WORKER_EXECUTORS.update(
+    {
+        "smoke": _execute_smoke,
+        "column": _execute_column,
+        "batch": _execute_batch,
+    }
+)

--- a/quorum/managed_commands.py
+++ b/quorum/managed_commands.py
@@ -1,0 +1,507 @@
+from __future__ import annotations
+
+import getpass
+import os
+import socket
+import subprocess
+import time
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Protocol
+
+from quorum.managed_state import (
+    ManagedJob,
+    ManagedPaths,
+    append_event,
+    discover_managed_paths,
+    list_jobs,
+    mark_job_state,
+    new_job_id,
+    read_job,
+    write_job_atomic,
+)
+
+TERMINAL_STATES = frozenset({"succeeded", "failed", "interrupted"})
+ACTIVE_STATES = frozenset({"planned", "running"})
+WORKER_EXECUTORS: dict[str, Callable[[ManagedJob, ManagedPaths, Mapping[str, str]], int]] = {}
+
+
+@dataclass(frozen=True)
+class StartResult:
+    job_id: str
+    command: list[str]
+    supervisor: Mapping[str, object]
+    exit_code: int | None = None
+
+
+class Supervisor(Protocol):
+    def start(
+        self,
+        job: ManagedJob,
+        paths: ManagedPaths,
+        command: Sequence[str],
+    ) -> StartResult: ...
+
+
+@dataclass(frozen=True)
+class InlineSupervisor:
+    env: Mapping[str, str] | None = None
+
+    def start(
+        self,
+        job: ManagedJob,
+        paths: ManagedPaths,
+        command: Sequence[str],
+    ) -> StartResult:
+        worker_env = dict(self.env or os.environ)
+        worker_env["QUORUM_MANAGED_WORKER"] = "1"
+        exit_code = run_managed_worker(job.id, paths, worker_env)
+        return StartResult(
+            job_id=job.id,
+            command=list(command),
+            supervisor={"kind": "inline"},
+            exit_code=exit_code,
+        )
+
+
+@dataclass(frozen=True)
+class TmuxSupervisor:
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run
+
+    def start(
+        self,
+        job: ManagedJob,
+        paths: ManagedPaths,
+        command: Sequence[str],
+    ) -> StartResult:
+        session = _tmux_session_name(job.id)
+        log_path = _job_log_path(job, paths)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.touch(exist_ok=True)
+        tmux_command = [
+            "tmux",
+            "new-session",
+            "-d",
+            "-s",
+            session,
+            "--",
+            *_log_wrapped_command(command, log_path),
+        ]
+        self.runner(tmux_command, check=True, text=True)
+        return StartResult(
+            job_id=job.id,
+            command=list(command),
+            supervisor={"kind": "tmux", "session": session},
+            exit_code=None,
+        )
+
+
+def create_job(
+    kind: str,
+    target: str | None,
+    args: Sequence[str],
+    paths: ManagedPaths,
+    owner: str | None,
+) -> ManagedJob:
+    now = datetime.now(UTC)
+    job_id = new_job_id(now, kind, target)
+    command = ["quorum", kind]
+    if target is not None:
+        command.append(target)
+    command.extend(args)
+    job = ManagedJob(
+        id=job_id,
+        state="planned",
+        created_at=now,
+        updated_at=now,
+        owner=owner or getpass.getuser(),
+        host=socket.gethostname(),
+        command=command,
+        managed_command=kind,
+        coding_agents=[target] if target else [],
+        out_root=str(paths.artifact_root),
+        log_path=str(paths.state_root / "logs" / f"{job_id}.log"),
+    )
+    write_job_atomic(paths, job)
+    append_event(
+        paths,
+        job.id,
+        {
+            "event": "job-created",
+            "job_id": job.id,
+            "state": job.state,
+            "created_at": now,
+            "command": command,
+        },
+    )
+    return job
+
+
+def start_job(job: ManagedJob, paths: ManagedPaths, supervisor: Supervisor) -> StartResult:
+    command = _worker_command(job.id, paths)
+    supervisor_info = _supervisor_info(supervisor, job.id)
+    write_job_atomic(
+        paths,
+        replace(
+            job,
+            supervisor=supervisor_info,
+            updated_at=datetime.now(UTC),
+        ),
+    )
+    append_event(
+        paths,
+        job.id,
+        {
+            "event": "job-started",
+            "job_id": job.id,
+            "supervisor": supervisor_info,
+            "worker_command": command,
+        },
+    )
+    try:
+        result = supervisor.start(read_job(paths, job.id), paths, command)
+    except subprocess.CalledProcessError as exc:
+        failure_reason = _failure_reason(exc)
+        append_event(
+            paths,
+            job.id,
+            {
+                "event": "job-start-failed",
+                "job_id": job.id,
+                "exit_code": exc.returncode,
+                "failure_reason": failure_reason,
+            },
+        )
+        mark_job_state(
+            paths,
+            job.id,
+            "failed",
+            final_exit_code=exc.returncode,
+            failure_reason=failure_reason,
+        )
+        return StartResult(
+            job_id=job.id,
+            command=command,
+            supervisor=supervisor_info,
+            exit_code=exc.returncode,
+        )
+    except Exception as exc:
+        exit_code = _exit_code(exc)
+        failure_reason = _failure_reason(exc)
+        append_event(
+            paths,
+            job.id,
+            {
+                "event": "job-start-failed",
+                "job_id": job.id,
+                "exit_code": exit_code,
+                "failure_reason": failure_reason,
+            },
+        )
+        mark_job_state(
+            paths,
+            job.id,
+            "failed",
+            final_exit_code=exit_code,
+            failure_reason=failure_reason,
+        )
+        return StartResult(
+            job_id=job.id,
+            command=command,
+            supervisor=supervisor_info,
+            exit_code=exit_code,
+        )
+    return result
+
+
+def run_managed_worker(job_id: str, paths: ManagedPaths, env: Mapping[str, str]) -> int:
+    worker_env = dict(env)
+    worker_env["QUORUM_MANAGED_WORKER"] = "1"
+    job = mark_job_state(paths, job_id, "running")
+    append_event(
+        paths,
+        job.id,
+        {
+            "event": "worker-started",
+            "job_id": job.id,
+            "state": "running",
+            "started_at": job.started_at or job.updated_at,
+        },
+    )
+    try:
+        exit_code = _run_executor(job, paths, worker_env)
+    except KeyboardInterrupt:
+        append_event(
+            paths,
+            job.id,
+            {
+                "event": "worker-interrupted",
+                "job_id": job.id,
+                "exit_code": 130,
+            },
+        )
+        mark_job_state(
+            paths,
+            job.id,
+            "interrupted",
+            final_exit_code=130,
+            failure_reason="worker interrupted",
+        )
+        return 130
+    except BaseException as exc:
+        exit_code = _exit_code(exc)
+        failure_reason = _failure_reason(exc)
+        append_event(
+            paths,
+            job.id,
+            {
+                "event": "worker-failed",
+                "job_id": job.id,
+                "exit_code": exit_code,
+                "failure_reason": failure_reason,
+            },
+        )
+        mark_job_state(
+            paths,
+            job.id,
+            "failed",
+            final_exit_code=exit_code,
+            failure_reason=failure_reason,
+        )
+        return exit_code
+
+    if exit_code == 0:
+        append_event(
+            paths,
+            job.id,
+            {
+                "event": "worker-succeeded",
+                "job_id": job.id,
+                "exit_code": 0,
+            },
+        )
+        mark_job_state(paths, job.id, "succeeded", final_exit_code=0)
+        return 0
+
+    failure_reason = f"managed worker exited {exit_code}"
+    append_event(
+        paths,
+        job.id,
+        {
+            "event": "worker-failed",
+            "job_id": job.id,
+            "exit_code": exit_code,
+            "failure_reason": failure_reason,
+        },
+    )
+    mark_job_state(
+        paths,
+        job.id,
+        "failed",
+        final_exit_code=exit_code,
+        failure_reason=failure_reason,
+    )
+    return exit_code
+
+
+def status_summary(paths: ManagedPaths, limit: int, include_finished: bool) -> list[ManagedJob]:
+    jobs = list_jobs(paths).jobs
+    active = sorted(
+        [job for job in jobs if job.state in ACTIVE_STATES],
+        key=lambda job: (job.updated_at, job.id),
+        reverse=True,
+    )
+    if not include_finished:
+        return active[:limit]
+    terminal = sorted(
+        [job for job in jobs if job.state in TERMINAL_STATES],
+        key=lambda job: (job.finished_at or job.updated_at, job.id),
+        reverse=True,
+    )
+    return [*active, *terminal][:limit]
+
+
+def tail_job(
+    job_id: str,
+    child_id: str | None = None,
+    follow: bool = False,
+    *,
+    paths: ManagedPaths | None = None,
+) -> Iterator[str]:
+    managed_paths = paths or discover_managed_paths(os.environ)
+    if child_id is None:
+        sources = _parent_tail_sources(managed_paths, job_id)
+    else:
+        sources = _child_tail_sources(managed_paths, job_id, child_id)
+    yield from _tail_sources(sources, managed_paths, job_id, follow)
+
+
+def _run_executor(job: ManagedJob, paths: ManagedPaths, env: Mapping[str, str]) -> int:
+    kind = job.managed_command or (job.command[1] if len(job.command) > 1 else "")
+    executor = WORKER_EXECUTORS.get(kind)
+    if executor is None:
+        raise NotImplementedError(f"managed job kind {kind!r} is not implemented yet")
+    return executor(job, paths, env)
+
+
+def _worker_command(job_id: str, paths: ManagedPaths) -> list[str]:
+    return [
+        "env",
+        "QUORUM_MANAGED_WORKER=1",
+        f"QUORUM_STATE_ROOT={paths.state_root}",
+        f"QUORUM_ARTIFACT_ROOT={paths.artifact_root}",
+        "uv",
+        "run",
+        "quorum",
+        "managed-worker",
+        job_id,
+    ]
+
+
+def _job_log_path(job: ManagedJob, paths: ManagedPaths) -> Path:
+    if job.log_path:
+        return Path(job.log_path)
+    return paths.state_root / "logs" / f"{job.id}.log"
+
+
+def _log_wrapped_command(command: Sequence[str], log_path: Path) -> list[str]:
+    return [
+        "sh",
+        "-c",
+        'exec >> "$1" 2>&1; shift; exec "$@"',
+        "quorum-managed-worker",
+        str(log_path),
+        *command,
+    ]
+
+
+def _tmux_session_name(job_id: str) -> str:
+    return f"quorum-{job_id}"
+
+
+def _supervisor_info(supervisor: Supervisor, job_id: str) -> Mapping[str, object]:
+    if isinstance(supervisor, InlineSupervisor):
+        return {"kind": "inline"}
+    if isinstance(supervisor, TmuxSupervisor):
+        return {"kind": "tmux", "session": _tmux_session_name(job_id)}
+    return {"kind": supervisor.__class__.__name__}
+
+
+def _exit_code(exc: BaseException) -> int:
+    value = getattr(exc, "returncode", None)
+    if isinstance(value, int):
+        return value
+    value = getattr(exc, "exit_code", None)
+    if isinstance(value, int):
+        return value
+    return 2 if isinstance(exc, NotImplementedError) else 1
+
+
+def _failure_reason(exc: BaseException) -> str:
+    if isinstance(exc, subprocess.CalledProcessError):
+        stderr = (
+            exc.stderr.decode(errors="replace") if isinstance(exc.stderr, bytes) else exc.stderr
+        )
+        stdout = (
+            exc.stdout.decode(errors="replace") if isinstance(exc.stdout, bytes) else exc.stdout
+        )
+        detail = (stderr or stdout or str(exc)).strip()
+        return detail or f"command exited {exc.returncode}"
+    return str(exc)
+
+
+def _parent_tail_sources(paths: ManagedPaths, job_id: str) -> list[Path]:
+    job = read_job(paths, job_id)
+    sources = [paths.events_dir / f"{job_id}.jsonl"]
+    if job.log_path:
+        sources.append(Path(job.log_path))
+    return sources
+
+
+def _child_tail_sources(paths: ManagedPaths, job_id: str, child_id: str) -> list[Path]:
+    job = read_job(paths, job_id)
+    child = _find_child(job, child_id)
+    sources: list[Path] = []
+    log_path = _path_value(child.get("log_path"))
+    if log_path is not None:
+        sources.append(log_path)
+    batch_dir = _path_value(child.get("batch_dir"))
+    if batch_dir is not None:
+        sources.extend([batch_dir / "batch.log", batch_dir / "results.jsonl"])
+    batch_id = _str_value(child.get("batch_id"))
+    if batch_id is not None:
+        sources.extend(
+            [
+                paths.artifact_root / "batches" / batch_id / "batch.log",
+                paths.artifact_root / "batches" / batch_id / "results.jsonl",
+            ]
+        )
+    run_dir = _path_value(child.get("run_dir"))
+    run_id = _str_value(child.get("run_id"))
+    if run_dir is None and run_id is not None:
+        run_dir = paths.artifact_root / run_id
+    if run_dir is not None:
+        sources.extend(
+            [
+                run_dir / "gauntlet-agent" / "transcript.txt",
+                run_dir / "coding-agent-config" / "agy.log",
+                run_dir / "coding-agent-tool-calls.jsonl",
+                run_dir / "verdict.json",
+            ]
+        )
+    return sources
+
+
+def _find_child(job: ManagedJob, child_id: str) -> Mapping[str, object]:
+    for child in job.children:
+        if child.get("id") == child_id or child.get("child_id") == child_id:
+            return child
+    raise ValueError(f"no child {child_id!r} for managed job {job.id}")
+
+
+def _path_value(value: object) -> Path | None:
+    if isinstance(value, str) and value:
+        return Path(value)
+    return None
+
+
+def _str_value(value: object) -> str | None:
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _tail_sources(
+    sources: Sequence[Path],
+    paths: ManagedPaths,
+    job_id: str,
+    follow: bool,
+) -> Iterator[str]:
+    offsets = {path: 0 for path in sources}
+    yield from _read_available_lines(sources, offsets)
+    if not follow:
+        return
+
+    while True:
+        yield from _read_available_lines(sources, offsets)
+        try:
+            if read_job(paths, job_id).state in TERMINAL_STATES:
+                yield from _read_available_lines(sources, offsets)
+                return
+        except (FileNotFoundError, ValueError):
+            return
+        time.sleep(0.25)
+
+
+def _read_available_lines(sources: Sequence[Path], offsets: dict[Path, int]) -> Iterator[str]:
+    for path in sources:
+        try:
+            with path.open() as f:
+                f.seek(offsets[path])
+                lines = f.readlines()
+                offsets[path] = f.tell()
+        except FileNotFoundError:
+            continue
+        yield from lines

--- a/quorum/managed_state.py
+++ b/quorum/managed_state.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import secrets
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, cast
+
+_SCHEMA_VERSION = 1
+_WORKER_WRITTEN_STATES = {"planned", "running", "succeeded", "failed", "interrupted"}
+_JOB_ID_RE = re.compile(r"^job-\d{8}T\d{6}Z-[0-9a-f]{4}$")
+
+
+@dataclass(frozen=True)
+class ManagedPaths:
+    state_root: Path
+    artifact_root: Path
+    jobs_dir: Path
+    events_dir: Path
+    locks_dir: Path
+    cooldowns_dir: Path
+    taints_dir: Path
+
+
+@dataclass(frozen=True)
+class ManagedDiagnostics:
+    warnings: list[dict[str, object]] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class JobListResult:
+    jobs: list[ManagedJob]
+    diagnostics: ManagedDiagnostics
+
+
+@dataclass(frozen=True)
+class ManagedJob:
+    id: str
+    state: str
+    created_at: datetime
+    updated_at: datetime
+    command: list[str]
+    schema_version: int = _SCHEMA_VERSION
+    managed_command: str | None = None
+    coding_agents: list[str] = field(default_factory=list)
+    result_rollup: Mapping[str, object] | None = None
+    owner: str | None = None
+    host: str | None = None
+    profile: str | None = None
+    scenario_filter: str | None = None
+    tier: str | None = None
+    include_drafts: bool | None = None
+    out_root: str | None = None
+    log_path: str | None = None
+    locks: list[str] = field(default_factory=list)
+    env_profiles: list[str] = field(default_factory=list)
+    evals_repo: Mapping[str, object] | None = None
+    superpowers_repo: Mapping[str, object] | None = None
+    supervisor: Mapping[str, object] | None = None
+    children: list[Mapping[str, object]] = field(default_factory=list)
+    artifact_bytes: int | None = None
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    final_exit_code: int | None = None
+    failure_reason: str | None = None
+    tainted: bool = False
+    taint_reason: str | None = None
+    taint_matches: list[Mapping[str, object]] = field(default_factory=list)
+    extra: Mapping[str, object] = field(default_factory=dict)
+
+
+def discover_managed_paths(env: Mapping[str, str]) -> ManagedPaths:
+    artifact_root = Path(env.get("QUORUM_ARTIFACT_ROOT") or env.get("QUORUM_OUT_ROOT") or "results")
+    state_root = Path(env.get("QUORUM_STATE_ROOT") or artifact_root / ".quorum")
+    return ManagedPaths(
+        state_root=state_root,
+        artifact_root=artifact_root,
+        jobs_dir=state_root / "jobs",
+        events_dir=state_root / "events",
+        locks_dir=state_root / "locks",
+        cooldowns_dir=state_root / "cooldowns",
+        taints_dir=state_root / "taints",
+    )
+
+
+def new_job_id(now: datetime, kind: str, target: str | None) -> str:
+    del kind, target
+    timestamp = _to_utc(now).strftime("%Y%m%dT%H%M%SZ")
+    return f"job-{timestamp}-{secrets.token_hex(2)}"
+
+
+def write_job_atomic(paths: ManagedPaths, job: ManagedJob) -> None:
+    _validate_job_id(job.id)
+    _validate_worker_state(job.state)
+    paths.jobs_dir.mkdir(parents=True, exist_ok=True)
+    destination = _job_path(paths, job.id)
+    payload = json.dumps(_job_to_json(job), indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+        dir=paths.jobs_dir,
+        text=True,
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w") as tmp:
+            tmp.write(payload)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        os.replace(str(tmp_path), str(destination))
+        _fsync_directory(paths.jobs_dir)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def read_job(paths: ManagedPaths, job_id: str) -> ManagedJob:
+    return _job_from_json(json.loads(_job_path(paths, job_id).read_text()))
+
+
+def list_jobs(paths: ManagedPaths) -> JobListResult:
+    warnings: list[dict[str, object]] = []
+    jobs: list[ManagedJob] = []
+    if not paths.jobs_dir.exists():
+        return JobListResult(jobs=[], diagnostics=ManagedDiagnostics())
+
+    for path in sorted(paths.jobs_dir.glob("*.json")):
+        try:
+            jobs.append(_job_from_json(json.loads(path.read_text())))
+        except (OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            warnings.append(
+                {
+                    "level": "warning",
+                    "event": "malformed-job-json",
+                    "path": str(path),
+                    "message": str(exc),
+                }
+            )
+
+    jobs.sort(key=lambda job: job.id)
+    return JobListResult(jobs=jobs, diagnostics=ManagedDiagnostics(warnings=warnings))
+
+
+def append_event(paths: ManagedPaths, job_id: str, event: Mapping[str, object]) -> None:
+    _validate_job_id(job_id)
+    paths.events_dir.mkdir(parents=True, exist_ok=True)
+    event_path = paths.events_dir / f"{job_id}.jsonl"
+    with event_path.open("a") as f:
+        f.write(json.dumps(_json_value(dict(event)), sort_keys=True) + "\n")
+
+
+def mark_job_state(
+    paths: ManagedPaths,
+    job_id: str,
+    state: str,
+    *,
+    result_rollup: Mapping[str, object] | None = None,
+    final_exit_code: int | None = None,
+    failure_reason: str | None = None,
+) -> ManagedJob:
+    _validate_worker_state(state)
+    job = read_job(paths, job_id)
+    updates: dict[str, Any] = {
+        "state": state,
+        "updated_at": datetime.now(UTC),
+    }
+    if result_rollup is not None:
+        updates["result_rollup"] = dict(result_rollup)
+    if final_exit_code is not None:
+        updates["final_exit_code"] = final_exit_code
+    if failure_reason is not None:
+        updates["failure_reason"] = failure_reason
+    if state == "running" and job.started_at is None:
+        updates["started_at"] = updates["updated_at"]
+    if state in {"succeeded", "failed", "interrupted"} and job.finished_at is None:
+        updates["finished_at"] = updates["updated_at"]
+    updated = _replace_job(job, **updates)
+    write_job_atomic(paths, updated)
+    return updated
+
+
+def heartbeat_job(paths: ManagedPaths, job_id: str, now: datetime) -> ManagedJob:
+    job = read_job(paths, job_id)
+    updated = _replace_job(job, updated_at=_to_utc(now))
+    write_job_atomic(paths, updated)
+    return updated
+
+
+def mark_job_tainted(
+    paths: ManagedPaths,
+    job_id: str,
+    reason: str,
+    matches: Sequence[Mapping[str, object]],
+) -> ManagedJob:
+    job = read_job(paths, job_id)
+    updated = _replace_job(
+        job,
+        updated_at=datetime.now(UTC),
+        tainted=True,
+        taint_reason=reason,
+        taint_matches=[dict(match) for match in matches],
+    )
+    write_job_atomic(paths, updated)
+    return updated
+
+
+def _job_path(paths: ManagedPaths, job_id: str) -> Path:
+    _validate_job_id(job_id)
+    return paths.jobs_dir / f"{job_id}.json"
+
+
+def _validate_job_id(job_id: str) -> None:
+    if _JOB_ID_RE.fullmatch(job_id) is None:
+        raise ValueError(f"invalid managed job id: {job_id}")
+
+
+def _validate_worker_state(state: str) -> None:
+    if state not in _WORKER_WRITTEN_STATES:
+        raise ValueError(f"unsupported managed job state: {state}")
+
+
+def _replace_job(job: ManagedJob, **updates: object) -> ManagedJob:
+    data = asdict(job)
+    data.update(updates)
+    return ManagedJob(**data)
+
+
+def _job_to_json(job: ManagedJob) -> dict[str, object]:
+    data = asdict(job)
+    known_fields = set(data)
+    extra = data.pop("extra", {})
+    if isinstance(extra, Mapping):
+        data.update({key: value for key, value in extra.items() if key not in known_fields})
+    return {key: _json_value(value) for key, value in data.items()}
+
+
+def _job_from_json(data: object) -> ManagedJob:
+    if not isinstance(data, dict) or not all(isinstance(key, str) for key in data):
+        raise ValueError("job JSON must be an object")
+
+    raw = cast(dict[str, object], data)
+    known_fields = ManagedJob.__dataclass_fields__
+    extra = {key: value for key, value in raw.items() if key not in known_fields or key == "extra"}
+
+    for key in ("id", "state", "created_at", "updated_at", "command"):
+        if key not in raw:
+            raise ValueError(f"job JSON missing required field: {key}")
+
+    return ManagedJob(
+        id=_valid_job_id(raw["id"]),
+        state=_valid_worker_state(raw["state"]),
+        created_at=_parse_datetime(raw["created_at"]),
+        updated_at=_parse_datetime(raw["updated_at"]),
+        command=_string_list(raw["command"], "command"),
+        schema_version=_int_value(raw.get("schema_version", _SCHEMA_VERSION), "schema_version"),
+        managed_command=_optional_str(raw.get("managed_command"), "managed_command"),
+        coding_agents=_string_list(raw.get("coding_agents", []), "coding_agents"),
+        result_rollup=_optional_mapping(raw.get("result_rollup"), "result_rollup"),
+        owner=_optional_str(raw.get("owner"), "owner"),
+        host=_optional_str(raw.get("host"), "host"),
+        profile=_optional_str(raw.get("profile"), "profile"),
+        scenario_filter=_optional_str(raw.get("scenario_filter"), "scenario_filter"),
+        tier=_optional_str(raw.get("tier"), "tier"),
+        include_drafts=_optional_bool(raw.get("include_drafts"), "include_drafts"),
+        out_root=_optional_str(raw.get("out_root"), "out_root"),
+        log_path=_optional_str(raw.get("log_path"), "log_path"),
+        locks=_string_list(raw.get("locks", []), "locks"),
+        env_profiles=_string_list(raw.get("env_profiles", []), "env_profiles"),
+        evals_repo=_optional_mapping(raw.get("evals_repo"), "evals_repo"),
+        superpowers_repo=_optional_mapping(raw.get("superpowers_repo"), "superpowers_repo"),
+        supervisor=_optional_mapping(raw.get("supervisor"), "supervisor"),
+        children=_mapping_list(raw.get("children", []), "children"),
+        artifact_bytes=_optional_int(raw.get("artifact_bytes"), "artifact_bytes"),
+        started_at=_optional_datetime(raw.get("started_at"), "started_at"),
+        finished_at=_optional_datetime(raw.get("finished_at"), "finished_at"),
+        final_exit_code=_optional_int(raw.get("final_exit_code"), "final_exit_code"),
+        failure_reason=_optional_str(raw.get("failure_reason"), "failure_reason"),
+        tainted=_bool_value(raw.get("tainted", False), "tainted"),
+        taint_reason=_optional_str(raw.get("taint_reason"), "taint_reason"),
+        taint_matches=_mapping_list(raw.get("taint_matches", []), "taint_matches"),
+        extra=extra,
+    )
+
+
+def _to_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _parse_datetime(value: object) -> datetime:
+    if not isinstance(value, str):
+        raise ValueError("datetime value must be a string")
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return _to_utc(parsed)
+
+
+def _optional_datetime(value: object, field_name: str) -> datetime | None:
+    if value is None:
+        return None
+    try:
+        return _parse_datetime(value)
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be a datetime string") from exc
+
+
+def _json_value(value: object) -> object:
+    if isinstance(value, datetime):
+        return _to_utc(value).isoformat().replace("+00:00", "Z")
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, list):
+        return [_json_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    return value
+
+
+def _string_list(value: object, field_name: str) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"{field_name} must be a list of strings")
+    return cast(list[str], value)
+
+
+def _mapping_list(value: object, field_name: str) -> list[Mapping[str, object]]:
+    if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
+        raise ValueError(f"{field_name} must be a list of objects")
+    return [cast(Mapping[str, object], item) for item in value]
+
+
+def _required_str(value: object, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    return value
+
+
+def _optional_str(value: object, field_name: str) -> str | None:
+    if value is None:
+        return None
+    return _required_str(value, field_name)
+
+
+def _bool_value(value: object, field_name: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{field_name} must be a boolean")
+    return value
+
+
+def _optional_bool(value: object, field_name: str) -> bool | None:
+    if value is None:
+        return None
+    return _bool_value(value, field_name)
+
+
+def _int_value(value: object, field_name: str) -> int:
+    if not isinstance(value, int):
+        raise ValueError(f"{field_name} must be an integer")
+    return value
+
+
+def _optional_int(value: object, field_name: str) -> int | None:
+    if value is None:
+        return None
+    return _int_value(value, field_name)
+
+
+def _optional_mapping(value: object, field_name: str) -> Mapping[str, object] | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError(f"{field_name} must be an object")
+    return cast(Mapping[str, object], value)
+
+
+def _valid_job_id(value: object) -> str:
+    job_id = _required_str(value, "id")
+    _validate_job_id(job_id)
+    return job_id
+
+
+def _valid_worker_state(value: object) -> str:
+    state = _required_str(value, "state")
+    _validate_worker_state(state)
+    return state
+
+
+def _fsync_directory(path: Path) -> None:
+    fd = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)

--- a/quorum/managed_state.py
+++ b/quorum/managed_state.py
@@ -119,6 +119,10 @@ def write_job_atomic(paths: ManagedPaths, job: ManagedJob) -> None:
             tmp_path.unlink()
 
 
+def job_to_json(job: ManagedJob) -> dict[str, object]:
+    return _job_to_json(job)
+
+
 def read_job(paths: ManagedPaths, job_id: str) -> ManagedJob:
     return _job_from_json(json.loads(_job_path(paths, job_id).read_text()))
 

--- a/quorum/opencode_capture.py
+++ b/quorum/opencode_capture.py
@@ -6,8 +6,11 @@ import json
 import os
 import subprocess
 import tempfile
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, cast
+
+from quorum.runtime_env import is_managed_host
 
 
 class OpenCodeCaptureError(RuntimeError):
@@ -47,6 +50,19 @@ OPENCODE_ENV_ALLOWLIST = {
     "AWS_SECRET_ACCESS_KEY",
     "AWS_SESSION_TOKEN",
 }
+OPENCODE_PROVIDER_ENV_NAMES = {
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "OPENROUTER_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "AWS_PROFILE",
+    "AWS_REGION",
+    "AWS_DEFAULT_REGION",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+}
 
 OPENCODE_CAPTURE_TIMEOUT_SECONDS = 30
 
@@ -57,6 +73,7 @@ def run_opencode_command(
     opencode_home: Path,
     launch_cwd: Path,
     timeout: float = OPENCODE_CAPTURE_TIMEOUT_SECONDS,
+    env_base: Mapping[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run an opencode CLI command with stdout redirected to a file.
 
@@ -73,7 +90,7 @@ def run_opencode_command(
             text=True,
             stdout=stdout_file,
             stderr=subprocess.PIPE,
-            env=opencode_run_env(opencode_home),
+            env=opencode_run_env(opencode_home, env_base=env_base),
             timeout=timeout,
         )
         stdout_file.seek(0)
@@ -81,8 +98,22 @@ def run_opencode_command(
     return result
 
 
-def opencode_run_env(opencode_home: Path) -> dict[str, str]:
-    env = {key: value for key, value in os.environ.items() if key in OPENCODE_ENV_ALLOWLIST}
+def opencode_run_env(
+    opencode_home: Path,
+    env_base: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    source = dict(env_base) if env_base is not None else dict(os.environ)
+    allowlist = set(OPENCODE_ENV_ALLOWLIST)
+    source_managed = is_managed_host(source) or is_managed_host(os.environ)
+    if source_managed:
+        target_provider_env = {
+            name.strip()
+            for name in source.get("QUORUM_TARGET_ENV_KEYS", "").split(",")
+            if name.strip()
+        }
+        allowlist -= OPENCODE_PROVIDER_ENV_NAMES
+        allowlist |= target_provider_env & OPENCODE_PROVIDER_ENV_NAMES
+    env = {key: value for key, value in source.items() if key in allowlist}
     env.setdefault("PATH", os.defpath)
     env.setdefault("TERM", "xterm-256color")
     env.setdefault("LANG", "C.UTF-8")
@@ -136,12 +167,18 @@ def _session_decisions(
     return decisions, matches
 
 
-def _list_sessions(*, opencode_home: Path, launch_cwd: Path) -> list[Any]:
+def _list_sessions(
+    *,
+    opencode_home: Path,
+    launch_cwd: Path,
+    env_base: Mapping[str, str] | None = None,
+) -> list[Any]:
     try:
         result = run_opencode_command(
             ["session", "list", "--format", "json"],
             opencode_home=opencode_home,
             launch_cwd=launch_cwd,
+            env_base=env_base,
         )
     except subprocess.TimeoutExpired as e:
         raise OpenCodeCaptureError(
@@ -161,9 +198,15 @@ def _list_sessions(*, opencode_home: Path, launch_cwd: Path) -> list[Any]:
     return sessions
 
 
-def snapshot_opencode_sessions(*, opencode_home: Path, launch_cwd: Path) -> set[str]:
+def snapshot_opencode_sessions(
+    *,
+    opencode_home: Path,
+    launch_cwd: Path,
+    env_base: Mapping[str, str] | None = None,
+) -> set[str]:
     _decisions, sessions = _session_decisions(
-        _list_sessions(opencode_home=opencode_home, launch_cwd=launch_cwd), launch_cwd
+        _list_sessions(opencode_home=opencode_home, launch_cwd=launch_cwd, env_base=env_base),
+        launch_cwd,
     )
     return {session["id"] for session in sessions}
 
@@ -177,13 +220,18 @@ def _session_created(session: dict[str, Any]) -> int | None:
 
 
 def _export_session(
-    *, session_id: str, opencode_home: Path, launch_cwd: Path
+    *,
+    session_id: str,
+    opencode_home: Path,
+    launch_cwd: Path,
+    env_base: Mapping[str, str] | None = None,
 ) -> tuple[dict[str, Any], str, str]:
     try:
         result = run_opencode_command(
             ["export", session_id],
             opencode_home=opencode_home,
             launch_cwd=launch_cwd,
+            env_base=env_base,
         )
     except subprocess.TimeoutExpired as e:
         raise OpenCodeCaptureError(
@@ -222,17 +270,25 @@ def export_opencode_sessions(
     export_dir: Path,
     launch_cwd: Path,
     snapshot: set[str],
+    env_base: Mapping[str, str] | None = None,
 ) -> tuple[Path, ...]:
     """Export OpenCode sessions for launch_cwd into export_dir."""
     export_dir.mkdir(parents=True, exist_ok=True)
-    raw_sessions = _list_sessions(opencode_home=opencode_home, launch_cwd=launch_cwd)
+    raw_sessions = _list_sessions(
+        opencode_home=opencode_home,
+        launch_cwd=launch_cwd,
+        env_base=env_base,
+    )
     decisions, sessions = _session_decisions(raw_sessions, launch_cwd)
     new_sessions = [session for session in sessions if session["id"] not in snapshot]
     export_records: list[dict[str, Any]] = []
     for session in new_sessions:
         session_id = session["id"]
         exported_json, stdout, stderr = _export_session(
-            session_id=session_id, opencode_home=opencode_home, launch_cwd=launch_cwd
+            session_id=session_id,
+            opencode_home=opencode_home,
+            launch_cwd=launch_cwd,
+            env_base=env_base,
         )
         created = _session_created(session) or _exported_created(exported_json)
         export_records.append(

--- a/quorum/run_all.py
+++ b/quorum/run_all.py
@@ -14,7 +14,7 @@ import secrets
 import subprocess
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import ExitStack
 from dataclasses import dataclass
@@ -37,7 +37,9 @@ from quorum.kimi import (
     run_kimi_auth_preflight,
     sanitize_kimi_diagnostic,
 )
+from quorum.managed_state import discover_managed_paths
 from quorum.runner import ANTIGRAVITY_RATE_LIMIT_MARKER, _allocate_run_dir, _write_indeterminate
+from quorum.runtime_env import build_managed_env, is_managed_host, load_target_profile
 from quorum.show import _fmt_cost
 from quorum.story_meta import read_quorum_tier, read_story_status
 
@@ -206,6 +208,7 @@ def invoke_child(
     out_root: Path,
     timeout_seconds: float | None = None,
     extra_env: dict[str, str] | None = None,
+    env_base: Mapping[str, str] | None = None,
 ) -> ChildResult:
     """Run one `quorum run` as a subprocess; capture its run-id line.
 
@@ -226,12 +229,13 @@ def invoke_child(
         str(out_root),
     ]
     try:
+        base_env = dict(env_base) if env_base is not None else dict(os.environ)
         completed = subprocess.run(
             cmd,
             capture_output=True,
             text=True,
             timeout=timeout_seconds,
-            env={**os.environ, **(extra_env or {})},
+            env={**base_env, **(extra_env or {})},
         )
     except subprocess.TimeoutExpired:
         return ChildResult(run_id=None, exit_code=-1, error="child timed out")
@@ -246,7 +250,12 @@ def invoke_child(
     return ChildResult(run_id=run_id, exit_code=completed.returncode, error=None)
 
 
-def prepare_kimi_batch_preflight(*, batch_dir: Path, coding_agents_dir: Path) -> dict[str, str]:
+def prepare_kimi_batch_preflight(
+    *,
+    batch_dir: Path,
+    coding_agents_dir: Path,
+    env_base: Mapping[str, str] | None = None,
+) -> dict[str, str]:
     """Run Kimi auth/model preflight once for a run-all batch.
 
     Children receive the returned marker env so they can skip their direct
@@ -260,12 +269,13 @@ def prepare_kimi_batch_preflight(*, batch_dir: Path, coding_agents_dir: Path) ->
     binary = raw.get("binary")
     if not isinstance(binary, str) or not binary:
         raise ValueError(f"{kimi_yaml}: missing Kimi binary")
-    kimi_binary = resolve_kimi_binary(binary)
-    kimi_env = effective_kimi_model_env(os.environ)
+    base_env = dict(env_base) if env_base is not None else dict(os.environ)
+    kimi_binary = resolve_kimi_binary(binary, env=base_env)
+    kimi_env = effective_kimi_model_env(base_env)
     run_kimi_auth_preflight(
         kimi_binary=kimi_binary,
         kimi_model_env=kimi_env,
-        base_env=os.environ,
+        base_env=base_env,
     )
     preflight_token = secrets.token_urlsafe(32)
     marker = batch_dir / "kimi-preflight-ok.json"
@@ -285,6 +295,26 @@ def prepare_kimi_batch_preflight(*, batch_dir: Path, coding_agents_dir: Path) ->
         "QUORUM_KIMI_PREFLIGHT_SENTINEL": str(marker),
         "QUORUM_KIMI_PREFLIGHT_TOKEN": preflight_token,
     }
+
+
+def _target_env_base_for_preflight(
+    env_base: Mapping[str, str] | None,
+    target: str,
+) -> Mapping[str, str] | None:
+    if env_base is None or not is_managed_host(env_base):
+        return env_base
+    if env_base.get("QUORUM_TARGET") == target:
+        return env_base
+    profile_root = env_base.get("QUORUM_TARGET_PROFILE_ROOT")
+    if not profile_root:
+        return env_base
+    profile = load_target_profile(Path(profile_root), target)
+    return build_managed_env(
+        env_base,
+        discover_managed_paths(env_base),
+        profile,
+        runtime_vars={},
+    )
 
 
 def _write_setup_indeterminate_run(
@@ -508,6 +538,7 @@ def run_batch(
     invoke: Callable[..., ChildResult] | None = None,
     stream: TextIO | None = None,
     use_cursor: bool = True,
+    env_base: Mapping[str, str] | None = None,
 ) -> Path:
     """Run the full batch. Returns the batch dir path.
 
@@ -618,13 +649,18 @@ def run_batch(
 
     kimi_entries = [(idx, entry) for idx, entry in runnable_indexed if entry.coding_agent == "kimi"]
     if kimi_entries:
+        kimi_env_base = _target_env_base_for_preflight(env_base, "kimi")
+        kimi_preflight_base_env = (
+            dict(kimi_env_base) if kimi_env_base is not None else dict(os.environ)
+        )
         try:
             preflight_env_by_agent["kimi"] = prepare_kimi_batch_preflight(
                 batch_dir=batch_dir,
                 coding_agents_dir=coding_agents_dir,
+                env_base=kimi_env_base,
             )
         except Exception as e:
-            message = sanitize_kimi_diagnostic(e)
+            message = sanitize_kimi_diagnostic(e, env=kimi_preflight_base_env)
             for idx, entry in kimi_entries:
                 run_id = _write_setup_indeterminate_run(
                     out_root=out_root,
@@ -677,13 +713,23 @@ def run_batch(
                     highlight=False,
                 )
         t0 = time.monotonic()
-        result = invoke(
-            scenario_dir=entry.scenario_dir,
-            coding_agent=entry.coding_agent,
-            coding_agents_dir=coding_agents_dir,
-            out_root=out_root,
-            extra_env=preflight_env_by_agent.get(entry.coding_agent),
-        )
+        if env_base is None:
+            result = invoke(
+                scenario_dir=entry.scenario_dir,
+                coding_agent=entry.coding_agent,
+                coding_agents_dir=coding_agents_dir,
+                out_root=out_root,
+                extra_env=preflight_env_by_agent.get(entry.coding_agent),
+            )
+        else:
+            result = invoke(
+                scenario_dir=entry.scenario_dir,
+                coding_agent=entry.coding_agent,
+                coding_agents_dir=coding_agents_dir,
+                out_root=out_root,
+                extra_env=preflight_env_by_agent.get(entry.coding_agent),
+                env_base=env_base,
+            )
         if result.run_id and _is_rate_limited_verdict(_read_verdict(out_root / result.run_id)):
             with rate_limit_lock:
                 rate_limited_agents.add(entry.coding_agent)

--- a/quorum/run_all.py
+++ b/quorum/run_all.py
@@ -200,6 +200,32 @@ def _parse_run_id(stdout: str) -> str | None:
     return None
 
 
+def _child_id_for_index(idx: int) -> str:
+    return f"child-{idx:04d}"
+
+
+def _child_run_command(
+    *,
+    scenario_dir: Path,
+    coding_agent: str,
+    coding_agents_dir: Path,
+    out_root: Path,
+) -> list[str]:
+    return [
+        "uv",
+        "run",
+        "quorum",
+        "run",
+        str(scenario_dir),
+        "--coding-agent",
+        coding_agent,
+        "--coding-agents-dir",
+        str(coding_agents_dir),
+        "--out-root",
+        str(out_root),
+    ]
+
+
 def invoke_child(
     *,
     scenario_dir: Path,
@@ -215,19 +241,12 @@ def invoke_child(
     `coding_agents_dir` and `out_root` are forwarded as explicit flags so
     the child doesn't rely on its own cwd-relative defaults.
     """
-    cmd = [
-        "uv",
-        "run",
-        "quorum",
-        "run",
-        str(scenario_dir),
-        "--coding-agent",
-        coding_agent,
-        "--coding-agents-dir",
-        str(coding_agents_dir),
-        "--out-root",
-        str(out_root),
-    ]
+    cmd = _child_run_command(
+        scenario_dir=scenario_dir,
+        coding_agent=coding_agent,
+        coding_agents_dir=coding_agents_dir,
+        out_root=out_root,
+    )
     try:
         base_env = dict(env_base) if env_base is not None else dict(os.environ)
         completed = subprocess.run(
@@ -539,6 +558,9 @@ def run_batch(
     stream: TextIO | None = None,
     use_cursor: bool = True,
     env_base: Mapping[str, str] | None = None,
+    on_batch_allocated: Callable[[Path], None] | None = None,
+    on_child_started: Callable[[str, MatrixEntry, list[str]], None] | None = None,
+    on_child_finished: Callable[[str, ChildResult], None] | None = None,
 ) -> Path:
     """Run the full batch. Returns the batch dir path.
 
@@ -564,6 +586,8 @@ def run_batch(
         include_drafts=include_drafts,
     )
     batch_dir = allocate_batch_dir(out_root=out_root)
+    if on_batch_allocated is not None:
+        on_batch_allocated(batch_dir)
     started_at = datetime.now(UTC)
     indexed = list(enumerate(entries, 1))
     total = len(entries)
@@ -633,6 +657,18 @@ def run_batch(
             f"  {'':<{_DUR_COL_W}}  {reason_label}",
         )
         console.print(line, markup=False, highlight=False)
+        child_id = _child_id_for_index(idx)
+        if on_child_started is not None:
+            on_child_started(
+                child_id,
+                entry,
+                _child_run_command(
+                    scenario_dir=entry.scenario_dir,
+                    coding_agent=entry.coding_agent,
+                    coding_agents_dir=coding_agents_dir,
+                    out_root=out_root,
+                ),
+            )
         append_result_record(
             batch_dir=batch_dir,
             scenario=entry.scenario,
@@ -640,6 +676,15 @@ def run_batch(
             run_id=None,
             skipped=entry.skipped_reason,
         )
+        if on_child_finished is not None:
+            on_child_finished(
+                child_id,
+                ChildResult(
+                    run_id=None,
+                    exit_code=0,
+                    error=f"skipped:{entry.skipped_reason or 'skipped'}",
+                ),
+            )
 
     # Lock guards both `console.print` from workers (plain mode) AND
     # results.jsonl writes (which happen on the main futures-completion
@@ -662,12 +707,29 @@ def run_batch(
         except Exception as e:
             message = sanitize_kimi_diagnostic(e, env=kimi_preflight_base_env)
             for idx, entry in kimi_entries:
+                child_id = _child_id_for_index(idx)
+                if on_child_started is not None:
+                    on_child_started(
+                        child_id,
+                        entry,
+                        _child_run_command(
+                            scenario_dir=entry.scenario_dir,
+                            coding_agent=entry.coding_agent,
+                            coding_agents_dir=coding_agents_dir,
+                            out_root=out_root,
+                        ),
+                    )
                 run_id = _write_setup_indeterminate_run(
                     out_root=out_root,
                     scenario=entry.scenario,
                     coding_agent=entry.coding_agent,
                     message=message,
                 )
+                if on_child_finished is not None:
+                    on_child_finished(
+                        child_id,
+                        ChildResult(run_id=run_id, exit_code=2, error=None),
+                    )
                 progress.finished(idx, "indeterminate")
                 append_result_record(
                     batch_dir=batch_dir,
@@ -688,18 +750,28 @@ def run_batch(
     rate_limited_agents: set[str] = set()
 
     def _worker(idx: int, entry: MatrixEntry) -> tuple[int, MatrixEntry, ChildResult, float]:
+        child_id = _child_id_for_index(idx)
+        if on_child_started is not None:
+            on_child_started(
+                child_id,
+                entry,
+                _child_run_command(
+                    scenario_dir=entry.scenario_dir,
+                    coding_agent=entry.coding_agent,
+                    coding_agents_dir=coding_agents_dir,
+                    out_root=out_root,
+                ),
+            )
         with rate_limit_lock:
             latched = entry.coding_agent in rate_limited_agents
         if latched:
             # This agent already exhausted its rate-limit window; don't invoke
             # — a doomed preflight can hang for the full timeout and deepen the
             # lockout. Signal a skip to _drain via the sentinel.
-            return (
-                idx,
-                entry,
-                ChildResult(run_id=None, exit_code=0, error=_RATE_LIMIT_SKIP_SENTINEL),
-                0.0,
-            )
+            result = ChildResult(run_id=None, exit_code=0, error=_RATE_LIMIT_SKIP_SENTINEL)
+            if on_child_finished is not None:
+                on_child_finished(child_id, result)
+            return (idx, entry, result, 0.0)
         progress.started(idx, entry)
         if not use_live:
             with print_lock:
@@ -733,6 +805,8 @@ def run_batch(
         if result.run_id and _is_rate_limited_verdict(_read_verdict(out_root / result.run_id)):
             with rate_limit_lock:
                 rate_limited_agents.add(entry.coding_agent)
+        if on_child_finished is not None:
+            on_child_finished(child_id, result)
         return idx, entry, result, time.monotonic() - t0
 
     def _drain(pool_for: Callable[[str], ThreadPoolExecutor]) -> None:

--- a/quorum/run_all.py
+++ b/quorum/run_all.py
@@ -191,6 +191,7 @@ _RUN_ID_PREFIX = "run-id: "
 # Sentinel ChildResult.error marking a cell we skipped without invoking because
 # its agent already hit its rate-limit window earlier this batch.
 _RATE_LIMIT_SKIP_SENTINEL = "agy-rate-limit-skip"
+_ABORT_SKIP_SENTINEL = "batch-abort-skip"
 
 
 def _parse_run_id(stdout: str) -> str | None:
@@ -561,6 +562,7 @@ def run_batch(
     on_batch_allocated: Callable[[Path], None] | None = None,
     on_child_started: Callable[[str, MatrixEntry, list[str]], None] | None = None,
     on_child_finished: Callable[[str, ChildResult], None] | None = None,
+    abort_event: threading.Event | None = None,
 ) -> Path:
     """Run the full batch. Returns the batch dir path.
 
@@ -751,16 +753,24 @@ def run_batch(
 
     def _worker(idx: int, entry: MatrixEntry) -> tuple[int, MatrixEntry, ChildResult, float]:
         child_id = _child_id_for_index(idx)
+        child_command = _child_run_command(
+            scenario_dir=entry.scenario_dir,
+            coding_agent=entry.coding_agent,
+            coding_agents_dir=coding_agents_dir,
+            out_root=out_root,
+        )
+        if abort_event is not None and abort_event.is_set():
+            result = ChildResult(run_id=None, exit_code=0, error=_ABORT_SKIP_SENTINEL)
+            if on_child_started is not None:
+                on_child_started(child_id, entry, child_command)
+            if on_child_finished is not None:
+                on_child_finished(child_id, result)
+            return (idx, entry, result, 0.0)
         if on_child_started is not None:
             on_child_started(
                 child_id,
                 entry,
-                _child_run_command(
-                    scenario_dir=entry.scenario_dir,
-                    coding_agent=entry.coding_agent,
-                    coding_agents_dir=coding_agents_dir,
-                    out_root=out_root,
-                ),
+                child_command,
             )
         with rate_limit_lock:
             latched = entry.coding_agent in rate_limited_agents
@@ -834,6 +844,25 @@ def run_batch(
                         coding_agent=entry.coding_agent,
                         run_id=None,
                         skipped="rate-limited",
+                    )
+                continue
+            if result.error == _ABORT_SKIP_SENTINEL:
+                scn = _truncate(entry.scenario, scn_w)
+                line = Text.assemble(
+                    f"[{idx:0{idx_w}d}/{total}] {'skip':<{_STATE_COL_W}}  "
+                    f"{scn:<{scn_w}}  {entry.coding_agent:<{agent_w}}  ",
+                    (_GLYPH_SKIP, _STATUS_STYLES["skipped"]),
+                    f"  {'':<{_DUR_COL_W}}  (batch aborted)",
+                )
+                with print_lock:
+                    progress.finished(idx, "skipped")
+                    console.print(line, markup=False, highlight=False)
+                    append_result_record(
+                        batch_dir=batch_dir,
+                        scenario=entry.scenario,
+                        coding_agent=entry.coding_agent,
+                        run_id=None,
+                        skipped="aborted",
                     )
                 continue
             final = _final_status_for_result(result, out_root)

--- a/quorum/runner.py
+++ b/quorum/runner.py
@@ -2626,6 +2626,33 @@ def run_scenario(
         scenario_name=scenario_dir.name,
         coding_agent=coding_agent,
     )
+    return run_scenario_in_dir(
+        run_dir=run_dir,
+        scenario_dir=scenario_dir,
+        coding_agent=coding_agent,
+        coding_agents_dir=coding_agents_dir,
+        out_root=out_root,
+        skeleton_root=skeleton_root,
+        env_base=env_base,
+    )
+
+
+def run_scenario_in_dir(
+    *,
+    run_dir: Path,
+    scenario_dir: Path,
+    coding_agent: str,
+    coding_agents_dir: Path,
+    out_root: Path,
+    skeleton_root: Path | None = None,
+    env_base: Mapping[str, str] | None = None,
+) -> tuple[Path, FinalVerdict]:
+    """Run one scenario in a caller-allocated run directory.
+
+    Managed smoke uses this seam to persist the run-dir in job state before
+    executing the live eval. Exception mapping intentionally matches
+    `run_scenario`.
+    """
     try:
         return _run_scenario_inner(
             run_dir=run_dir,

--- a/quorum/runner.py
+++ b/quorum/runner.py
@@ -208,14 +208,23 @@ class RunnerError(RuntimeError):
         self.stage = stage
 
 
-def _preflight_coding_agent_binary(tcfg: CodingAgentConfig) -> None:
+def _preflight_coding_agent_binary(
+    tcfg: CodingAgentConfig,
+    env_base: Mapping[str, str] | None = None,
+) -> None:
     if tcfg.runtime_family != "claude":
         return
-    if shutil.which(tcfg.binary) is None:
+    if _which(tcfg.binary, env_base) is None:
         raise RunnerError(
             f"Claude Code is not on PATH: {tcfg.binary!r}",
             stage="setup",
         )
+
+
+def _which(binary: str, env_base: Mapping[str, str] | None = None) -> str | None:
+    if env_base is None:
+        return shutil.which(binary)
+    return shutil.which(binary, path=env_base.get("PATH", os.defpath))
 
 
 @dataclasses.dataclass(frozen=True)
@@ -339,7 +348,12 @@ def _seed_codex_auth(codex_home: Path) -> None:
     dest.chmod(0o600)
 
 
-def _seed_codex_plugin_hooks(codex_home: Path, workdir: Path) -> None:
+def _seed_codex_plugin_hooks(
+    codex_home: Path,
+    workdir: Path,
+    *,
+    env_base: Mapping[str, str] | None = None,
+) -> None:
     """Stage Superpowers as a trusted Codex plugin hook in the per-run home.
 
     The codex home already exists and is logged in (see _seed_codex_auth).
@@ -348,7 +362,8 @@ def _seed_codex_plugin_hooks(codex_home: Path, workdir: Path) -> None:
     the Superpowers access every claude run gets. The install ceremony is
     the shared setup_helpers function, pointed at the per-run CODEX_HOME.
     """
-    superpowers_root = os.environ.get("SUPERPOWERS_ROOT", "")
+    host_env = os.environ if env_base is None else env_base
+    superpowers_root = host_env.get("SUPERPOWERS_ROOT", "")
     if not superpowers_root:
         raise RunnerError("SUPERPOWERS_ROOT not set; cannot install codex plugin hooks")
     install_codex_superpowers_plugin_hooks(workdir, superpowers_root, codex_home=codex_home)
@@ -387,8 +402,9 @@ def _shell_single_quote(value: str) -> str:
     return "'" + value.replace("'", "'\"'\"'") + "'"
 
 
-def _gemini_stderr_excerpt(stderr: str) -> str:
-    api_key = os.environ.get("GEMINI_API_KEY", "")
+def _gemini_stderr_excerpt(stderr: str, env: Mapping[str, str] | None = None) -> str:
+    host_env = os.environ if env is None else env
+    api_key = host_env.get("GEMINI_API_KEY", "")
     excerpt = stderr.strip()
     if api_key:
         excerpt = excerpt.replace(api_key, "[redacted]")
@@ -402,9 +418,15 @@ def _gemini_extension_list_shows_superpowers(stdout: str) -> bool:
     )
 
 
-def _write_gemini_env_file(gemini_home: Path, auth_type: str | None = None) -> Path:
-    auth_type = auth_type or _gemini_auth_type()
-    api_key = os.environ.get("GEMINI_API_KEY", "")
+def _write_gemini_env_file(
+    gemini_home: Path,
+    auth_type: str | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> Path:
+    host_env = os.environ if env is None else env
+    auth_type = auth_type or _gemini_auth_type(host_env)
+    api_key = host_env.get("GEMINI_API_KEY", "")
     if auth_type == GEMINI_AUTH_TYPE_API_KEY and not api_key:
         raise RunnerError("GEMINI_API_KEY not set; cannot seed Gemini auth", stage="setup")
     env_file = gemini_home / GEMINI_ENV_FILE_NAME
@@ -433,9 +455,14 @@ def _write_private_text(path: Path, content: str) -> None:
         os.fchmod(f.fileno(), 0o600)
 
 
-def _copy_gemini_oauth_credentials(gemini_home: Path) -> None:
+def _copy_gemini_oauth_credentials(
+    gemini_home: Path,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> None:
+    host_env = os.environ if env is None else env
     source_home = Path(
-        os.environ.get("GEMINI_OAUTH_HOME", str(Path.home() / ".gemini"))
+        host_env.get("GEMINI_OAUTH_HOME", str(Path.home() / ".gemini"))
     ).expanduser()
     for name in ("oauth_creds.json", "google_accounts.json"):
         source = source_home / name
@@ -447,8 +474,12 @@ def _copy_gemini_oauth_credentials(gemini_home: Path) -> None:
         _write_private_text(gemini_home / ".gemini" / name, source.read_text())
 
 
-def _write_claude_env_file(claude_config_dir: Path) -> Path:
-    api_key = _require_env("ANTHROPIC_API_KEY", "seed Claude auth")
+def _write_claude_env_file(
+    claude_config_dir: Path,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> Path:
+    api_key = _require_env("ANTHROPIC_API_KEY", "seed Claude auth", env)
     env_file = claude_config_dir / CLAUDE_ENV_FILE_NAME
     env_file.parent.mkdir(parents=True, exist_ok=True)
     flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
@@ -506,6 +537,8 @@ def _gh_auth_token() -> str | None:
 
 def _resolve_copilot_auth_env(
     env: Mapping[str, str] | None = None,
+    *,
+    allow_gh_fallback: bool = True,
 ) -> tuple[dict[str, str], tuple[str, ...], tuple[str, ...]]:
     host_env = os.environ if env is None else env
     if _copilot_offline_requested(host_env) and not host_env.get("COPILOT_PROVIDER_BASE_URL"):
@@ -532,7 +565,7 @@ def _resolve_copilot_auth_env(
         if value:
             token_value = value
             break
-    if not token_value:
+    if not token_value and allow_gh_fallback:
         token_value = _gh_auth_token() or ""
     if not token_value:
         raise RunnerError(
@@ -575,25 +608,31 @@ def _require_gemini_superpowers_root(superpowers_root: str) -> Path:
     return root
 
 
-def _seed_gemini_config(gemini_home: Path, workdir: Path) -> None:
+def _seed_gemini_config(
+    gemini_home: Path,
+    workdir: Path,
+    *,
+    env_base: Mapping[str, str] | None = None,
+) -> None:
     """Install Superpowers into an isolated Gemini CLI home without invoking the model."""
     del workdir
-    superpowers_root = _require_gemini_superpowers_root(os.environ.get("SUPERPOWERS_ROOT", ""))
-    if shutil.which("gemini") is None:
+    host_env = os.environ if env_base is None else env_base
+    superpowers_root = _require_gemini_superpowers_root(host_env.get("SUPERPOWERS_ROOT", ""))
+    if _which("gemini", env_base) is None:
         raise RunnerError(
             "gemini not found on PATH; cannot run Gemini evals",
             stage="setup",
         )
 
-    auth_type = _gemini_auth_type()
+    auth_type = _gemini_auth_type(host_env)
     gemini_home.mkdir(parents=True, exist_ok=True)
     _write_gemini_settings(gemini_home, auth_type)
-    _write_gemini_env_file(gemini_home, auth_type)
+    _write_gemini_env_file(gemini_home, auth_type, env=host_env)
     if auth_type == GEMINI_AUTH_TYPE_OAUTH:
-        _copy_gemini_oauth_credentials(gemini_home)
+        _copy_gemini_oauth_credentials(gemini_home, env=host_env)
 
     env = {
-        **os.environ,
+        **host_env,
         "GEMINI_CLI_HOME": str(gemini_home),
         "GEMINI_CLI_TRUST_WORKSPACE": "true",
         "GEMINI_DEFAULT_AUTH_TYPE": auth_type,
@@ -609,7 +648,7 @@ def _seed_gemini_config(gemini_home: Path, workdir: Path) -> None:
     if link.returncode != 0:
         raise RunnerError(
             "gemini extensions link failed "
-            f"(exit {link.returncode}); stderr: {_gemini_stderr_excerpt(link.stderr)}",
+            f"(exit {link.returncode}); stderr: {_gemini_stderr_excerpt(link.stderr, host_env)}",
             stage="setup",
         )
 
@@ -622,9 +661,10 @@ def _seed_gemini_config(gemini_home: Path, workdir: Path) -> None:
         env=env,
     )
     if listing.returncode != 0:
+        stderr = _gemini_stderr_excerpt(listing.stderr, host_env)
         raise RunnerError(
             "gemini extensions list failed "
-            f"(exit {listing.returncode}); stderr: {_gemini_stderr_excerpt(listing.stderr)}",
+            f"(exit {listing.returncode}); stderr: {stderr}",
             stage="setup",
         )
     if not _gemini_extension_list_shows_superpowers(f"{listing.stdout}\n{listing.stderr}"):
@@ -656,20 +696,27 @@ def _seed_gemini_config(gemini_home: Path, workdir: Path) -> None:
         )
 
 
-def _seed_kimi_config(kimi_home: Path, *, run_dir: Path, binary: str) -> AgentRuntime:
+def _seed_kimi_config(
+    kimi_home: Path,
+    *,
+    run_dir: Path,
+    binary: str,
+    env_base: Mapping[str, str] | None = None,
+) -> AgentRuntime:
     """Seed an isolated Kimi home with env-overlay auth and local Superpowers plugin."""
-    superpowers_root = os.environ.get("SUPERPOWERS_ROOT", "")
+    host_env = os.environ if env_base is None else env_base
+    superpowers_root = host_env.get("SUPERPOWERS_ROOT", "")
     if not superpowers_root:
         raise RunnerError(
             "SUPERPOWERS_ROOT not set; cannot install Kimi Superpowers plugin",
             stage="setup",
         )
-    preflight_sentinel = os.environ.get("QUORUM_KIMI_PREFLIGHT_SENTINEL")
-    preflight_token = os.environ.get("QUORUM_KIMI_PREFLIGHT_TOKEN")
+    preflight_sentinel = host_env.get("QUORUM_KIMI_PREFLIGHT_SENTINEL")
+    preflight_token = host_env.get("QUORUM_KIMI_PREFLIGHT_TOKEN")
 
     try:
-        kimi_binary = resolve_kimi_binary(binary)
-        kimi_env = effective_kimi_model_env(os.environ)
+        kimi_binary = resolve_kimi_binary(binary, env=env_base)
+        kimi_env = effective_kimi_model_env(host_env)
         if preflight_sentinel:
             validate_kimi_preflight_sentinel(
                 Path(preflight_sentinel),
@@ -681,18 +728,18 @@ def _seed_kimi_config(kimi_home: Path, *, run_dir: Path, binary: str) -> AgentRu
             run_kimi_auth_preflight(
                 kimi_binary=kimi_binary,
                 kimi_model_env=kimi_env,
-                base_env=os.environ,
+                base_env=host_env,
             )
         install_kimi_superpowers_plugin(kimi_home, superpowers_root)
     except KimiConfigError as e:
-        raise RunnerError(sanitize_kimi_diagnostic(e), stage="setup") from e
+        raise RunnerError(sanitize_kimi_diagnostic(e, env=host_env), stage="setup") from e
 
     kimi_home.mkdir(parents=True, exist_ok=True)
     for child in ("home", "cache", "xdg-config", "xdg-cache", "xdg-data"):
         (kimi_home / child).mkdir(parents=True, exist_ok=True)
 
     runtime_env = build_kimi_subprocess_env(
-        base_env=os.environ,
+        base_env=host_env,
         kimi_home=kimi_home,
         cwd=kimi_home,
         kimi_model_env=kimi_env,
@@ -756,8 +803,9 @@ def _agy_log_shows_rate_limit(*texts: str) -> bool:
     return any(sig in blob for sig in _AGY_RATE_LIMIT_SUBSTRINGS) or bool(_AGY_429_RE.search(blob))
 
 
-def _run_antigravity_auth_preflight() -> None:
+def _run_antigravity_auth_preflight(env_base: Mapping[str, str] | None = None) -> None:
     """Verify agy auth and hidden --gemini_dir isolation using throwaway state."""
+    host_env = os.environ if env_base is None else env_base
     with tempfile.TemporaryDirectory(prefix="quorum-antigravity-preflight-") as tmp:
         tmp_path = Path(tmp)
         cwd = tmp_path / "cwd"
@@ -782,7 +830,7 @@ def _run_antigravity_auth_preflight() -> None:
                 text=True,
                 capture_output=True,
                 timeout=90,
-                env={**os.environ, "AGY_CLI_DISABLE_AUTO_UPDATE": "true"},
+                env={**host_env, "AGY_CLI_DISABLE_AUTO_UPDATE": "true"},
             )
         except subprocess.TimeoutExpired as e:
             raise RunnerError(
@@ -859,22 +907,31 @@ def _write_antigravity_settings(
     settings_path.write_text(json.dumps(settings, indent=2))
 
 
-def _seed_antigravity_config(antigravity_config_dir: Path, workdir: Path) -> None:
+def _seed_antigravity_config(
+    antigravity_config_dir: Path,
+    workdir: Path,
+    *,
+    env_base: Mapping[str, str] | None = None,
+) -> None:
     """Install Superpowers into an isolated Antigravity .gemini tree."""
-    superpowers_root = os.environ.get("SUPERPOWERS_ROOT", "")
+    host_env = os.environ if env_base is None else env_base
+    superpowers_root = host_env.get("SUPERPOWERS_ROOT", "")
     if not superpowers_root:
         raise RunnerError(
             "SUPERPOWERS_ROOT not set; cannot install antigravity Superpowers plugin",
             stage="setup",
         )
-    if shutil.which("agy") is None:
+    if _which("agy", env_base) is None:
         raise RunnerError(
             "agy not found on PATH; cannot run antigravity evals",
             stage="setup",
         )
 
     antigravity_config_dir.mkdir(parents=True, exist_ok=True)
-    _run_antigravity_auth_preflight()
+    if env_base is None:
+        _run_antigravity_auth_preflight()
+    else:
+        _run_antigravity_auth_preflight(host_env)
 
     cmd = [
         "agy",
@@ -888,7 +945,7 @@ def _seed_antigravity_config(antigravity_config_dir: Path, workdir: Path) -> Non
         cwd=antigravity_config_dir,
         text=True,
         capture_output=True,
-        env={**os.environ, "AGY_CLI_DISABLE_AUTO_UPDATE": "true"},
+        env={**host_env, "AGY_CLI_DISABLE_AUTO_UPDATE": "true"},
     )
     if result.returncode != 0:
         raise RunnerError(
@@ -923,7 +980,7 @@ def _seed_antigravity_config(antigravity_config_dir: Path, workdir: Path) -> Non
         )
 
 
-def _run_opencode_provider_preflight() -> None:
+def _run_opencode_provider_preflight(env_base: Mapping[str, str] | None = None) -> None:
     """Verify OpenCode can answer in a throwaway isolated home.
 
     The model is pinned (-m) so the check exercises the same provider the
@@ -952,6 +1009,7 @@ def _run_opencode_provider_preflight() -> None:
                 opencode_home=home,
                 launch_cwd=cwd,
                 timeout=15,
+                env_base=env_base,
             )
             version_hint = (version.stdout or version.stderr).strip() or "unknown"
         except (subprocess.TimeoutExpired, OSError):
@@ -970,6 +1028,7 @@ def _run_opencode_provider_preflight() -> None:
                     opencode_home=home,
                     launch_cwd=cwd,
                     timeout=90,
+                    env_base=env_base,
                 )
             except subprocess.TimeoutExpired as e:
                 raise RunnerError(
@@ -1081,14 +1140,20 @@ def _seed_copilot_config(
     copilot_home: Path,
     workdir: Path,
     session_id: str,
+    *,
+    env_base: Mapping[str, str] | None = None,
 ) -> CopilotProvisioning:
     """Stage Superpowers and prepare isolated Copilot CLI state."""
     del workdir
-    sp_root = _require_copilot_superpowers_root(os.environ.get("SUPERPOWERS_ROOT", ""))
-    if shutil.which("copilot") is None:
+    host_env = os.environ if env_base is None else env_base
+    sp_root = _require_copilot_superpowers_root(host_env.get("SUPERPOWERS_ROOT", ""))
+    if _which("copilot", env_base) is None:
         raise RunnerError("copilot not found on PATH; cannot run Copilot evals", stage="setup")
 
-    env_values, secret_names, secret_values = _resolve_copilot_auth_env()
+    env_values, secret_names, secret_values = _resolve_copilot_auth_env(
+        host_env,
+        allow_gh_fallback=env_base is None,
+    )
     env_file = _write_copilot_env_file(copilot_home, env_values)
     for path in (
         copilot_home / ".quorum",
@@ -1170,15 +1235,20 @@ def _scan_copilot_secret_leaks(
     return tuple(leaks)
 
 
-def _seed_opencode_config(opencode_home: Path) -> None:
+def _seed_opencode_config(
+    opencode_home: Path,
+    *,
+    env_base: Mapping[str, str] | None = None,
+) -> None:
     """Install Superpowers into an isolated OpenCode home."""
-    superpowers_root = os.environ.get("SUPERPOWERS_ROOT", "")
+    host_env = os.environ if env_base is None else env_base
+    superpowers_root = host_env.get("SUPERPOWERS_ROOT", "")
     if not superpowers_root:
         raise RunnerError(
             "SUPERPOWERS_ROOT not set; cannot install opencode Superpowers plugin",
             stage="setup",
         )
-    if shutil.which("opencode") is None:
+    if _which("opencode", env_base) is None:
         raise RunnerError("opencode not found on PATH; cannot run opencode evals", stage="setup")
 
     sp_root = Path(superpowers_root)
@@ -1244,7 +1314,7 @@ def _seed_opencode_config(opencode_home: Path) -> None:
         plugin_link.unlink()
     plugin_link.symlink_to(staged_plugin)
 
-    node = shutil.which("node")
+    node = _which("node", env_base)
     if node is not None:
         result = subprocess.run(
             [node, "--check", str(staged_plugin)],
@@ -1264,11 +1334,12 @@ def _seed_opencode_config(opencode_home: Path) -> None:
     for path in staged_skills.rglob("*"):
         _require_under_home(path, opencode_home)
 
-    _run_opencode_provider_preflight()
+    _run_opencode_provider_preflight(env_base)
 
 
-def _require_env(name: str, purpose: str) -> str:
-    value = os.environ.get(name, "")
+def _require_env(name: str, purpose: str, env: Mapping[str, str] | None = None) -> str:
+    host_env = os.environ if env is None else env
+    value = host_env.get(name, "")
     if not value:
         raise RunnerError(f"{name} not set; cannot {purpose}", stage="setup")
     return value
@@ -1297,10 +1368,14 @@ PI_AZURE_ENV_NAMES = (
 )
 
 
-def _pi_provider_extra_env(provider: str) -> dict[str, str]:
+def _pi_provider_extra_env(
+    provider: str,
+    env: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    host_env = os.environ if env is None else env
     if provider != "azure-openai-responses":
         return {}
-    if not os.environ.get("AZURE_OPENAI_BASE_URL") and not os.environ.get(
+    if not host_env.get("AZURE_OPENAI_BASE_URL") and not host_env.get(
         "AZURE_OPENAI_RESOURCE_NAME"
     ):
         raise RunnerError(
@@ -1308,7 +1383,7 @@ def _pi_provider_extra_env(provider: str) -> dict[str, str]:
             "or AZURE_OPENAI_RESOURCE_NAME",
             stage="setup",
         )
-    return {name: os.environ[name] for name in PI_AZURE_ENV_NAMES if os.environ.get(name)}
+    return {name: host_env[name] for name in PI_AZURE_ENV_NAMES if host_env.get(name)}
 
 
 def _write_pi_env_file(
@@ -1332,17 +1407,24 @@ def _write_pi_env_file(
     return env_path
 
 
-def _seed_pi_config(pi_config_dir: Path) -> None:
-    superpowers_raw = _require_env("SUPERPOWERS_ROOT", "load Pi Superpowers extension")
-    provider = _require_env("PI_PROVIDER", "configure Pi provider")
-    model = _require_env("PI_MODEL", "configure Pi model")
-    api_key = _require_env("PI_API_KEY", "configure Pi API-key auth")
-    extra_env = _pi_provider_extra_env(provider)
+def _seed_pi_config(
+    pi_config_dir: Path,
+    *,
+    env_base: Mapping[str, str] | None = None,
+) -> None:
+    host_env = os.environ if env_base is None else env_base
+    superpowers_raw = _require_env(
+        "SUPERPOWERS_ROOT", "load Pi Superpowers extension", host_env
+    )
+    provider = _require_env("PI_PROVIDER", "configure Pi provider", host_env)
+    model = _require_env("PI_MODEL", "configure Pi model", host_env)
+    api_key = _require_env("PI_API_KEY", "configure Pi API-key auth", host_env)
+    extra_env = _pi_provider_extra_env(provider, host_env)
 
     superpowers_root = Path(superpowers_raw).expanduser()
     _require_pi_superpowers_source(superpowers_root)
 
-    if shutil.which("pi") is None:
+    if _which("pi", env_base) is None:
         raise RunnerError("pi not found on PATH; cannot run Pi evals", stage="setup")
 
     pi_config_dir.mkdir(parents=True, exist_ok=True)
@@ -1383,6 +1465,7 @@ def _seed_agent_config_dir(
     workdir: Path,
     *,
     run_dir: Path,
+    env_base: Mapping[str, str] | None = None,
 ) -> AgentRuntime:
     """Allocate a fresh per-run agent-config dir.
 
@@ -1422,8 +1505,8 @@ def _seed_agent_config_dir(
         }
         config_path.write_text(json.dumps(config))
     if runtime_family == "claude" and "ANTHROPIC_API_KEY" in coding_agent.required_env:
-        api_key = _require_env("ANTHROPIC_API_KEY", "seed Claude auth")
-        env_file = _write_claude_env_file(dest)
+        api_key = _require_env("ANTHROPIC_API_KEY", "seed Claude auth", env_base)
+        env_file = _write_claude_env_file(dest, env=env_base)
         _approve_claude_api_key(dest / ".claude.json", api_key)
         runtime = AgentRuntime(
             substitutions={
@@ -1433,17 +1516,37 @@ def _seed_agent_config_dir(
         )
     if coding_agent.name == "codex":
         _seed_codex_auth(dest)
-        _seed_codex_plugin_hooks(dest, workdir)
+        if env_base is None:
+            _seed_codex_plugin_hooks(dest, workdir)
+        else:
+            _seed_codex_plugin_hooks(dest, workdir, env_base=env_base)
     if coding_agent.name == "kimi":
-        runtime = _seed_kimi_config(dest, run_dir=run_dir, binary=coding_agent.binary)
+        if env_base is None:
+            runtime = _seed_kimi_config(dest, run_dir=run_dir, binary=coding_agent.binary)
+        else:
+            runtime = _seed_kimi_config(
+                dest,
+                run_dir=run_dir,
+                binary=coding_agent.binary,
+                env_base=env_base,
+            )
     if coding_agent.name == "antigravity":
-        _seed_antigravity_config(dest, workdir)
+        if env_base is None:
+            _seed_antigravity_config(dest, workdir)
+        else:
+            _seed_antigravity_config(dest, workdir, env_base=env_base)
     if coding_agent.name == "gemini":
-        _seed_gemini_config(dest, workdir)
+        if env_base is None:
+            _seed_gemini_config(dest, workdir)
+        else:
+            _seed_gemini_config(dest, workdir, env_base=env_base)
     if coding_agent.name == "opencode":
-        _seed_opencode_config(dest)
+        _seed_opencode_config(dest, env_base=env_base)
     if coding_agent.name == "pi":
-        _seed_pi_config(dest)
+        if env_base is None:
+            _seed_pi_config(dest)
+        else:
+            _seed_pi_config(dest, env_base=env_base)
     return runtime
 
 
@@ -1817,6 +1920,7 @@ def _run_scenario_inner(
     coding_agents_dir: Path,
     out_root: Path,
     skeleton_root: Path | None = None,
+    env_base: Mapping[str, str] | None = None,
 ) -> tuple[Path, FinalVerdict]:
     """Inner implementation — run_dir is pre-allocated by the wrapper.
 
@@ -1824,10 +1928,12 @@ def _run_scenario_inner(
     Runs checks.sh pre() before the agent, post() after capture.
     """
     # 1. Parse coding-agent config.
+    runtime_env_base = dict(env_base) if env_base is not None else None
+    host_env: Mapping[str, str] = runtime_env_base if runtime_env_base is not None else os.environ
     coding_agent_path = coding_agents_dir / f"{coding_agent}.yaml"
     if not coding_agent_path.exists():
         raise RunnerError(f"unknown coding-agent {coding_agent!r}: no {coding_agent_path}")
-    tcfg = load_coding_agent_config(coding_agent_path)
+    tcfg = load_coding_agent_config(coding_agent_path, env=host_env)
 
     story_path = scenario_dir / "story.md"
     if not story_path.exists():
@@ -1858,7 +1964,7 @@ def _run_scenario_inner(
             run_dir,
             final_reason=f"requires coding-agents: {', '.join(allowed)}",
         )
-    _preflight_coding_agent_binary(tcfg)
+    _preflight_coding_agent_binary(tcfg, runtime_env_base)
 
     # 3. Create workdir (inside run_dir) + per-run coding-agent-config dir.
     #    Both live inside run_dir so they persist with the rest of the
@@ -1869,11 +1975,19 @@ def _run_scenario_inner(
     agent_runtime = AgentRuntime()
     copilot_provisioning: CopilotProvisioning | None = None
     if tcfg.name == "copilot":
-        copilot_provisioning = _seed_copilot_config(
-            agent_config_dir,
-            workdir,
-            str(uuid.uuid4()),
-        )
+        if runtime_env_base is None:
+            copilot_provisioning = _seed_copilot_config(
+                agent_config_dir,
+                workdir,
+                str(uuid.uuid4()),
+            )
+        else:
+            copilot_provisioning = _seed_copilot_config(
+                agent_config_dir,
+                workdir,
+                str(uuid.uuid4()),
+                env_base=runtime_env_base,
+            )
     else:
         agent_runtime = _seed_agent_config_dir(
             tcfg,
@@ -1881,6 +1995,7 @@ def _run_scenario_inner(
             dest=agent_config_dir,
             workdir=workdir,
             run_dir=run_dir,
+            env_base=runtime_env_base,
         )
     try:
         session_log_dir = tcfg.resolve_session_log_dir(agent_config_dir)
@@ -1889,7 +2004,7 @@ def _run_scenario_inner(
         # 4. Run setup.sh (build the fixture).
         # SetupError propagates directly to the run_scenario wrapper, which maps it
         # to an indeterminate verdict with error.stage="setup".
-        run_setup(scenario_dir, workdir, env_extra=env_extra)
+        run_setup(scenario_dir, workdir, env_extra=env_extra, env_base=runtime_env_base)
 
         # 4b. Run checks.sh pre() — verifies the fixture is in the expected state.
         pre_records, pre_exit = run_phase(
@@ -1899,6 +2014,7 @@ def _run_scenario_inner(
             quorum_bin=_quorum_bin_dir(),
             tool_calls_path=run_dir / "coding-agent-tool-calls.jsonl",
             run_dir=run_dir,
+            env_base=runtime_env_base,
         )
         if pre_exit != 0:
             return run_dir, _write_indeterminate(
@@ -1918,10 +2034,17 @@ def _run_scenario_inner(
         opencode_session_snapshot: set[str] = set()
         if tcfg.normalizer == "opencode":
             try:
-                opencode_session_snapshot = snapshot_opencode_sessions(
-                    opencode_home=agent_config_dir,
-                    launch_cwd=launch_cwd,
-                )
+                if runtime_env_base is None:
+                    opencode_session_snapshot = snapshot_opencode_sessions(
+                        opencode_home=agent_config_dir,
+                        launch_cwd=launch_cwd,
+                    )
+                else:
+                    opencode_session_snapshot = snapshot_opencode_sessions(
+                        opencode_home=agent_config_dir,
+                        launch_cwd=launch_cwd,
+                        env_base=runtime_env_base,
+                    )
             except OpenCodeCaptureError as e:
                 return run_dir, _write_indeterminate(
                     run_dir,
@@ -1947,7 +2070,7 @@ def _run_scenario_inner(
         substitutions = {
             "$QUORUM_AGENT_CWD": str(launch_cwd),
             "$QUORUM_AGENT_CWD_SH": _shell_single_quote(str(launch_cwd)),
-            "$SUPERPOWERS_ROOT": os.environ.get("SUPERPOWERS_ROOT", ""),
+            "$SUPERPOWERS_ROOT": host_env.get("SUPERPOWERS_ROOT", ""),
             "$QUORUM_LAUNCH_AGENT": str(launch_agent_path),
             "$QUORUM_LAUNCH_AGENT_SH": _shell_single_quote(str(launch_agent_path)),
             f"${tcfg.agent_config_env}": str(agent_config_dir),
@@ -1955,7 +2078,7 @@ def _run_scenario_inner(
             **agent_runtime.substitutions,
         }
         if tcfg.name == "gemini":
-            gemini_auth_type = _gemini_auth_type()
+            gemini_auth_type = _gemini_auth_type(host_env)
             substitutions["$GEMINI_ENV_FILE"] = str(agent_config_dir / GEMINI_ENV_FILE_NAME)
             substitutions["$GEMINI_ENV_FILE_SH"] = _shell_single_quote(
                 str(agent_config_dir / GEMINI_ENV_FILE_NAME)
@@ -1994,7 +2117,11 @@ def _run_scenario_inner(
         #    token refresh can corrupt the shared ~/.gemini/oauth_creds.json. Back
         #    it up before the run and verify/restore in a finally after it returns
         #    (A4). Antigravity only; no overhead for other agents.
-        gauntlet_env_base = _copilot_gauntlet_env(os.environ) if tcfg.name == "copilot" else None
+        gauntlet_env_base = (
+            _copilot_gauntlet_env(host_env)
+            if tcfg.name == "copilot"
+            else runtime_env_base
+        )
         cb = agy_creds.backup_credential() if coding_agent == "antigravity" else None
         try:
             gauntlet_result = invoke_gauntlet(
@@ -2040,12 +2167,21 @@ def _run_scenario_inner(
         opencode_exported_paths: tuple[Path, ...] = ()
         if tcfg.normalizer == "opencode":
             try:
-                opencode_exported_paths = export_opencode_sessions(
-                    opencode_home=agent_config_dir,
-                    export_dir=session_log_dir,
-                    launch_cwd=launch_cwd,
-                    snapshot=opencode_session_snapshot,
-                )
+                if runtime_env_base is None:
+                    opencode_exported_paths = export_opencode_sessions(
+                        opencode_home=agent_config_dir,
+                        export_dir=session_log_dir,
+                        launch_cwd=launch_cwd,
+                        snapshot=opencode_session_snapshot,
+                    )
+                else:
+                    opencode_exported_paths = export_opencode_sessions(
+                        opencode_home=agent_config_dir,
+                        export_dir=session_log_dir,
+                        launch_cwd=launch_cwd,
+                        snapshot=opencode_session_snapshot,
+                        env_base=runtime_env_base,
+                    )
             except OpenCodeCaptureError as e:
                 gauntlet_layer = _build_gauntlet_layer_from_run_dir(run_dir)
                 if gauntlet_layer is None:
@@ -2402,6 +2538,7 @@ def _run_scenario_inner(
             quorum_bin=_quorum_bin_dir(),
             tool_calls_path=run_dir / "coding-agent-tool-calls.jsonl",
             run_dir=run_dir,
+            env_base=runtime_env_base,
         )
         if post_exit != 0:
             return run_dir, _write_indeterminate(
@@ -2474,6 +2611,7 @@ def run_scenario(
     coding_agents_dir: Path,
     out_root: Path,
     skeleton_root: Path | None = None,
+    env_base: Mapping[str, str] | None = None,
 ) -> tuple[Path, FinalVerdict]:
     """Run one scenario against one Coding-Agent, always writing verdict.json.
 
@@ -2496,6 +2634,7 @@ def run_scenario(
             coding_agents_dir=coding_agents_dir,
             out_root=out_root,
             skeleton_root=skeleton_root,
+            env_base=env_base,
         )
     except CodingAgentConfigError as e:
         v = _write_indeterminate(

--- a/quorum/runtime_env.py
+++ b/quorum/runtime_env.py
@@ -1,0 +1,150 @@
+"""Managed-host runtime environment helpers."""
+
+from __future__ import annotations
+
+import hmac
+import os
+import re
+import shlex
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+from quorum.managed_state import ManagedPaths
+
+RAW_COMMAND_DISABLED_MESSAGE = (
+    "raw live eval commands are disabled on the managed Quorum host; "
+    "use quorum smoke, quorum column, or quorum batch"
+)
+MANAGED_WORKER_TOKEN_PATH = Path("/opt/quorum/state/worker-token")
+
+_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_TARGET_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+_BASE_ENV_ALLOWLIST = (
+    "PATH",
+    "HOME",
+    "TMPDIR",
+    "LANG",
+    "LC_ALL",
+    "QUORUM_MANAGED_HOST",
+    "QUORUM_MANAGED_WORKER",
+    "QUORUM_TARGET_PROFILE_ROOT",
+    "SUPERPOWERS_ROOT",
+)
+_RUNTIME_ENV_ALLOWLIST = {
+    "PATH",
+    "HOME",
+    "TMPDIR",
+    "LANG",
+    "LC_ALL",
+    "SUPERPOWERS_ROOT",
+}
+_CONTROLLER_ENV_KEYS = {
+    "QUORUM_ARTIFACT_ROOT",
+    "QUORUM_STATE_ROOT",
+    "QUORUM_TARGET",
+    "QUORUM_TARGET_ENV_KEYS",
+    "QUORUM_MANAGED_WORKER_TOKEN",
+}
+
+
+@dataclass(frozen=True)
+class TargetProfile:
+    target: str
+    path: Path | None
+    env: Mapping[str, str]
+
+
+class TargetProfileError(RuntimeError):
+    """Raised when a managed target profile is missing or malformed."""
+
+
+def is_managed_host(env: Mapping[str, str]) -> bool:
+    return env.get("QUORUM_MANAGED_HOST") == "1"
+
+
+def is_managed_worker(env: Mapping[str, str]) -> bool:
+    return env.get("QUORUM_MANAGED_WORKER") == "1"
+
+
+def is_trusted_managed_worker(env: Mapping[str, str]) -> bool:
+    if not is_managed_worker(env):
+        return False
+    supplied = env.get("QUORUM_MANAGED_WORKER_TOKEN")
+    if not supplied:
+        return False
+    try:
+        st = MANAGED_WORKER_TOKEN_PATH.stat()
+        if st.st_mode & 0o077:
+            return False
+        expected = MANAGED_WORKER_TOKEN_PATH.read_text().strip()
+    except OSError:
+        return False
+    return bool(expected) and hmac.compare_digest(supplied, expected)
+
+
+def load_target_profile(profile_root: Path, target: str) -> TargetProfile:
+    if _TARGET_RE.fullmatch(target) is None:
+        raise TargetProfileError(f"invalid target profile name: {target!r}")
+    path = profile_root / f"{target}.env"
+    if not path.is_file():
+        raise TargetProfileError(f"target profile not found: {path}")
+
+    values: dict[str, str] = {}
+    for line_no, raw_line in enumerate(path.read_text().splitlines(), 1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        try:
+            parts = shlex.split(raw_line, comments=True, posix=True)
+        except ValueError as exc:
+            raise TargetProfileError(f"{path}:{line_no}: malformed shell assignment") from exc
+        if not parts:
+            continue
+        if parts[0] == "export":
+            parts = parts[1:]
+        if len(parts) != 1 or "=" not in parts[0]:
+            raise TargetProfileError(f"{path}:{line_no}: unsupported target profile line")
+        name, value = parts[0].split("=", 1)
+        if _ENV_NAME_RE.fullmatch(name) is None:
+            raise TargetProfileError(f"{path}:{line_no}: invalid environment variable name")
+        values[name] = value
+    return TargetProfile(target=target, path=path, env=values)
+
+
+def build_managed_env(
+    base_env: Mapping[str, str],
+    paths: ManagedPaths,
+    target_profile: TargetProfile,
+    runtime_vars: Mapping[str, str],
+) -> dict[str, str]:
+    env = {name: base_env[name] for name in _BASE_ENV_ALLOWLIST if base_env.get(name)}
+    env.setdefault("PATH", os.defpath)
+    env.setdefault("LANG", "C.UTF-8")
+    env.update(dict(target_profile.env))
+    env.update(
+        {
+            key: value
+            for key, value in runtime_vars.items()
+            if (key.startswith("QUORUM_") or key in _RUNTIME_ENV_ALLOWLIST)
+            and key not in _CONTROLLER_ENV_KEYS
+        }
+    )
+    env["QUORUM_ARTIFACT_ROOT"] = str(paths.artifact_root)
+    env["QUORUM_STATE_ROOT"] = str(paths.state_root)
+    env["QUORUM_TARGET"] = target_profile.target
+    env["QUORUM_TARGET_ENV_KEYS"] = ",".join(sorted(target_profile.env))
+    return env
+
+
+def redact_env_for_logs(env: Mapping[str, str]) -> dict[str, str]:
+    return {key: "[redacted]" for key in env}
+
+
+def assert_raw_command_allowed(command_name: str, env: Mapping[str, str]) -> None:
+    if (
+        command_name in {"run", "run-all"}
+        and is_managed_host(env)
+        and not is_trusted_managed_worker(env)
+    ):
+        raise PermissionError(RAW_COMMAND_DISABLED_MESSAGE)

--- a/quorum/secret_scan.py
+++ b/quorum/secret_scan.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import BinaryIO
+
+from quorum.managed_state import ManagedJob, ManagedPaths, append_event, mark_job_tainted
+from quorum.runtime_env import TargetProfile
+
+_BINARY_SAMPLE_BYTES = 4096
+_SCAN_CHUNK_BYTES = 1024 * 1024
+_SCAN_OVERLAP_BYTES = 8192
+_SECRET_ENV_NAME_RE = re.compile(
+    r"(?:^|_)(?:API_KEY|KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL|CREDENTIALS)(?:_|$)"
+)
+
+
+@dataclass(frozen=True)
+class SecretPattern:
+    name: str
+    regex: re.Pattern[bytes]
+
+
+@dataclass(frozen=True)
+class SecretMatch:
+    path: str
+    offset: int
+    pattern: str
+    digest: str
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "path": self.path,
+            "offset": self.offset,
+            "pattern": self.pattern,
+            "digest": self.digest,
+        }
+
+
+@dataclass(frozen=True)
+class SecretScanResult:
+    matches: list[SecretMatch] = field(default_factory=list)
+
+    @property
+    def found(self) -> bool:
+        return bool(self.matches)
+
+    def to_json(self) -> dict[str, object]:
+        return {"matches": [match.to_json() for match in self.matches]}
+
+
+def build_secret_patterns(target_profile: TargetProfile) -> list[SecretPattern]:
+    patterns = [
+        SecretPattern("anthropic-api-key", re.compile(rb"\bsk-ant-[A-Za-z0-9_-]{16,}\b")),
+        SecretPattern("openai-api-key", re.compile(rb"\bsk-(?!ant-)[A-Za-z0-9_-]{16,}\b")),
+        SecretPattern(
+            "github-token",
+            re.compile(
+                rb"\b(?:ghp_[A-Za-z0-9_]{20,}|"
+                rb"gho_[A-Za-z0-9_]{20,}|"
+                rb"github_pat_[A-Za-z0-9_]{20,})\b"
+            ),
+        ),
+        SecretPattern("google-api-key", re.compile(rb"\bAIza[0-9A-Za-z_-]{20,}\b")),
+        SecretPattern("aws-access-key-id", re.compile(rb"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b")),
+    ]
+    for name, value in sorted(target_profile.env.items()):
+        if value and _SECRET_ENV_NAME_RE.search(name):
+            patterns.append(SecretPattern(name, re.compile(re.escape(value.encode()))))
+    return patterns
+
+
+def scan_path_for_secrets(path: Path, patterns: Sequence[SecretPattern]) -> SecretScanResult:
+    if not patterns:
+        return SecretScanResult()
+    matches: list[SecretMatch] = []
+    for file_path in _iter_scan_files(path):
+        matches.extend(_scan_file_for_secrets(file_path, patterns))
+    return SecretScanResult(matches=matches)
+
+
+def scan_job_artifacts(
+    job: ManagedJob,
+    patterns: Sequence[SecretPattern],
+    paths: ManagedPaths | None = None,
+) -> SecretScanResult:
+    matches: list[SecretMatch] = []
+    for path in _job_artifact_paths(job, paths):
+        matches.extend(scan_path_for_secrets(path, patterns).matches)
+    return SecretScanResult(matches=matches)
+
+
+def taint_job_on_secret_match(
+    paths: ManagedPaths,
+    job: ManagedJob,
+    result: SecretScanResult,
+) -> ManagedJob:
+    if not result.found:
+        return job
+    match_list = [match.to_json() for match in result.matches]
+    reason = "secret-like material detected in managed artifacts"
+    updated = mark_job_tainted(paths, job.id, reason, match_list)
+    append_event(
+        paths,
+        job.id,
+        {
+            "event": "job-tainted",
+            "job_id": job.id,
+            "reason": reason,
+            "matches": match_list,
+        },
+    )
+    return updated
+
+
+def _iter_scan_files(path: Path) -> list[Path]:
+    try:
+        if path.is_symlink() or not path.exists():
+            return []
+        if path.is_file():
+            return [path]
+        if not path.is_dir():
+            return []
+    except OSError:
+        return []
+
+    files: list[Path] = []
+    for root, dirs, filenames in os.walk(path, followlinks=False):
+        root_path = Path(root)
+        dirs[:] = sorted(dirname for dirname in dirs if not (root_path / dirname).is_symlink())
+        for filename in sorted(filenames):
+            file_path = root_path / filename
+            try:
+                if file_path.is_file() and not file_path.is_symlink():
+                    files.append(file_path)
+            except OSError:
+                continue
+    return files
+
+
+def _scan_file_for_secrets(path: Path, patterns: Sequence[SecretPattern]) -> list[SecretMatch]:
+    try:
+        with path.open("rb") as file:
+            sample = file.read(_BINARY_SAMPLE_BYTES)
+            if b"\x00" in sample:
+                return []
+            file.seek(0)
+            return _scan_stream_for_secrets(file, str(path), patterns)
+    except OSError:
+        return []
+
+
+def _scan_stream_for_secrets(
+    stream: BinaryIO,
+    path: str,
+    patterns: Sequence[SecretPattern],
+) -> list[SecretMatch]:
+    matches: list[SecretMatch] = []
+    seen: set[tuple[str, int, str]] = set()
+    pending = b""
+    stream_offset = 0
+
+    while True:
+        chunk = stream.read(_SCAN_CHUNK_BYTES)
+        if not chunk:
+            _extend_matches(matches, seen, path, pending, stream_offset - len(pending), patterns)
+            return matches
+
+        data = pending + chunk
+        base_offset = stream_offset - len(pending)
+        safe_end = max(0, len(data) - _SCAN_OVERLAP_BYTES)
+        _extend_matches(
+            matches,
+            seen,
+            path,
+            data[:safe_end],
+            base_offset,
+            patterns,
+        )
+        pending = data[safe_end:]
+        if len(pending) > _SCAN_OVERLAP_BYTES:
+            pending = pending[-_SCAN_OVERLAP_BYTES:]
+        stream_offset += len(chunk)
+
+
+def _extend_matches(
+    matches: list[SecretMatch],
+    seen: set[tuple[str, int, str]],
+    path: str,
+    data: bytes,
+    base_offset: int,
+    patterns: Sequence[SecretPattern],
+) -> None:
+    for pattern in patterns:
+        for match in pattern.regex.finditer(data):
+            offset = base_offset + match.start()
+            digest = _short_digest(match.group(0))
+            key = (pattern.name, offset, digest)
+            if key in seen:
+                continue
+            seen.add(key)
+            matches.append(
+                SecretMatch(
+                    path=path,
+                    offset=offset,
+                    pattern=pattern.name,
+                    digest=digest,
+                )
+            )
+
+
+def _job_artifact_paths(job: ManagedJob, managed_paths: ManagedPaths | None) -> list[Path]:
+    artifact_paths: list[Path] = []
+    seen: set[str] = set()
+    if managed_paths is not None:
+        _append_unique(artifact_paths, managed_paths.jobs_dir / f"{job.id}.json", seen)
+        _append_unique(artifact_paths, managed_paths.events_dir / f"{job.id}.jsonl", seen)
+    if job.log_path:
+        _append_unique(artifact_paths, Path(job.log_path), seen)
+    for child in job.children:
+        for path in _child_artifact_paths(job, child):
+            _append_unique(artifact_paths, path, seen)
+    return artifact_paths
+
+
+def _append_unique(paths: list[Path], path: Path, seen: set[str]) -> None:
+    key = str(path)
+    if key in seen:
+        return
+    seen.add(key)
+    paths.append(path)
+
+
+def _child_artifact_paths(job: ManagedJob, child: Mapping[str, object]) -> list[Path]:
+    paths: list[Path] = []
+    run_dir = _path_value(child.get("run_dir"))
+    run_id = _str_value(child.get("run_id"))
+    out_root = _path_value(job.out_root)
+    if run_dir is None and run_id is not None and out_root is not None:
+        run_dir = out_root / run_id
+    if run_dir is not None:
+        paths.append(run_dir)
+
+    batch_dir = _path_value(child.get("batch_dir"))
+    batch_id = _str_value(child.get("batch_id"))
+    if batch_dir is None and batch_id is not None and out_root is not None:
+        batch_dir = out_root / "batches" / batch_id
+    if batch_dir is not None:
+        paths.append(batch_dir)
+    return paths
+
+
+def _path_value(value: object) -> Path | None:
+    if isinstance(value, str) and value:
+        return Path(value)
+    return None
+
+
+def _str_value(value: object) -> str | None:
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _short_digest(value: bytes) -> str:
+    return f"sha256:{hashlib.sha256(value).hexdigest()[:8]}"

--- a/quorum/setup_step.py
+++ b/quorum/setup_step.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+from collections.abc import Mapping
 from pathlib import Path
 
 
@@ -22,11 +23,13 @@ def _run_scenario_script(
     workdir: Path,
     env_extra: dict[str, str] | None,
     error_cls: type[RuntimeError],
+    env_base: Mapping[str, str] | None = None,
 ) -> None:
     script = scenario_dir / script_name
     if not script.exists():
         return
-    env = {**os.environ, "QUORUM_WORKDIR": str(workdir), **(env_extra or {})}
+    base_env = dict(env_base) if env_base is not None else dict(os.environ)
+    env = {**base_env, "QUORUM_WORKDIR": str(workdir), **(env_extra or {})}
     proc = subprocess.run(
         [str(script)],
         cwd=workdir,
@@ -46,5 +49,13 @@ def run_setup(
     scenario_dir: Path,
     workdir: Path,
     env_extra: dict[str, str] | None = None,
+    env_base: Mapping[str, str] | None = None,
 ) -> None:
-    _run_scenario_script(scenario_dir, "setup.sh", workdir, env_extra, SetupError)
+    _run_scenario_script(
+        scenario_dir,
+        "setup.sh",
+        workdir,
+        env_extra,
+        SetupError,
+        env_base=env_base,
+    )

--- a/tests/fixtures/lock_holder.py
+++ b/tests/fixtures/lock_holder.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from quorum.locks import LockRequest, acquire_locks, release_locks
+from quorum.managed_state import discover_managed_paths
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print("usage: lock_holder.py STATE_ROOT LOCK_NAME JOB_ID", file=sys.stderr)
+        return 2
+
+    state_root = Path(sys.argv[1])
+    lock_name = sys.argv[2]
+    job_id = sys.argv[3]
+    paths = discover_managed_paths({"QUORUM_STATE_ROOT": str(state_root)})
+
+    held = acquire_locks(
+        paths,
+        [LockRequest(lock_name)],
+        job_id=job_id,
+        command=["lock-holder", lock_name],
+    )
+    try:
+        print("locked", flush=True)
+        sys.stdin.readline()
+    finally:
+        release_locks(held)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/quorum/test_checks.py
+++ b/tests/quorum/test_checks.py
@@ -140,3 +140,25 @@ def test_run_phase_omits_harness_run_dir_when_none(tmp_path: Path):
     )
     assert exit_code == 0
     assert len(records) == 1 and records[0].passed
+
+
+def test_run_phase_env_base_replaces_ambient_environment(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "ambient-poison")
+    workdir = tmp_path / "wd"
+    workdir.mkdir()
+    checks_sh = tmp_path / "checks.sh"
+    checks_sh.write_text(
+        "pre() { :; }\n"
+        "post() { command-succeeds 'test -z \"${ANTHROPIC_API_KEY:-}\"'; }\n"
+    )
+
+    records, exit_code = run_phase(
+        checks_sh=checks_sh,
+        phase="post",
+        workdir=workdir,
+        quorum_bin=Path("bin").resolve(),
+        env_base={"PATH": "/usr/bin:/bin"},
+    )
+
+    assert exit_code == 0
+    assert len(records) == 1 and records[0].passed

--- a/tests/quorum/test_cli.py
+++ b/tests/quorum/test_cli.py
@@ -1,11 +1,16 @@
 # tests/quorum/test_cli.py
 import json
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 
 from quorum.cli import _managed_env_base_for_target, main
+
+
+def _allow_test_profile_owner(monkeypatch) -> None:
+    monkeypatch.setattr("quorum.doctor.DEFAULT_PROFILE_OWNER_UID", os.getuid())
 
 
 def test_list_finds_scenarios(tmp_path):
@@ -454,6 +459,245 @@ def test_managed_kimi_target_env_preserves_batch_preflight_markers(tmp_path, mon
     assert env_base["KIMI_MODEL_API_KEY"] == "profile-key"
     assert env_base["QUORUM_KIMI_PREFLIGHT_SENTINEL"] == str(marker)
     assert env_base["QUORUM_KIMI_PREFLIGHT_TOKEN"] == "batch-token"
+
+
+def _write_doctor_agent_fixture(
+    tmp_path: Path,
+    *,
+    target: str = "gemini",
+) -> tuple[Path, Path, Path]:
+    import yaml
+
+    agents = tmp_path / "coding-agents"
+    scenarios = tmp_path / "scenarios"
+    profiles = tmp_path / "profiles"
+    bin_dir = tmp_path / "bin"
+    agents.mkdir()
+    scenarios.mkdir()
+    profiles.mkdir()
+    profiles.chmod(0o700)
+    bin_dir.mkdir()
+    (bin_dir / "demo-agent").write_text("#!/bin/sh\nexit 0\n")
+    (bin_dir / "demo-agent").chmod(0o755)
+    (agents / f"{target}.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "name": target,
+                "binary": "demo-agent",
+                "agent_config_env": "DEMO_HOME",
+                "session_log_dir": "${DEMO_HOME}/sessions",
+                "session_log_glob": "*.jsonl",
+                "normalizer": "codex",
+                "required_env": ["GEMINI_API_KEY", "SUPERPOWERS_ROOT"],
+            }
+        )
+    )
+    context = agents / f"{target}-context"
+    context.mkdir()
+    (context / "HOWTO.md").write_text("Use gemini.\n")
+    sentinel = scenarios / "sentinel"
+    sentinel.mkdir()
+    (sentinel / "story.md").write_text(
+        "---\nid: sentinel\nstatus: ready\nquorum_tier: sentinel\n---\n"
+    )
+    (sentinel / "checks.sh").write_text(
+        f"# coding-agents: {target}\npre() {{ :; }}\npost() {{ :; }}\n"
+    )
+    profile = profiles / f"{target}.env"
+    profile.write_text("GEMINI_API_KEY=profile-key\n")
+    profile.chmod(0o600)
+    superpowers = tmp_path / "superpowers"
+    for rel in (
+        "GEMINI.md",
+        "skills/using-superpowers/SKILL.md",
+        "skills/using-superpowers/references/gemini-tools.md",
+    ):
+        path = superpowers / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("fixture\n")
+    return agents, scenarios, profiles
+
+
+def test_doctor_ready_target_exits_zero(tmp_path, monkeypatch):
+    _allow_test_profile_owner(monkeypatch)
+    agents, scenarios, profiles = _write_doctor_agent_fixture(tmp_path)
+    monkeypatch.setenv("QUORUM_MANAGED_HOST", "1")
+    monkeypatch.setenv("QUORUM_TARGET_PROFILE_ROOT", str(profiles))
+    monkeypatch.setenv("SUPERPOWERS_ROOT", str(tmp_path / "superpowers"))
+    monkeypatch.setenv("PATH", str(tmp_path / "bin"))
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "doctor",
+            "gemini",
+            "--coding-agents-dir",
+            str(agents),
+            "--scenarios-root",
+            str(scenarios),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "gemini" in result.output
+    assert "ready" in result.output
+
+
+def test_doctor_missing_profile_on_managed_host_exits_one(tmp_path, monkeypatch):
+    _allow_test_profile_owner(monkeypatch)
+    agents, scenarios, profiles = _write_doctor_agent_fixture(tmp_path)
+    (profiles / "gemini.env").unlink()
+    monkeypatch.setenv("QUORUM_MANAGED_HOST", "1")
+    monkeypatch.setenv("QUORUM_TARGET_PROFILE_ROOT", str(profiles))
+    monkeypatch.setenv("SUPERPOWERS_ROOT", str(tmp_path / "superpowers"))
+    monkeypatch.setenv("PATH", str(tmp_path / "bin"))
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "doctor",
+            "gemini",
+            "--coding-agents-dir",
+            str(agents),
+            "--scenarios-root",
+            str(scenarios),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "failed" in result.output
+    assert "profile" in result.output
+
+
+def test_doctor_all_reports_failed_profile_and_exits_one(tmp_path, monkeypatch):
+    _allow_test_profile_owner(monkeypatch)
+    agents, scenarios, profiles = _write_doctor_agent_fixture(tmp_path)
+    (profiles / "gemini.env").unlink()
+    monkeypatch.setenv("QUORUM_MANAGED_HOST", "1")
+    monkeypatch.setenv("QUORUM_TARGET_PROFILE_ROOT", str(profiles))
+    monkeypatch.setenv("SUPERPOWERS_ROOT", str(tmp_path / "superpowers"))
+    monkeypatch.setenv("PATH", str(tmp_path / "bin"))
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "doctor",
+            "--all",
+            "--coding-agents-dir",
+            str(agents),
+            "--scenarios-root",
+            str(scenarios),
+        ],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "gemini" in result.output
+    assert "failed" in result.output
+
+
+def test_doctor_all_missing_coding_agents_dir_exits_two(tmp_path, monkeypatch):
+    missing_agents = tmp_path / "missing-agents"
+    scenarios = tmp_path / "scenarios"
+    scenarios.mkdir()
+    monkeypatch.setenv("QUORUM_MANAGED_HOST", "1")
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "doctor",
+            "--all",
+            "--coding-agents-dir",
+            str(missing_agents),
+            "--scenarios-root",
+            str(scenarios),
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "coding-agents directory not found" in result.output
+
+
+def test_doctor_missing_coding_agent_yaml_fails_and_exits_one(tmp_path, monkeypatch):
+    _allow_test_profile_owner(monkeypatch)
+    agents, scenarios, profiles = _write_doctor_agent_fixture(tmp_path)
+    (agents / "gemini.yaml").unlink()
+    monkeypatch.setenv("QUORUM_MANAGED_HOST", "1")
+    monkeypatch.setenv("QUORUM_TARGET_PROFILE_ROOT", str(profiles))
+    monkeypatch.setenv("SUPERPOWERS_ROOT", str(tmp_path / "superpowers"))
+    monkeypatch.setenv("PATH", str(tmp_path / "bin"))
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "doctor",
+            "gemini",
+            "--coding-agents-dir",
+            str(agents),
+            "--scenarios-root",
+            str(scenarios),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "failed" in result.output
+    assert "coding-agent config" in result.output
+
+
+def test_doctor_malformed_coding_agent_yaml_exits_two(tmp_path, monkeypatch):
+    _allow_test_profile_owner(monkeypatch)
+    agents, scenarios, profiles = _write_doctor_agent_fixture(tmp_path)
+    (agents / "gemini.yaml").write_text("[]\n")
+    monkeypatch.setenv("QUORUM_MANAGED_HOST", "1")
+    monkeypatch.setenv("QUORUM_TARGET_PROFILE_ROOT", str(profiles))
+    monkeypatch.setenv("SUPERPOWERS_ROOT", str(tmp_path / "superpowers"))
+    monkeypatch.setenv("PATH", str(tmp_path / "bin"))
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "doctor",
+            "gemini",
+            "--coding-agents-dir",
+            str(agents),
+            "--scenarios-root",
+            str(scenarios),
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "failed" in result.output
+    assert "coding-agent config" in result.output
+
+
+def test_doctor_json_output_is_stable(tmp_path, monkeypatch):
+    _allow_test_profile_owner(monkeypatch)
+    agents, scenarios, profiles = _write_doctor_agent_fixture(tmp_path)
+    (profiles / "gemini.env").chmod(0o666)
+    monkeypatch.setenv("QUORUM_MANAGED_HOST", "1")
+    monkeypatch.setenv("QUORUM_TARGET_PROFILE_ROOT", str(profiles))
+    monkeypatch.setenv("SUPERPOWERS_ROOT", str(tmp_path / "superpowers"))
+    monkeypatch.setenv("PATH", str(tmp_path / "bin"))
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "doctor",
+            "gemini",
+            "--json",
+            "--coding-agents-dir",
+            str(agents),
+            "--scenarios-root",
+            str(scenarios),
+        ],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["target"] == "gemini"
+    assert payload["status"] == "failed"
+    assert isinstance(payload["checks"], list)
+    assert any(check.get("remediation") for check in payload["checks"])
+    assert any(check.get("reason") == "config-error" for check in payload["checks"])
 
 
 def test_run_all_scenarios_filter_forwarded(tmp_path, monkeypatch):

--- a/tests/quorum/test_cli.py
+++ b/tests/quorum/test_cli.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 
-from quorum.cli import main
+from quorum.cli import _managed_env_base_for_target, main
 
 
 def test_list_finds_scenarios(tmp_path):
@@ -47,6 +47,106 @@ def test_run_invokes_run_scenario(tmp_path):
         )
         assert result.exit_code == 0
         mock.assert_called_once()
+
+
+def test_run_blocked_on_managed_host_before_runner(tmp_path, monkeypatch):
+    sd = tmp_path / "scenarios" / "x"
+    sd.mkdir(parents=True)
+    (sd / "story.md").write_text("---\nid: x\n---\n")
+    monkeypatch.setenv("QUORUM_MANAGED_HOST", "1")
+    runner = CliRunner()
+    with patch("quorum.cli.run_scenario") as mock:
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                str(sd),
+                "--coding-agent",
+                "claude",
+            ],
+        )
+    assert result.exit_code == 2
+    assert "raw live eval commands are disabled on the managed Quorum host" in result.output
+    mock.assert_not_called()
+
+
+def test_run_all_blocked_on_managed_host_before_batch(tmp_path, monkeypatch):
+    scenarios = tmp_path / "scenarios"
+    agents = tmp_path / "agents"
+    (scenarios / "x").mkdir(parents=True)
+    (scenarios / "x" / "story.md").write_text("---\nid: x\n---\n")
+    agents.mkdir()
+    (agents / "claude.yaml").write_text("name: claude\nbinary: echo\n")
+    monkeypatch.setenv("QUORUM_MANAGED_HOST", "1")
+    runner = CliRunner()
+    with patch("quorum.cli.run_batch") as mock:
+        result = runner.invoke(
+            main,
+            [
+                "run-all",
+                "--scenarios-root",
+                str(scenarios),
+                "--coding-agents-dir",
+                str(agents),
+            ],
+        )
+    assert result.exit_code == 2
+    assert "raw live eval commands are disabled on the managed Quorum host" in result.output
+    mock.assert_not_called()
+
+
+def test_run_managed_worker_flag_without_token_is_blocked(tmp_path, monkeypatch):
+    sd = tmp_path / "scenarios" / "x"
+    sd.mkdir(parents=True)
+    (sd / "story.md").write_text("---\nid: x\n---\n")
+    monkeypatch.setenv("QUORUM_MANAGED_HOST", "1")
+    monkeypatch.setenv("QUORUM_MANAGED_WORKER", "1")
+    runner = CliRunner()
+    with patch("quorum.cli.run_scenario") as mock:
+        fake_run_dir = tmp_path / "results" / "x-claude-20260101T000000"
+        fake_verdict = MagicMock(final="pass", to_dict=lambda: {"final": "pass"})
+        mock.return_value = (fake_run_dir, fake_verdict)
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                str(sd),
+                "--coding-agent",
+                "claude",
+            ],
+        )
+    assert result.exit_code == 2
+    mock.assert_not_called()
+
+
+def test_run_allowed_on_managed_worker_with_matching_token(tmp_path, monkeypatch):
+    sd = tmp_path / "scenarios" / "x"
+    sd.mkdir(parents=True)
+    (sd / "story.md").write_text("---\nid: x\n---\n")
+    state_root = tmp_path / "state"
+    state_root.mkdir()
+    (state_root / "worker-token").write_text("worker-secret\n")
+    (state_root / "worker-token").chmod(0o600)
+    monkeypatch.setenv("QUORUM_MANAGED_HOST", "1")
+    monkeypatch.setenv("QUORUM_MANAGED_WORKER", "1")
+    monkeypatch.setenv("QUORUM_MANAGED_WORKER_TOKEN", "worker-secret")
+    monkeypatch.setattr("quorum.runtime_env.MANAGED_WORKER_TOKEN_PATH", state_root / "worker-token")
+    runner = CliRunner()
+    with patch("quorum.cli.run_scenario") as mock:
+        fake_run_dir = tmp_path / "results" / "x-claude-20260101T000000"
+        fake_verdict = MagicMock(final="pass", to_dict=lambda: {"final": "pass"})
+        mock.return_value = (fake_run_dir, fake_verdict)
+        result = runner.invoke(
+            main,
+            [
+                "run",
+                str(sd),
+                "--coding-agent",
+                "claude",
+            ],
+        )
+    assert result.exit_code == 0
+    mock.assert_called_once()
 
 
 def test_run_prints_run_id_line(tmp_path, monkeypatch):
@@ -303,6 +403,57 @@ def test_run_all_command_invokes_run_batch(tmp_path, monkeypatch):
     assert result.exit_code == 0, result.output
     assert captured["jobs"] == 4
     assert captured["agent_filter"] == ["claude", "codex"]
+
+
+def test_run_all_managed_worker_passes_token_to_child_control_env(tmp_path, monkeypatch):
+    captured = {}
+    state_root = tmp_path / "state"
+    state_root.mkdir()
+    token_file = state_root / "worker-token"
+    token_file.write_text("worker-secret\n")
+    token_file.chmod(0o600)
+
+    def fake_run_batch(**kwargs):
+        captured.update(kwargs)
+        return tmp_path / "results" / "batches" / "fakebatch"
+
+    monkeypatch.setattr("quorum.cli.run_batch", fake_run_batch)
+    monkeypatch.setattr("quorum.runtime_env.MANAGED_WORKER_TOKEN_PATH", token_file)
+    monkeypatch.setenv("QUORUM_MANAGED_HOST", "1")
+    monkeypatch.setenv("QUORUM_MANAGED_WORKER", "1")
+    monkeypatch.setenv("QUORUM_MANAGED_WORKER_TOKEN", "worker-secret")
+    monkeypatch.setenv("QUORUM_STATE_ROOT", str(state_root))
+    monkeypatch.setenv("OPENAI_API_KEY", "ambient-poison")
+    (tmp_path / "scenarios").mkdir(parents=True)
+    (tmp_path / "coding-agents").mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(main, ["run-all"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["env_base"]["QUORUM_MANAGED_WORKER_TOKEN"] == "worker-secret"
+    assert "OPENAI_API_KEY" not in captured["env_base"]
+
+
+def test_managed_kimi_target_env_preserves_batch_preflight_markers(tmp_path, monkeypatch):
+    profile_root = tmp_path / "profiles"
+    profile_root.mkdir()
+    (profile_root / "kimi.env").write_text("KIMI_MODEL_API_KEY=profile-key\n")
+    marker = tmp_path / "batch" / "kimi-preflight-ok.json"
+
+    monkeypatch.setenv("QUORUM_MANAGED_HOST", "1")
+    monkeypatch.setenv("QUORUM_TARGET_PROFILE_ROOT", str(profile_root))
+    monkeypatch.setenv("QUORUM_STATE_ROOT", str(tmp_path / "state"))
+    monkeypatch.setenv("QUORUM_ARTIFACT_ROOT", str(tmp_path / "artifacts"))
+    monkeypatch.setenv("QUORUM_KIMI_PREFLIGHT_SENTINEL", str(marker))
+    monkeypatch.setenv("QUORUM_KIMI_PREFLIGHT_TOKEN", "batch-token")
+
+    env_base = _managed_env_base_for_target("kimi")
+
+    assert env_base is not None
+    assert env_base["KIMI_MODEL_API_KEY"] == "profile-key"
+    assert env_base["QUORUM_KIMI_PREFLIGHT_SENTINEL"] == str(marker)
+    assert env_base["QUORUM_KIMI_PREFLIGHT_TOKEN"] == "batch-token"
 
 
 def test_run_all_scenarios_filter_forwarded(tmp_path, monkeypatch):

--- a/tests/quorum/test_cli.py
+++ b/tests/quorum/test_cli.py
@@ -7,10 +7,20 @@ from unittest.mock import MagicMock, patch
 from click.testing import CliRunner
 
 from quorum.cli import _managed_env_base_for_target, main
+from quorum.doctor import DoctorCheck, DoctorStatus, TargetDoctorResult
+from quorum.managed_commands import StartResult
+from quorum.managed_state import discover_managed_paths, read_job
 
 
 def _allow_test_profile_owner(monkeypatch) -> None:
     monkeypatch.setattr("quorum.doctor.DEFAULT_PROFILE_OWNER_UID", os.getuid())
+
+
+def _managed_paths_env(tmp_path: Path) -> dict[str, str]:
+    return {
+        "QUORUM_STATE_ROOT": str(tmp_path / "state"),
+        "QUORUM_ARTIFACT_ROOT": str(tmp_path / "artifacts"),
+    }
 
 
 def test_list_finds_scenarios(tmp_path):
@@ -861,3 +871,110 @@ def test_show_renders_batch_when_target_is_batch_id(tmp_path, monkeypatch):
     assert result.exit_code == 0, result.output
     assert "Legend:" in result.output
     assert "— skip" in result.output
+
+
+def test_smoke_command_creates_job_starts_worker_and_prints_next_command(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_start_job(job, paths, supervisor):
+        captured["job"] = job
+        captured["paths"] = paths
+        captured["supervisor"] = supervisor
+        return StartResult(
+            job_id=job.id,
+            command=["env", "uv", "run", "quorum", "managed-worker", job.id],
+            supervisor={"kind": "inline"},
+            exit_code=0,
+        )
+
+    monkeypatch.setattr("quorum.cli.start_job", fake_start_job)
+    env = _managed_paths_env(tmp_path)
+
+    result = CliRunner().invoke(main, ["smoke", "claude"], env=env)
+
+    assert result.exit_code == 0, result.output
+    job = captured["job"]
+    paths = discover_managed_paths(env)
+    stored = read_job(paths, job.id)
+    assert stored.managed_command == "smoke"
+    assert stored.command == ["quorum", "smoke", "claude"]
+    assert stored.coding_agents == ["claude"]
+    assert f"job id: {job.id}" in result.output
+    assert f"quorum status {job.id}" in result.output
+    assert f"quorum tail {job.id}" in result.output
+
+
+def test_column_command_creates_sentinel_job_with_jobs(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_start_job(job, paths, supervisor):
+        captured["job"] = job
+        return StartResult(job_id=job.id, command=[], supervisor={"kind": "inline"}, exit_code=0)
+
+    monkeypatch.setattr("quorum.cli.start_job", fake_start_job)
+    env = _managed_paths_env(tmp_path)
+
+    result = CliRunner().invoke(main, ["column", "claude", "--jobs", "2"], env=env)
+
+    assert result.exit_code == 0, result.output
+    stored = read_job(discover_managed_paths(env), captured["job"].id)
+    assert stored.managed_command == "column"
+    assert stored.command == ["quorum", "column", "claude", "--jobs", "2"]
+    assert stored.coding_agents == ["claude"]
+    assert stored.tier == "sentinel"
+    assert stored.include_drafts is False
+
+
+def test_batch_without_target_or_all_ready_targets_exits_two(tmp_path):
+    result = CliRunner().invoke(main, ["batch"], env=_managed_paths_env(tmp_path))
+
+    assert result.exit_code == 2
+    assert "pass --coding-agent, --coding-agents, or --all-ready-targets" in result.output
+
+
+def test_batch_all_ready_targets_expands_only_ready_doctor_targets(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_doctors(paths, env):
+        del paths, env
+        return [
+            TargetDoctorResult(
+                target="claude",
+                status=DoctorStatus.READY,
+                checks=[DoctorCheck("unit", DoctorStatus.READY, "ok")],
+            ),
+            TargetDoctorResult(
+                target="codex",
+                status=DoctorStatus.BLOCKED,
+                checks=[DoctorCheck("unit", DoctorStatus.BLOCKED, "blocked")],
+            ),
+            TargetDoctorResult(
+                target="gemini",
+                status=DoctorStatus.FAILED,
+                checks=[DoctorCheck("unit", DoctorStatus.FAILED, "failed")],
+            ),
+        ]
+
+    def fake_start_job(job, paths, supervisor):
+        captured["job"] = job
+        return StartResult(job_id=job.id, command=[], supervisor={"kind": "inline"}, exit_code=0)
+
+    monkeypatch.setattr("quorum.cli.run_all_doctors", fake_doctors)
+    monkeypatch.setattr("quorum.cli.start_job", fake_start_job)
+    (tmp_path / "scenarios").mkdir()
+    (tmp_path / "coding-agents").mkdir()
+    monkeypatch.chdir(tmp_path)
+    env = _managed_paths_env(tmp_path)
+
+    result = CliRunner().invoke(
+        main,
+        ["batch", "--all-ready-targets"],
+        env=env,
+    )
+
+    assert result.exit_code == 0, result.output
+    stored = read_job(discover_managed_paths(env), captured["job"].id)
+    assert stored.coding_agents == ["claude"]
+    assert stored.command == ["quorum", "batch", "--coding-agents", "claude"]
+    assert stored.tier == "sentinel"
+    assert stored.include_drafts is False

--- a/tests/quorum/test_coding_agent_config.py
+++ b/tests/quorum/test_coding_agent_config.py
@@ -449,6 +449,27 @@ class TestLoadCodingAgentConfig:
         with pytest.raises(CodingAgentConfigError, match="ANTHROPIC_API_KEY"):
             load_coding_agent_config(path)
 
+    def test_required_env_can_be_supplied_by_explicit_env(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        path = _write(
+            tmp_path,
+            "claude",
+            {
+                "name": "claude",
+                "binary": "claude",
+                "agent_config_env": "CLAUDE_CONFIG_DIR",
+                "session_log_dir": "/tmp",
+                "session_log_glob": "*.jsonl",
+                "normalizer": "claude",
+                "required_env": ["ANTHROPIC_API_KEY"],
+                "model": "opus",
+            },
+        )
+
+        cfg = load_coding_agent_config(path, env={"ANTHROPIC_API_KEY": "profile-key"})
+
+        assert cfg.required_env == ("ANTHROPIC_API_KEY",)
+
     def test_missing_agent_config_env_raises(self, tmp_path):
         path = _write(
             tmp_path,

--- a/tests/quorum/test_coding_agent_config.py
+++ b/tests/quorum/test_coding_agent_config.py
@@ -372,6 +372,59 @@ class TestLoadCodingAgentConfig:
         with pytest.raises(CodingAgentConfigError, match="model must be a string"):
             load_coding_agent_config(path)
 
+    @pytest.mark.parametrize(
+        ("field", "value", "message"),
+        [
+            ("name", 42, "name must be a string"),
+            ("binary", 42, "binary must be a string"),
+            ("binary", ["codex"], "binary must be a string"),
+            ("agent_config_env", ["CODEX_HOME"], "agent_config_env must be a string"),
+            ("session_log_dir", ["${CODEX_HOME}/sessions"], "session_log_dir must be a string"),
+            ("session_log_glob", 42, "session_log_glob must be a string"),
+            ("normalizer", ["codex"], "normalizer must be a string"),
+            ("runtime_family", ["codex"], "runtime_family must be a string"),
+            ("max_time", 10, "max_time must be a string"),
+            ("project_prompt", ["prompt.md"], "project_prompt must be a string"),
+        ],
+    )
+    def test_string_fields_must_be_strings(self, tmp_path, field, value, message):
+        doc = {
+            "name": "codex",
+            "binary": "codex",
+            "agent_config_env": "CODEX_HOME",
+            "session_log_dir": "${CODEX_HOME}/sessions",
+            "session_log_glob": "*.jsonl",
+            "normalizer": "codex",
+            "required_env": [],
+        }
+        doc[field] = value
+        path = _write(tmp_path, "codex", doc)
+
+        with pytest.raises(CodingAgentConfigError, match=message):
+            load_coding_agent_config(path)
+
+    @pytest.mark.parametrize(
+        "value",
+        [42, "SUPERPOWERS_ROOT", [["SUPERPOWERS_ROOT"]], [""]],
+    )
+    def test_required_env_must_be_list_of_strings(self, tmp_path, value):
+        path = _write(
+            tmp_path,
+            "codex",
+            {
+                "name": "codex",
+                "binary": "codex",
+                "agent_config_env": "CODEX_HOME",
+                "session_log_dir": "${CODEX_HOME}/sessions",
+                "session_log_glob": "*.jsonl",
+                "normalizer": "codex",
+                "required_env": value,
+            },
+        )
+
+        with pytest.raises(CodingAgentConfigError, match="required_env must be"):
+            load_coding_agent_config(path)
+
     def test_non_claude_variant_is_rejected_in_v1(self, tmp_path):
         path = _write(
             tmp_path,

--- a/tests/quorum/test_doctor.py
+++ b/tests/quorum/test_doctor.py
@@ -1,6 +1,7 @@
 import json
 import os
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 import yaml
@@ -49,12 +50,7 @@ def _write_sentinel(scenarios_root: Path, target: str = "codex") -> None:
     scenario = scenarios_root / "sentinel"
     scenario.mkdir(parents=True, exist_ok=True)
     scenario.joinpath("story.md").write_text(
-        "---\n"
-        "id: sentinel\n"
-        "status: ready\n"
-        "quorum_tier: sentinel\n"
-        "---\n"
-        "Sentinel.\n"
+        "---\nid: sentinel\nstatus: ready\nquorum_tier: sentinel\n---\nSentinel.\n"
     )
     scenario.joinpath("checks.sh").write_text(
         f"# coding-agents: {target}\npre() {{ :; }}\npost() {{ :; }}\n"
@@ -91,6 +87,12 @@ def _doctor_paths(tmp_path: Path) -> DoctorPaths:
     )
 
 
+def _profiles_dir(paths: DoctorPaths) -> Path:
+    """Narrow DoctorPaths.profile_root (Optional) to Path — every doctor test sets it."""
+    assert paths.profile_root is not None
+    return paths.profile_root
+
+
 def _ready_fixture(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -101,16 +103,16 @@ def _ready_fixture(
     _write_agent(paths.coding_agents_dir, required_env=["GEMINI_API_KEY", "SUPERPOWERS_ROOT"])
     _write_context(paths.coding_agents_dir, runtime_family="gemini")
     _write_sentinel(paths.scenarios_root, target="gemini")
-    paths.profile_root.mkdir(parents=True)
-    paths.profile_root.chmod(0o700)
-    profile = paths.profile_root / "gemini.env"
+    _profiles_dir(paths).mkdir(parents=True)
+    _profiles_dir(paths).chmod(0o700)
+    profile = _profiles_dir(paths) / "gemini.env"
     profile.write_text("GEMINI_API_KEY=profile-key\n")
     profile.chmod(0o600)
     _write_superpowers_root(tmp_path / "superpowers")
     env = {
         "PATH": str(bin_dir),
         "QUORUM_MANAGED_HOST": "1",
-        "QUORUM_TARGET_PROFILE_ROOT": str(paths.profile_root),
+        "QUORUM_TARGET_PROFILE_ROOT": str(_profiles_dir(paths)),
         "SUPERPOWERS_ROOT": str(tmp_path / "superpowers"),
     }
     monkeypatch.setenv("PATH", str(bin_dir))
@@ -147,7 +149,7 @@ def test_bad_profile_permissions_are_failed_with_remediation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     paths, env = _ready_fixture(tmp_path, monkeypatch)
-    profile = paths.profile_root / "gemini.env"
+    profile = _profiles_dir(paths) / "gemini.env"
     profile.chmod(0o666)
 
     result = run_target_doctor("gemini", paths, env)
@@ -163,15 +165,17 @@ def test_json_shape_includes_target_status_checks_and_remediation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     paths, env = _ready_fixture(tmp_path, monkeypatch)
-    (paths.profile_root / "gemini.env").chmod(0o666)
+    (_profiles_dir(paths) / "gemini.env").chmod(0o666)
 
     payload = run_target_doctor("gemini", paths, env).to_dict()
 
     assert payload["target"] == "gemini"
     assert payload["status"] == "failed"
-    assert isinstance(payload["checks"], list)
-    assert any(check.get("remediation") for check in payload["checks"])
-    assert any(check.get("reason") == "config-error" for check in payload["checks"])
+    checks = payload["checks"]
+    assert isinstance(checks, list)
+    typed_checks = cast("list[dict[str, Any]]", checks)
+    assert any(check.get("remediation") for check in typed_checks)
+    assert any(check.get("reason") == "config-error" for check in typed_checks)
     json.dumps(payload)
 
 
@@ -223,9 +227,9 @@ def test_codex_is_blocked_until_key_backed_mode_is_verified(
     _write_agent(paths.coding_agents_dir, name="codex", required_env=["SUPERPOWERS_ROOT"])
     _write_context(paths.coding_agents_dir)
     _write_sentinel(paths.scenarios_root, target="codex")
-    paths.profile_root.mkdir(parents=True)
-    paths.profile_root.chmod(0o700)
-    profile = paths.profile_root / "codex.env"
+    _profiles_dir(paths).mkdir(parents=True)
+    _profiles_dir(paths).chmod(0o700)
+    profile = _profiles_dir(paths) / "codex.env"
     profile.write_text("OPENAI_API_KEY=profile-key\n")
     profile.chmod(0o600)
     _write_superpowers_root(tmp_path / "superpowers")
@@ -270,7 +274,7 @@ def test_placeholder_profile_secret_is_failed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     paths, env = _ready_fixture(tmp_path, monkeypatch)
-    (paths.profile_root / "gemini.env").write_text("GEMINI_API_KEY=placeholder\n")
+    (_profiles_dir(paths) / "gemini.env").write_text("GEMINI_API_KEY=placeholder\n")
 
     result = run_target_doctor("gemini", paths, env)
 
@@ -280,14 +284,12 @@ def test_placeholder_profile_secret_is_failed(
     assert "GEMINI_API_KEY" in credentials.message
 
 
-def test_wrong_profile_owner_is_failed(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_wrong_profile_owner_is_failed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     paths, env = _ready_fixture(tmp_path, monkeypatch)
     paths = DoctorPaths(
         coding_agents_dir=paths.coding_agents_dir,
         scenarios_root=paths.scenarios_root,
-        profile_root=paths.profile_root,
+        profile_root=_profiles_dir(paths),
         profile_owner_uid=os.getuid() + 1,
     )
 
@@ -299,9 +301,7 @@ def test_wrong_profile_owner_is_failed(
     assert "owner uid" in permissions.message
 
 
-def test_managed_roots_must_be_directories(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_managed_roots_must_be_directories(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     paths, env = _ready_fixture(tmp_path, monkeypatch)
     artifact_root = tmp_path / "artifact-file"
     artifact_root.write_text("not a directory\n")
@@ -379,11 +379,9 @@ def test_run_all_missing_coding_agents_dir_is_command_error(tmp_path: Path) -> N
     assert check.reason == "config-error"
 
 
-def test_gemini_personal_oauth_is_blocked(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_gemini_personal_oauth_is_blocked(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     paths, env = _ready_fixture(tmp_path, monkeypatch)
-    (paths.profile_root / "gemini.env").write_text(
+    (_profiles_dir(paths) / "gemini.env").write_text(
         "GEMINI_API_KEY=profile-key\nGEMINI_AUTH_TYPE=oauth-personal\n"
     )
 
@@ -404,9 +402,9 @@ def test_copilot_missing_provider_mode_profile_is_failed(
     _write_agent(paths.coding_agents_dir, name="copilot", required_env=["SUPERPOWERS_ROOT"])
     _write_context(paths.coding_agents_dir, runtime_family="copilot")
     _write_sentinel(paths.scenarios_root, target="copilot")
-    paths.profile_root.mkdir(parents=True)
-    paths.profile_root.chmod(0o700)
-    profile = paths.profile_root / "copilot.env"
+    _profiles_dir(paths).mkdir(parents=True)
+    _profiles_dir(paths).chmod(0o700)
+    profile = _profiles_dir(paths) / "copilot.env"
     profile.write_text("# no provider mode yet\n")
     profile.chmod(0o600)
     _write_superpowers_root(tmp_path / "superpowers")
@@ -434,9 +432,9 @@ def test_copilot_hook_env_references_must_be_profile_backed(
     _write_agent(paths.coding_agents_dir, name="copilot", required_env=["SUPERPOWERS_ROOT"])
     _write_context(paths.coding_agents_dir, runtime_family="copilot")
     _write_sentinel(paths.scenarios_root, target="copilot")
-    paths.profile_root.mkdir(parents=True)
-    paths.profile_root.chmod(0o700)
-    profile = paths.profile_root / "copilot.env"
+    _profiles_dir(paths).mkdir(parents=True)
+    _profiles_dir(paths).chmod(0o700)
+    profile = _profiles_dir(paths) / "copilot.env"
     profile.write_text(
         "COPILOT_PROVIDER_BASE_URL=https://example.invalid\n"
         "COPILOT_PROVIDER_TYPE=openai\n"
@@ -445,7 +443,7 @@ def test_copilot_hook_env_references_must_be_profile_backed(
     profile.chmod(0o600)
     sp_root = tmp_path / "superpowers"
     _write_superpowers_root(sp_root)
-    (sp_root / "hooks" / "session-start").write_text("echo \"$OPENAI_API_KEY\"\n")
+    (sp_root / "hooks" / "session-start").write_text('echo "$OPENAI_API_KEY"\n')
     env = {
         "PATH": str(bin_dir),
         "QUORUM_MANAGED_HOST": "1",
@@ -470,9 +468,9 @@ def test_copilot_personal_github_token_is_blocked(
     _write_agent(paths.coding_agents_dir, name="copilot", required_env=["SUPERPOWERS_ROOT"])
     _write_context(paths.coding_agents_dir, runtime_family="copilot")
     _write_sentinel(paths.scenarios_root, target="copilot")
-    paths.profile_root.mkdir(parents=True)
-    paths.profile_root.chmod(0o700)
-    profile = paths.profile_root / "copilot.env"
+    _profiles_dir(paths).mkdir(parents=True)
+    _profiles_dir(paths).chmod(0o700)
+    profile = _profiles_dir(paths) / "copilot.env"
     profile.write_text(
         "COPILOT_PROVIDER_BASE_URL=https://example.invalid\n"
         "COPILOT_PROVIDER_TYPE=openai\n"

--- a/tests/quorum/test_doctor.py
+++ b/tests/quorum/test_doctor.py
@@ -1,0 +1,496 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from quorum.doctor import DoctorPaths, DoctorStatus, run_all_doctors, run_target_doctor
+
+
+def _write_agent(
+    coding_agents_dir: Path,
+    name: str = "gemini",
+    *,
+    binary: str = "demo-agent",
+    runtime_family: str | None = None,
+    required_env: list[str] | None = None,
+) -> None:
+    coding_agents_dir.mkdir(parents=True, exist_ok=True)
+    doc = {
+        "name": name,
+        "binary": binary,
+        "agent_config_env": f"{name.upper().replace('-', '_')}_HOME",
+        "session_log_dir": f"${{{name.upper().replace('-', '_')}_HOME}}/sessions",
+        "session_log_glob": "*.jsonl",
+        "normalizer": "codex",
+        "required_env": required_env or ["SUPERPOWERS_ROOT"],
+    }
+    if runtime_family is not None:
+        doc["runtime_family"] = runtime_family
+    (coding_agents_dir / f"{name}.yaml").write_text(yaml.safe_dump(doc))
+
+
+def _write_tool(bin_dir: Path, name: str) -> None:
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    tool = bin_dir / name
+    tool.write_text("#!/bin/sh\nexit 0\n")
+    tool.chmod(0o755)
+
+
+def _write_context(coding_agents_dir: Path, runtime_family: str = "codex") -> None:
+    context = coding_agents_dir / f"{runtime_family}-context"
+    context.mkdir(parents=True, exist_ok=True)
+    (context / "HOWTO.md").write_text("use the target\n")
+    (context / "launch-agent").write_text("#!/bin/sh\nexec demo-agent\n")
+
+
+def _write_sentinel(scenarios_root: Path, target: str = "codex") -> None:
+    scenario = scenarios_root / "sentinel"
+    scenario.mkdir(parents=True, exist_ok=True)
+    scenario.joinpath("story.md").write_text(
+        "---\n"
+        "id: sentinel\n"
+        "status: ready\n"
+        "quorum_tier: sentinel\n"
+        "---\n"
+        "Sentinel.\n"
+    )
+    scenario.joinpath("checks.sh").write_text(
+        f"# coding-agents: {target}\npre() {{ :; }}\npost() {{ :; }}\n"
+    )
+
+
+def _write_superpowers_root(root: Path) -> None:
+    required = {
+        ".claude-plugin/plugin.json",
+        ".kimi-plugin/plugin.json",
+        ".opencode/plugins/superpowers.js",
+        "GEMINI.md",
+        "hooks/hooks.json",
+        "hooks/run-hook.cmd",
+        "hooks/session-start",
+        "skills/brainstorming/SKILL.md",
+        "skills/using-superpowers/SKILL.md",
+        "skills/using-superpowers/references/copilot-tools.md",
+        "skills/using-superpowers/references/gemini-tools.md",
+        "skills/using-superpowers/references/pi-tools.md",
+    }
+    for rel in required:
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}\n" if rel.endswith(".json") else "fixture\n")
+
+
+def _doctor_paths(tmp_path: Path) -> DoctorPaths:
+    return DoctorPaths(
+        coding_agents_dir=tmp_path / "coding-agents",
+        scenarios_root=tmp_path / "scenarios",
+        profile_root=tmp_path / "profiles",
+        profile_owner_uid=os.getuid(),
+    )
+
+
+def _ready_fixture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[DoctorPaths, dict[str, str]]:
+    paths = _doctor_paths(tmp_path)
+    bin_dir = tmp_path / "bin"
+    _write_tool(bin_dir, "demo-agent")
+    _write_agent(paths.coding_agents_dir, required_env=["GEMINI_API_KEY", "SUPERPOWERS_ROOT"])
+    _write_context(paths.coding_agents_dir, runtime_family="gemini")
+    _write_sentinel(paths.scenarios_root, target="gemini")
+    paths.profile_root.mkdir(parents=True)
+    paths.profile_root.chmod(0o700)
+    profile = paths.profile_root / "gemini.env"
+    profile.write_text("GEMINI_API_KEY=profile-key\n")
+    profile.chmod(0o600)
+    _write_superpowers_root(tmp_path / "superpowers")
+    env = {
+        "PATH": str(bin_dir),
+        "QUORUM_MANAGED_HOST": "1",
+        "QUORUM_TARGET_PROFILE_ROOT": str(paths.profile_root),
+        "SUPERPOWERS_ROOT": str(tmp_path / "superpowers"),
+    }
+    monkeypatch.setenv("PATH", str(bin_dir))
+    return paths, env
+
+
+def test_ready_target_returns_ready(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    paths, env = _ready_fixture(tmp_path, monkeypatch)
+
+    result = run_target_doctor("gemini", paths, env)
+
+    assert result.target == "gemini"
+    assert result.status is DoctorStatus.READY
+    assert all(check.status is DoctorStatus.READY for check in result.checks)
+    assert any(check.name == "sanitized-env" for check in result.checks)
+
+
+def test_managed_readiness_ignores_ambient_required_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths, env = _ready_fixture(tmp_path, monkeypatch)
+    env["GEMINI_API_KEY"] = ""
+
+    result = run_target_doctor("gemini", paths, env)
+
+    assert result.status is DoctorStatus.READY
+    assert all(
+        check.name != "coding-agent-config" or check.status is DoctorStatus.READY
+        for check in result.checks
+    )
+
+
+def test_bad_profile_permissions_are_failed_with_remediation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths, env = _ready_fixture(tmp_path, monkeypatch)
+    profile = paths.profile_root / "gemini.env"
+    profile.chmod(0o666)
+
+    result = run_target_doctor("gemini", paths, env)
+
+    assert result.status is DoctorStatus.FAILED
+    permissions = next(check for check in result.checks if check.name == "profile-permissions")
+    assert permissions.status is DoctorStatus.FAILED
+    assert permissions.remediation
+    assert "chmod 0600" in permissions.remediation
+
+
+def test_json_shape_includes_target_status_checks_and_remediation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths, env = _ready_fixture(tmp_path, monkeypatch)
+    (paths.profile_root / "gemini.env").chmod(0o666)
+
+    payload = run_target_doctor("gemini", paths, env).to_dict()
+
+    assert payload["target"] == "gemini"
+    assert payload["status"] == "failed"
+    assert isinstance(payload["checks"], list)
+    assert any(check.get("remediation") for check in payload["checks"])
+    assert any(check.get("reason") == "config-error" for check in payload["checks"])
+    json.dumps(payload)
+
+
+@pytest.mark.parametrize("yaml_text", ["- name\n", "42\n"])
+def test_malformed_coding_agent_yaml_does_not_crash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    yaml_text: str,
+) -> None:
+    paths, env = _ready_fixture(tmp_path, monkeypatch)
+    (paths.coding_agents_dir / "gemini.yaml").write_text(yaml_text)
+
+    result = run_target_doctor("gemini", paths, env)
+
+    assert result.status is DoctorStatus.FAILED
+    config = next(check for check in result.checks if check.name == "coding-agent-config")
+    assert config.reason == "config-error"
+
+
+@pytest.mark.parametrize(
+    "yaml_text",
+    [
+        "name: gemini\nrequired_env: 42\n",
+        "name: gemini\nrequired_env:\n  - [GEMINI_API_KEY]\n",
+        "name: gemini\nnormalizer:\n  - codex\n",
+    ],
+)
+def test_malformed_coding_agent_yaml_mapping_fields_do_not_crash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    yaml_text: str,
+) -> None:
+    paths, env = _ready_fixture(tmp_path, monkeypatch)
+    (paths.coding_agents_dir / "gemini.yaml").write_text(yaml_text)
+
+    result = run_target_doctor("gemini", paths, env)
+
+    assert result.status is DoctorStatus.FAILED
+    config = next(check for check in result.checks if check.name == "coding-agent-config")
+    assert config.reason == "config-error"
+
+
+def test_codex_is_blocked_until_key_backed_mode_is_verified(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = _doctor_paths(tmp_path)
+    bin_dir = tmp_path / "bin"
+    _write_tool(bin_dir, "demo-agent")
+    _write_agent(paths.coding_agents_dir, name="codex", required_env=["SUPERPOWERS_ROOT"])
+    _write_context(paths.coding_agents_dir)
+    _write_sentinel(paths.scenarios_root, target="codex")
+    paths.profile_root.mkdir(parents=True)
+    paths.profile_root.chmod(0o700)
+    profile = paths.profile_root / "codex.env"
+    profile.write_text("OPENAI_API_KEY=profile-key\n")
+    profile.chmod(0o600)
+    _write_superpowers_root(tmp_path / "superpowers")
+    env = {
+        "PATH": str(bin_dir),
+        "QUORUM_MANAGED_HOST": "1",
+        "SUPERPOWERS_ROOT": str(tmp_path / "superpowers"),
+    }
+    monkeypatch.setenv("PATH", str(bin_dir))
+
+    result = run_target_doctor("codex", paths, env)
+
+    assert result.status is DoctorStatus.BLOCKED
+    credentials = next(check for check in result.checks if check.name == "required-credentials")
+    assert "key-backed Codex mode" in credentials.message
+    assert credentials.reason == "unsupported-key-backed-mode"
+
+
+def test_opencode_is_blocked_until_managed_env_surface_is_accepted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = _doctor_paths(tmp_path)
+    bin_dir = tmp_path / "bin"
+    _write_tool(bin_dir, "demo-agent")
+    _write_agent(paths.coding_agents_dir, name="opencode", required_env=["SUPERPOWERS_ROOT"])
+    env = {
+        "PATH": str(bin_dir),
+        "QUORUM_MANAGED_HOST": "1",
+        "SUPERPOWERS_ROOT": str(tmp_path / "superpowers"),
+    }
+    monkeypatch.setenv("PATH", str(bin_dir))
+
+    result = run_target_doctor("opencode", paths, env)
+
+    assert result.status is DoctorStatus.BLOCKED
+    credentials = next(check for check in result.checks if check.name == "required-credentials")
+    assert "OpenCode managed env narrowing" in credentials.message
+    assert credentials.reason == "unsupported-key-backed-mode"
+
+
+def test_placeholder_profile_secret_is_failed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths, env = _ready_fixture(tmp_path, monkeypatch)
+    (paths.profile_root / "gemini.env").write_text("GEMINI_API_KEY=placeholder\n")
+
+    result = run_target_doctor("gemini", paths, env)
+
+    assert result.status is DoctorStatus.FAILED
+    credentials = next(check for check in result.checks if check.name == "required-credentials")
+    assert credentials.reason == "placeholder-secret"
+    assert "GEMINI_API_KEY" in credentials.message
+
+
+def test_wrong_profile_owner_is_failed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths, env = _ready_fixture(tmp_path, monkeypatch)
+    paths = DoctorPaths(
+        coding_agents_dir=paths.coding_agents_dir,
+        scenarios_root=paths.scenarios_root,
+        profile_root=paths.profile_root,
+        profile_owner_uid=os.getuid() + 1,
+    )
+
+    result = run_target_doctor("gemini", paths, env)
+
+    assert result.status is DoctorStatus.FAILED
+    permissions = next(check for check in result.checks if check.name == "profile-permissions")
+    assert permissions.reason == "config-error"
+    assert "owner uid" in permissions.message
+
+
+def test_managed_roots_must_be_directories(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths, env = _ready_fixture(tmp_path, monkeypatch)
+    artifact_root = tmp_path / "artifact-file"
+    artifact_root.write_text("not a directory\n")
+    artifact_root.chmod(0o700)
+    env["QUORUM_ARTIFACT_ROOT"] = str(artifact_root)
+
+    result = run_target_doctor("gemini", paths, env)
+
+    assert result.status is DoctorStatus.FAILED
+    artifact = next(check for check in result.checks if check.name == "artifact-root")
+    assert artifact.reason == "config-error"
+    assert "not a directory" in artifact.message
+
+
+def test_managed_root_parent_must_be_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths, env = _ready_fixture(tmp_path, monkeypatch)
+    file_parent = tmp_path / "file-parent"
+    file_parent.write_text("not a directory\n")
+    file_parent.chmod(0o700)
+    env["QUORUM_ARTIFACT_ROOT"] = str(file_parent / "child")
+
+    result = run_target_doctor("gemini", paths, env)
+
+    assert result.status is DoctorStatus.FAILED
+    artifact = next(check for check in result.checks if check.name == "artifact-root")
+    assert artifact.reason == "config-error"
+    assert "nearest existing parent" in artifact.message
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks unavailable")
+def test_managed_root_broken_symlink_is_failed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths, env = _ready_fixture(tmp_path, monkeypatch)
+    artifact_root = tmp_path / "artifact-link"
+    artifact_root.symlink_to(tmp_path / "missing-target")
+    env["QUORUM_ARTIFACT_ROOT"] = str(artifact_root)
+
+    result = run_target_doctor("gemini", paths, env)
+
+    assert result.status is DoctorStatus.FAILED
+    artifact = next(check for check in result.checks if check.name == "artifact-root")
+    assert artifact.reason == "config-error"
+    assert "symlink" in artifact.message
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks unavailable")
+def test_managed_root_broken_symlink_parent_is_failed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths, env = _ready_fixture(tmp_path, monkeypatch)
+    parent = tmp_path / "parent-link"
+    parent.symlink_to(tmp_path / "missing-target")
+    env["QUORUM_ARTIFACT_ROOT"] = str(parent / "child")
+
+    result = run_target_doctor("gemini", paths, env)
+
+    assert result.status is DoctorStatus.FAILED
+    artifact = next(check for check in result.checks if check.name == "artifact-root")
+    assert artifact.reason == "config-error"
+    assert "symlink" in artifact.message
+
+
+def test_run_all_missing_coding_agents_dir_is_command_error(tmp_path: Path) -> None:
+    paths = DoctorPaths(coding_agents_dir=tmp_path / "missing")
+
+    results = run_all_doctors(paths, {"QUORUM_MANAGED_HOST": "1"})
+
+    assert len(results) == 1
+    assert results[0].status is DoctorStatus.FAILED
+    check = results[0].checks[0]
+    assert check.name == "coding-agent-config"
+    assert check.reason == "config-error"
+
+
+def test_gemini_personal_oauth_is_blocked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths, env = _ready_fixture(tmp_path, monkeypatch)
+    (paths.profile_root / "gemini.env").write_text(
+        "GEMINI_API_KEY=profile-key\nGEMINI_AUTH_TYPE=oauth-personal\n"
+    )
+
+    result = run_target_doctor("gemini", paths, env)
+
+    assert result.status is DoctorStatus.BLOCKED
+    credentials = next(check for check in result.checks if check.name == "required-credentials")
+    assert credentials.reason == "personal-auth"
+    assert "oauth-personal" in credentials.message
+
+
+def test_copilot_missing_provider_mode_profile_is_failed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = _doctor_paths(tmp_path)
+    bin_dir = tmp_path / "bin"
+    _write_tool(bin_dir, "demo-agent")
+    _write_agent(paths.coding_agents_dir, name="copilot", required_env=["SUPERPOWERS_ROOT"])
+    _write_context(paths.coding_agents_dir, runtime_family="copilot")
+    _write_sentinel(paths.scenarios_root, target="copilot")
+    paths.profile_root.mkdir(parents=True)
+    paths.profile_root.chmod(0o700)
+    profile = paths.profile_root / "copilot.env"
+    profile.write_text("# no provider mode yet\n")
+    profile.chmod(0o600)
+    _write_superpowers_root(tmp_path / "superpowers")
+    env = {
+        "PATH": str(bin_dir),
+        "QUORUM_MANAGED_HOST": "1",
+        "SUPERPOWERS_ROOT": str(tmp_path / "superpowers"),
+    }
+    monkeypatch.setenv("PATH", str(bin_dir))
+
+    result = run_target_doctor("copilot", paths, env)
+
+    assert result.status is DoctorStatus.FAILED
+    credentials = next(check for check in result.checks if check.name == "required-credentials")
+    assert credentials.reason == "missing-secret"
+    assert "COPILOT_PROVIDER_BASE_URL" in credentials.message
+
+
+def test_copilot_hook_env_references_must_be_profile_backed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = _doctor_paths(tmp_path)
+    bin_dir = tmp_path / "bin"
+    _write_tool(bin_dir, "demo-agent")
+    _write_agent(paths.coding_agents_dir, name="copilot", required_env=["SUPERPOWERS_ROOT"])
+    _write_context(paths.coding_agents_dir, runtime_family="copilot")
+    _write_sentinel(paths.scenarios_root, target="copilot")
+    paths.profile_root.mkdir(parents=True)
+    paths.profile_root.chmod(0o700)
+    profile = paths.profile_root / "copilot.env"
+    profile.write_text(
+        "COPILOT_PROVIDER_BASE_URL=https://example.invalid\n"
+        "COPILOT_PROVIDER_TYPE=openai\n"
+        "COPILOT_PROVIDER_API_KEY=provider-key\n"
+    )
+    profile.chmod(0o600)
+    sp_root = tmp_path / "superpowers"
+    _write_superpowers_root(sp_root)
+    (sp_root / "hooks" / "session-start").write_text("echo \"$OPENAI_API_KEY\"\n")
+    env = {
+        "PATH": str(bin_dir),
+        "QUORUM_MANAGED_HOST": "1",
+        "SUPERPOWERS_ROOT": str(sp_root),
+    }
+    monkeypatch.setenv("PATH", str(bin_dir))
+
+    result = run_target_doctor("copilot", paths, env)
+
+    assert result.status is DoctorStatus.FAILED
+    credentials = next(check for check in result.checks if check.name == "required-credentials")
+    assert credentials.reason == "missing-secret"
+    assert "OPENAI_API_KEY" in credentials.message
+
+
+def test_copilot_personal_github_token_is_blocked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = _doctor_paths(tmp_path)
+    bin_dir = tmp_path / "bin"
+    _write_tool(bin_dir, "demo-agent")
+    _write_agent(paths.coding_agents_dir, name="copilot", required_env=["SUPERPOWERS_ROOT"])
+    _write_context(paths.coding_agents_dir, runtime_family="copilot")
+    _write_sentinel(paths.scenarios_root, target="copilot")
+    paths.profile_root.mkdir(parents=True)
+    paths.profile_root.chmod(0o700)
+    profile = paths.profile_root / "copilot.env"
+    profile.write_text(
+        "COPILOT_PROVIDER_BASE_URL=https://example.invalid\n"
+        "COPILOT_PROVIDER_TYPE=openai\n"
+        "COPILOT_PROVIDER_API_KEY=provider-key\n"
+        "GITHUB_TOKEN=profile-github-token\n"
+    )
+    profile.chmod(0o600)
+    _write_superpowers_root(tmp_path / "superpowers")
+    env = {
+        "PATH": str(bin_dir),
+        "QUORUM_MANAGED_HOST": "1",
+        "SUPERPOWERS_ROOT": str(tmp_path / "superpowers"),
+    }
+    monkeypatch.setenv("PATH", str(bin_dir))
+
+    result = run_target_doctor("copilot", paths, env)
+
+    assert result.status is DoctorStatus.BLOCKED
+    credentials = next(check for check in result.checks if check.name == "required-credentials")
+    assert credentials.reason == "personal-auth"
+    assert "GITHUB_TOKEN" in credentials.message

--- a/tests/quorum/test_kimi.py
+++ b/tests/quorum/test_kimi.py
@@ -15,6 +15,7 @@ from quorum.kimi import (
     kimi_logs_have_superpowers_session_start,
     kimi_preflight_sentinel_payload,
     kimi_stream_json_reply_ok,
+    resolve_kimi_binary,
     run_kimi_auth_preflight,
     sanitize_kimi_diagnostic,
     validate_kimi_preflight_sentinel,
@@ -70,6 +71,19 @@ def test_sanitized_env_drops_host_state(monkeypatch, tmp_path):
     assert env["XDG_DATA_HOME"] == str(kimi_home / "xdg-data")
     assert "PWD" not in env
     assert "MOONSHOT_API_KEY" not in env
+
+
+def test_resolve_kimi_binary_uses_os_defpath_for_explicit_env_without_path(monkeypatch):
+    seen_paths: list[str | None] = []
+
+    def fake_which(binary, path=None):
+        seen_paths.append(path)
+        return "/bin/kimi"
+
+    monkeypatch.setattr("quorum.kimi.shutil.which", fake_which)
+
+    assert resolve_kimi_binary("kimi", env={}) == "/bin/kimi"
+    assert seen_paths == [os.defpath]
 
 
 def test_runtime_env_file_is_0600_outside_run_dir_and_sourceable(tmp_path):

--- a/tests/quorum/test_locks.py
+++ b/tests/quorum/test_locks.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from quorum.locks import (
+    LockConflict,
+    LockRequest,
+    acquire_locks,
+    read_active_cooldowns,
+    read_lock_holder,
+    release_locks,
+    write_cooldown,
+)
+from quorum.managed_state import discover_managed_paths
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _paths(tmp_path):
+    return discover_managed_paths({"QUORUM_STATE_ROOT": str(tmp_path / "state")})
+
+
+def test_second_process_cannot_acquire_exclusive_lock_already_held(tmp_path):
+    paths = _paths(tmp_path)
+    holder = subprocess.Popen(
+        [
+            sys.executable,
+            str(FIXTURES / "lock_holder.py"),
+            str(paths.state_root),
+            "target:claude",
+            "job-20260612T190000Z-a1b2",
+        ],
+        text=True,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        assert holder.stdout is not None
+        assert holder.stdout.readline().strip() == "locked"
+
+        with pytest.raises(LockConflict) as exc_info:
+            acquire_locks(
+                paths,
+                [LockRequest("target:claude")],
+                job_id="job-20260612T190001Z-b2c3",
+                command=["quorum", "smoke", "claude"],
+            )
+
+        conflict = exc_info.value
+        assert conflict.lock_name == "target:claude"
+        assert conflict.holder is not None
+        assert conflict.holder.job_id == "job-20260612T190000Z-a1b2"
+        assert conflict.holder.command == ["lock-holder", "target:claude"]
+    finally:
+        if holder.stdin is not None:
+            holder.stdin.write("\n")
+            holder.stdin.flush()
+        holder.wait(timeout=10)
+        assert holder.returncode == 0, holder.stderr.read() if holder.stderr else ""
+
+
+def test_lock_requests_are_acquired_in_deterministic_order(tmp_path):
+    paths = _paths(tmp_path)
+    held = acquire_locks(
+        paths,
+        [
+            LockRequest("target:claude"),
+            LockRequest("provider:anthropic"),
+            LockRequest("checkout:evals:abc123", exclusive=False),
+            LockRequest("global:broad-batch"),
+        ],
+        job_id="job-20260612T190000Z-a1b2",
+        command=["quorum", "batch", "sentinel-default"],
+    )
+    try:
+        assert [lock.name for lock in held] == [
+            "global:broad-batch",
+            "checkout:evals:abc123",
+            "provider:anthropic",
+            "target:claude",
+        ]
+    finally:
+        release_locks(held)
+
+
+def test_sidecar_content_includes_holder_diagnostics_and_is_removed_on_release(tmp_path):
+    paths = _paths(tmp_path)
+    held = acquire_locks(
+        paths,
+        [LockRequest("provider:anthropic")],
+        job_id="job-20260612T190000Z-a1b2",
+        command=["quorum", "column", "claude"],
+    )
+    try:
+        holder = read_lock_holder(paths, "provider:anthropic")
+
+        assert holder is not None
+        assert holder.lock_name == "provider:anthropic"
+        assert holder.job_id == "job-20260612T190000Z-a1b2"
+        assert isinstance(holder.pid, int)
+        assert holder.pid > 0
+        assert holder.hostname
+        assert holder.started_at.tzinfo is not None
+        assert holder.command == ["quorum", "column", "claude"]
+        sidecar = paths.locks_dir / "provider:anthropic.job-20260612T190000Z-a1b2.json"
+        assert json.loads(sidecar.read_text())["started_at"].endswith("Z")
+    finally:
+        release_locks(held)
+
+    assert read_lock_holder(paths, "provider:anthropic") is None
+    assert not (paths.locks_dir / "provider:anthropic.job-20260612T190000Z-a1b2.json").exists()
+
+
+def test_hyphenated_lock_and_cooldown_names_are_allowed(tmp_path):
+    paths = _paths(tmp_path)
+    now = datetime(2026, 6, 12, 19, 0, tzinfo=UTC)
+    held = acquire_locks(
+        paths,
+        [LockRequest("target:claude-sonnet"), LockRequest("provider:google-code-assist")],
+        job_id="job-20260612T190000Z-a1b2",
+        command=["quorum", "smoke", "claude-sonnet"],
+    )
+    try:
+        assert [lock.name for lock in held] == [
+            "provider:google-code-assist",
+            "target:claude-sonnet",
+        ]
+        assert read_lock_holder(paths, "target:claude-sonnet") is not None
+    finally:
+        release_locks(held)
+
+    write_cooldown(
+        paths,
+        "google-code-assist",
+        "quota window",
+        now + timedelta(minutes=5),
+    )
+    assert [cooldown.provider for cooldown in read_active_cooldowns(paths, now)] == [
+        "google-code-assist"
+    ]
+
+
+def test_sidecar_write_failure_releases_kernel_lock(tmp_path, monkeypatch):
+    paths = _paths(tmp_path)
+    class TrackingFile:
+        def __init__(self, path: Path) -> None:
+            self._file = path.open("a+")
+            self.closed_explicitly = False
+
+        def fileno(self) -> int:
+            return self._file.fileno()
+
+        def close(self) -> None:
+            self.closed_explicitly = True
+            self._file.close()
+
+    opened: list[TrackingFile] = []
+
+    def open_tracking_file(path: Path):
+        tracking = TrackingFile(path)
+        opened.append(tracking)
+        return tracking
+
+    def fail_write(*_args, **_kwargs) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr("quorum.locks._open_lock_file", open_tracking_file)
+    monkeypatch.setattr("quorum.locks._write_json_atomic", fail_write)
+
+    with pytest.raises(OSError, match="disk full"):
+        acquire_locks(
+            paths,
+            [LockRequest("target:claude")],
+            job_id="job-20260612T190000Z-a1b2",
+            command=["quorum", "smoke", "claude"],
+        )
+
+    assert opened
+    assert all(file.closed_explicitly for file in opened)
+
+    monkeypatch.undo()
+    held = acquire_locks(
+        paths,
+        [LockRequest("target:claude")],
+        job_id="job-20260612T190001Z-b2c3",
+        command=["quorum", "smoke", "claude"],
+    )
+    release_locks(held)
+
+
+def test_shared_locks_keep_per_holder_sidecars_until_each_holder_releases(tmp_path):
+    paths = _paths(tmp_path)
+    first = acquire_locks(
+        paths,
+        [LockRequest("checkout:evals:abc123", exclusive=False)],
+        job_id="job-20260612T190000Z-a1b2",
+        command=["quorum", "column", "claude"],
+    )
+    second = acquire_locks(
+        paths,
+        [LockRequest("checkout:evals:abc123", exclusive=False)],
+        job_id="job-20260612T190001Z-b2c3",
+        command=["quorum", "column", "kimi"],
+    )
+
+    try:
+        holder = read_lock_holder(paths, "checkout:evals:abc123")
+        assert holder is not None
+        assert holder.job_id in {"job-20260612T190000Z-a1b2", "job-20260612T190001Z-b2c3"}
+        sidecars = sorted(paths.locks_dir.glob("checkout:evals:abc123.*.json"))
+        assert len(sidecars) == 2
+
+        release_locks(first)
+
+        remaining_sidecars = sorted(paths.locks_dir.glob("checkout:evals:abc123.*.json"))
+        assert len(remaining_sidecars) == 1
+        assert read_lock_holder(paths, "checkout:evals:abc123") is not None
+
+        with pytest.raises(LockConflict):
+            acquire_locks(
+                paths,
+                [LockRequest("checkout:evals:abc123")],
+                job_id="job-20260612T190002Z-c3d4",
+                command=["quorum", "sync"],
+            )
+    finally:
+        release_locks(second)
+
+    assert read_lock_holder(paths, "checkout:evals:abc123") is None
+
+
+def test_cooldown_read_returns_active_cooldowns_and_drops_expired(tmp_path):
+    paths = _paths(tmp_path)
+    now = datetime(2026, 6, 12, 19, 0, tzinfo=UTC)
+    write_cooldown(paths, "anthropic", "429 from claude", now + timedelta(minutes=20))
+    write_cooldown(paths, "google", "old quota window", now - timedelta(minutes=1))
+
+    active = read_active_cooldowns(paths, now)
+
+    assert [cooldown.provider for cooldown in active] == ["anthropic"]
+    assert active[0].reason == "429 from claude"
+    assert active[0].until == now + timedelta(minutes=20)
+    assert (paths.cooldowns_dir / "anthropic.json").exists()
+    assert not (paths.cooldowns_dir / "google.json").exists()
+
+
+def test_lock_conflict_objects_are_json_serializable_for_status_output(tmp_path):
+    paths = _paths(tmp_path)
+    held = acquire_locks(
+        paths,
+        [LockRequest("target:kimi")],
+        job_id="job-20260612T190000Z-a1b2",
+        command=["quorum", "smoke", "kimi"],
+    )
+    try:
+        with pytest.raises(LockConflict) as exc_info:
+            acquire_locks(
+                paths,
+                [LockRequest("target:kimi")],
+                job_id="job-20260612T190001Z-b2c3",
+                command=["quorum", "smoke", "kimi"],
+            )
+
+        payload = exc_info.value.to_json()
+        holder = cast(dict[str, object], payload["holder"])
+        encoded = json.dumps(payload, sort_keys=True)
+        assert '"lock_name": "target:kimi"' in encoded
+        assert holder["job_id"] == "job-20260612T190000Z-a1b2"
+        assert payload["wait"] is False
+    finally:
+        release_locks(held)
+
+
+def test_malformed_sidecar_is_diagnostic_only_for_lock_conflicts(tmp_path):
+    paths = _paths(tmp_path)
+    holder = subprocess.Popen(
+        [
+            sys.executable,
+            str(FIXTURES / "lock_holder.py"),
+            str(paths.state_root),
+            "provider:google",
+            "job-20260612T190000Z-a1b2",
+        ],
+        text=True,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        assert holder.stdout is not None
+        assert holder.stdout.readline().strip() == "locked"
+        (paths.locks_dir / "provider:google.job-20260612T190000Z-a1b2.json").write_text(
+            "{not-json"
+        )
+
+        with pytest.raises(LockConflict) as exc_info:
+            acquire_locks(
+                paths,
+                [LockRequest("provider:google")],
+                job_id="job-20260612T190001Z-b2c3",
+                command=["quorum", "smoke", "gemini"],
+            )
+
+        assert exc_info.value.holder is None
+    finally:
+        if holder.stdin is not None:
+            holder.stdin.write("\n")
+            holder.stdin.flush()
+        holder.wait(timeout=10)
+        assert holder.returncode == 0, holder.stderr.read() if holder.stderr else ""
+
+
+def test_sidecar_with_invalid_holder_identity_is_diagnostic_only(tmp_path):
+    paths = _paths(tmp_path)
+    holder = subprocess.Popen(
+        [
+            sys.executable,
+            str(FIXTURES / "lock_holder.py"),
+            str(paths.state_root),
+            "provider:google",
+            "job-20260612T190000Z-a1b2",
+        ],
+        text=True,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        assert holder.stdout is not None
+        assert holder.stdout.readline().strip() == "locked"
+        (paths.locks_dir / "provider:google.job-20260612T190000Z-a1b2.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "lock_name": "../escape",
+                    "job_id": "not-a-job",
+                    "pid": 123,
+                    "hostname": "host",
+                    "started_at": "2026-06-12T19:00:00Z",
+                    "command": ["quorum", "smoke", "gemini"],
+                }
+            )
+        )
+
+        assert read_lock_holder(paths, "provider:google") is None
+        with pytest.raises(LockConflict) as exc_info:
+            acquire_locks(
+                paths,
+                [LockRequest("provider:google")],
+                job_id="job-20260612T190001Z-b2c3",
+                command=["quorum", "smoke", "gemini"],
+            )
+
+        assert exc_info.value.holder is None
+    finally:
+        if holder.stdin is not None:
+            holder.stdin.write("\n")
+            holder.stdin.flush()
+        holder.wait(timeout=10)
+        assert holder.returncode == 0, holder.stderr.read() if holder.stderr else ""
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    [
+        "../escape",
+        "/tmp/escape",
+        "provider:../anthropic",
+        "target:claude/child",
+        "provider",
+        "provider:",
+        "target",
+        "target:",
+        "global:",
+        "checkout:",
+        "",
+    ],
+)
+def test_lock_file_names_reject_path_traversal(tmp_path, bad_name):
+    paths = _paths(tmp_path)
+
+    with pytest.raises(ValueError, match="invalid lock name"):
+        acquire_locks(
+            paths,
+            [LockRequest(bad_name)],
+            job_id="job-20260612T190000Z-a1b2",
+            command=["quorum", "smoke", "claude"],
+        )
+    with pytest.raises(ValueError, match="invalid lock name"):
+        read_lock_holder(paths, bad_name)
+
+    assert not (tmp_path / "escape.lock").exists()
+    assert not (tmp_path / "escape.json").exists()
+
+
+@pytest.mark.parametrize("job_id", ["../escape", "not-a-job", "job-20260612T190000Z-zzzz"])
+def test_acquire_locks_rejects_invalid_job_ids(tmp_path, job_id):
+    paths = _paths(tmp_path)
+
+    with pytest.raises(ValueError, match="invalid managed job id"):
+        acquire_locks(
+            paths,
+            [LockRequest("target:claude")],
+            job_id=job_id,
+            command=["quorum", "smoke", "claude"],
+        )
+
+    assert not paths.locks_dir.exists()
+
+
+@pytest.mark.parametrize("bad_provider", ["../escape", "/tmp/escape", "openai/child", ""])
+def test_cooldown_file_names_reject_path_traversal(tmp_path, bad_provider):
+    paths = _paths(tmp_path)
+    now = datetime(2026, 6, 12, 19, 0, tzinfo=UTC)
+
+    with pytest.raises(ValueError, match="invalid cooldown name"):
+        write_cooldown(paths, bad_provider, "quota", now + timedelta(minutes=5))
+
+    assert not (tmp_path / "escape.json").exists()

--- a/tests/quorum/test_managed_commands.py
+++ b/tests/quorum/test_managed_commands.py
@@ -1,12 +1,23 @@
 import json
 import subprocess
+from collections.abc import Mapping
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Literal
 
 from click.testing import CliRunner
 
 import quorum.managed_commands as managed_commands
 from quorum.cli import main
+from quorum.composer import FinalVerdict, GauntletLayer
+from quorum.locks import (
+    LockConflict,
+    LockRequest,
+    acquire_locks,
+    read_active_cooldowns,
+    release_locks,
+)
 from quorum.managed_state import (
     ManagedJob,
     append_event,
@@ -15,6 +26,7 @@ from quorum.managed_state import (
     read_job,
     write_job_atomic,
 )
+from quorum.run_all import ChildResult, MatrixEntry
 
 
 def _paths(tmp_path):
@@ -39,7 +51,7 @@ def _job(
     state: str,
     created_at: datetime,
     updated_at: datetime | None = None,
-    children: list[dict[str, object]] | None = None,
+    children: list[Mapping[str, object]] | None = None,
 ) -> ManagedJob:
     return ManagedJob(
         id=job_id,
@@ -49,13 +61,37 @@ def _job(
         command=["quorum", "unit", "claude"],
         managed_command="unit",
         coding_agents=["claude"],
-        children=children or [],
+        children=list(children) if children is not None else [],
     )
 
 
 def _events(paths, job_id):
     event_path = paths.events_dir / f"{job_id}.jsonl"
     return [json.loads(line) for line in event_path.read_text().splitlines()]
+
+
+def _pass_verdict(final: Literal["pass", "fail", "indeterminate"] = "pass") -> FinalVerdict:
+    return FinalVerdict(
+        final=final,
+        final_reason=f"{final} reason",
+        gauntlet=GauntletLayer(status="pass", summary="ok", reasoning="ok"),
+        checks=[],
+        error=None,
+    )
+
+
+def _scenario(root: Path, name: str = "00-quorum-smoke-hello-world") -> Path:
+    scenario = root / name
+    scenario.mkdir(parents=True)
+    (scenario / "story.md").write_text("---\nid: smoke\nstatus: draft\ntags: smoke\n---\n")
+    (scenario / "setup.sh").write_text("true\n")
+    (scenario / "checks.sh").write_text("pre() { :; }\npost() { :; }\n")
+    return scenario
+
+
+def _agent(root: Path, name: str = "claude") -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / f"{name}.yaml").write_text(f"name: {name}\nbinary: echo\n")
 
 
 def test_create_job_writes_planned_state_and_creation_event(tmp_path):
@@ -165,7 +201,7 @@ def test_tmux_supervisor_uses_phase_one_worker_command(tmp_path):
     result = managed_commands.start_job(
         job,
         paths,
-        managed_commands.TmuxSupervisor(runner=runner),
+        managed_commands.TmuxSupervisor(runner=runner, env={}),
     )
 
     assert result.exit_code is None
@@ -184,6 +220,11 @@ def test_tmux_supervisor_uses_phase_one_worker_command(tmp_path):
                 'exec >> "$1" 2>&1; shift; exec "$@"',
                 "quorum-managed-worker",
                 str(log_path),
+                "sh",
+                "-c",
+                managed_commands.WORKER_TOKEN_WRAPPER,
+                "quorum-managed-worker-token",
+                str(managed_commands.runtime_env.MANAGED_WORKER_TOKEN_PATH),
                 "env",
                 "QUORUM_MANAGED_WORKER=1",
                 f"QUORUM_STATE_ROOT={paths.state_root}",
@@ -199,6 +240,43 @@ def test_tmux_supervisor_uses_phase_one_worker_command(tmp_path):
     ]
     assert log_path.parent.is_dir()
     assert log_path.read_text() == ""
+
+
+def test_tmux_supervisor_hands_control_env_without_leaking_worker_token(tmp_path, monkeypatch):
+    paths = _paths(tmp_path)
+    calls = []
+    token_path = tmp_path / "worker-token"
+    monkeypatch.setattr(managed_commands.runtime_env, "MANAGED_WORKER_TOKEN_PATH", token_path)
+    secret = "worker-secret-value"
+
+    def runner(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0)
+
+    job = managed_commands.create_job("unit", "claude", [], paths, owner="drew")
+
+    managed_commands.start_job(
+        job,
+        paths,
+        managed_commands.TmuxSupervisor(
+            runner=runner,
+            env={
+                "QUORUM_MANAGED_HOST": "1",
+                "QUORUM_TARGET_PROFILE_ROOT": str(tmp_path / "profiles"),
+                "QUORUM_MANAGED_WORKER_TOKEN": secret,
+                "SUPERPOWERS_ROOT": str(tmp_path / "superpowers"),
+            },
+        ),
+    )
+
+    command = calls[0][0]
+    assert "QUORUM_MANAGED_HOST=1" in command
+    assert f"QUORUM_TARGET_PROFILE_ROOT={tmp_path / 'profiles'}" in command
+    assert f"SUPERPOWERS_ROOT={tmp_path / 'superpowers'}" in command
+    assert str(token_path) in command
+    assert secret not in command
+    assert secret not in json.dumps(_events(paths, job.id))
+    assert secret not in (paths.jobs_dir / f"{job.id}.json").read_text()
 
 
 def test_tmux_supervisor_does_not_interpolate_paths_into_shell_wrapper(tmp_path):
@@ -234,7 +312,7 @@ def test_start_job_marks_failed_when_supervisor_cannot_launch(tmp_path):
     paths = _paths(tmp_path)
 
     class BrokenSupervisor:
-        def start(self, job, worker_paths, command):
+        def start(self, job, paths, command):
             raise FileNotFoundError("tmux")
 
     job = managed_commands.create_job("unit", "claude", [], paths, owner="drew")
@@ -404,3 +482,388 @@ def test_status_can_hide_finished_jobs(tmp_path):
 
     assert result.exit_code == 0, result.output
     assert json.loads(result.output) == []
+
+
+def test_smoke_executor_records_run_child_before_completion(tmp_path, monkeypatch):
+    paths = _paths(tmp_path)
+    scenarios_root = tmp_path / "scenarios"
+    coding_agents_dir = tmp_path / "coding-agents"
+    _scenario(scenarios_root)
+    _agent(coding_agents_dir, "claude")
+    job = managed_commands.create_job(
+        "smoke",
+        "claude",
+        [
+            "--scenarios-root",
+            str(scenarios_root),
+            "--coding-agents-dir",
+            str(coding_agents_dir),
+        ],
+        paths,
+        owner="drew",
+    )
+    observed_children_during_run = []
+
+    def fake_run_scenario_in_dir(**kwargs):
+        stored = read_job(paths, job.id)
+        observed_children_during_run.extend(stored.children)
+        assert kwargs["run_dir"].parent == paths.artifact_root
+        assert kwargs["run_dir"].name.startswith("00-quorum-smoke-hello-world-claude-")
+        assert kwargs["scenario_dir"] == scenarios_root / "00-quorum-smoke-hello-world"
+        assert kwargs["coding_agent"] == "claude"
+        assert kwargs["env_base"]["QUORUM_TARGET"] == "claude"
+        assert "QUORUM_MANAGED_WORKER_TOKEN" not in kwargs["env_base"]
+        return kwargs["run_dir"], _pass_verdict("fail")
+
+    monkeypatch.setattr(managed_commands, "run_scenario_in_dir", fake_run_scenario_in_dir)
+
+    worker_env = {**_env(paths), "QUORUM_MANAGED_WORKER_TOKEN": "worker-secret"}
+
+    exit_code = managed_commands.run_managed_worker(job.id, paths, worker_env)
+
+    assert exit_code == 0
+    stored = read_job(paths, job.id)
+    serialized_job = (paths.jobs_dir / f"{job.id}.json").read_text(encoding="utf-8")
+    assert "worker-secret" not in serialized_job
+    assert "worker-secret" not in json.dumps(_events(paths, job.id), sort_keys=True)
+    assert stored.state == "succeeded"
+    assert observed_children_during_run[0]["state"] == "running"
+    assert observed_children_during_run[0]["run_dir"].startswith(str(paths.artifact_root))
+    run_id = Path(observed_children_during_run[0]["run_dir"]).name
+    assert stored.children == [
+        {
+            "id": "child-0001",
+            "kind": "run",
+            "target": "claude",
+            "coding_agent": "claude",
+            "scenario": "00-quorum-smoke-hello-world",
+            "run_id": run_id,
+            "run_dir": str(paths.artifact_root / run_id),
+            "state": "finished",
+            "final": "fail",
+        }
+    ]
+    assert stored.result_rollup == {"final": "fail", "total": 1, "passed": 0, "failed": 1}
+    assert sorted(stored.locks) == ["global:active", "provider:anthropic", "target:claude"]
+
+
+def test_column_executor_calls_run_batch_and_rolls_up_child_results(tmp_path, monkeypatch):
+    paths = _paths(tmp_path)
+    scenarios_root = tmp_path / "scenarios"
+    coding_agents_dir = tmp_path / "coding-agents"
+    scenario_dir = _scenario(scenarios_root, "triggering-test-driven-development")
+    _agent(coding_agents_dir, "claude")
+    job = managed_commands.create_job(
+        "column",
+        "claude",
+        [
+            "--jobs",
+            "2",
+            "--scenarios-root",
+            str(scenarios_root),
+            "--coding-agents-dir",
+            str(coding_agents_dir),
+        ],
+        paths,
+        owner="drew",
+    )
+    batch_dir = paths.artifact_root / "batches" / "batch-test"
+
+    def fake_run_batch(**kwargs):
+        assert kwargs["agent_filter"] == ["claude"]
+        assert kwargs["jobs"] == 2
+        assert kwargs["tier"] == "sentinel"
+        assert kwargs["include_drafts"] is False
+        assert kwargs["env_base"]["QUORUM_TARGET"] == "claude"
+        kwargs["on_batch_allocated"](batch_dir)
+        entry = MatrixEntry(
+            scenario="triggering-test-driven-development",
+            coding_agent="claude",
+            scenario_dir=scenario_dir,
+            skipped_reason=None,
+            tier="sentinel",
+            status="ready",
+        )
+        kwargs["on_child_started"](
+            "child-0001",
+            entry,
+            ["uv", "run", "quorum", "run", str(scenario_dir)],
+        )
+        run_dir = paths.artifact_root / "triggering-test-driven-development-claude-x"
+        run_dir.mkdir(parents=True)
+        (run_dir / "verdict.json").write_text(json.dumps({"final": "indeterminate"}))
+        kwargs["on_child_finished"](
+            "child-0001",
+            ChildResult(
+                run_id="triggering-test-driven-development-claude-x",
+                exit_code=2,
+                error=None,
+            ),
+        )
+        return batch_dir
+
+    monkeypatch.setattr(managed_commands, "run_batch", fake_run_batch)
+
+    exit_code = managed_commands.run_managed_worker(job.id, paths, _env(paths))
+
+    assert exit_code == 0
+    stored = read_job(paths, job.id)
+    assert stored.state == "succeeded"
+    assert stored.result_rollup == {
+        "final": "indeterminate",
+        "total": 1,
+        "passed": 0,
+        "failed": 0,
+        "indeterminate": 1,
+    }
+    run_children = [child for child in stored.children if child["kind"] == "run"]
+    assert run_children == [
+        {
+            "id": "child-0001",
+            "kind": "run",
+            "target": "claude",
+            "coding_agent": "claude",
+            "scenario": "triggering-test-driven-development",
+            "command": ["uv", "run", "quorum", "run", str(scenario_dir)],
+            "batch_id": "batch-test",
+            "batch_dir": str(batch_dir),
+            "run_id": "triggering-test-driven-development-claude-x",
+            "run_dir": str(paths.artifact_root / "triggering-test-driven-development-claude-x"),
+            "state": "finished",
+            "final": "indeterminate",
+        }
+    ]
+    batch_children = [child for child in stored.children if child["kind"] == "batch"]
+    assert batch_children == [
+        {
+            "id": "batch",
+            "kind": "batch",
+            "batch_id": "batch-test",
+            "batch_dir": str(batch_dir),
+            "state": "finished",
+        }
+    ]
+
+
+def test_column_executor_records_children_under_configured_out_root(tmp_path, monkeypatch):
+    paths = _paths(tmp_path)
+    custom_out_root = tmp_path / "custom-results"
+    scenarios_root = tmp_path / "scenarios"
+    coding_agents_dir = tmp_path / "coding-agents"
+    scenario_dir = _scenario(scenarios_root, "alpha")
+    _agent(coding_agents_dir, "claude")
+    job = managed_commands.create_job(
+        "column",
+        "claude",
+        [
+            "--out-root",
+            str(custom_out_root),
+            "--scenarios-root",
+            str(scenarios_root),
+            "--coding-agents-dir",
+            str(coding_agents_dir),
+        ],
+        paths,
+        owner="drew",
+    )
+
+    def fake_run_batch(**kwargs):
+        assert kwargs["out_root"] == custom_out_root.resolve()
+        batch_dir = custom_out_root.resolve() / "batches" / "batch-custom"
+        kwargs["on_batch_allocated"](batch_dir)
+        entry = MatrixEntry(
+            scenario="alpha",
+            coding_agent="claude",
+            scenario_dir=scenario_dir,
+            skipped_reason=None,
+            tier="sentinel",
+            status="ready",
+        )
+        kwargs["on_child_started"]("child-0001", entry, ["uv", "run", "quorum", "run"])
+        run_id = "alpha-claude-x"
+        run_dir = custom_out_root.resolve() / run_id
+        run_dir.mkdir(parents=True)
+        (run_dir / "verdict.json").write_text(json.dumps({"final": "pass"}))
+        kwargs["on_child_finished"](
+            "child-0001",
+            ChildResult(run_id=run_id, exit_code=0, error=None),
+        )
+        return batch_dir
+
+    monkeypatch.setattr(managed_commands, "run_batch", fake_run_batch)
+
+    exit_code = managed_commands.run_managed_worker(job.id, paths, _env(paths))
+
+    assert exit_code == 0
+    stored = read_job(paths, job.id)
+    run_child = next(child for child in stored.children if child.get("kind") == "run")
+    assert run_child["run_dir"] == str(custom_out_root.resolve() / "alpha-claude-x")
+    assert stored.result_rollup == {"final": "pass", "total": 1, "passed": 1, "failed": 0}
+
+
+def test_worker_records_lock_conflict_event(tmp_path, monkeypatch):
+    paths = _paths(tmp_path)
+    scenarios_root = tmp_path / "scenarios"
+    coding_agents_dir = tmp_path / "coding-agents"
+    _scenario(scenarios_root)
+    _agent(coding_agents_dir, "claude")
+    job = managed_commands.create_job(
+        "smoke",
+        "claude",
+        [
+            "--scenarios-root",
+            str(scenarios_root),
+            "--coding-agents-dir",
+            str(coding_agents_dir),
+        ],
+        paths,
+        owner="drew",
+    )
+
+    def fake_acquire_locks(paths_arg, requests, job_id, command, wait=False):
+        del requests
+        raise LockConflict(
+            lock_name="target:claude",
+            lock_path=paths_arg.locks_dir / "target:claude.lock",
+            holder=None,
+            requested_job_id=job_id,
+            command=command,
+            wait=wait,
+        )
+
+    monkeypatch.setattr(managed_commands, "acquire_locks", fake_acquire_locks)
+
+    exit_code = managed_commands.run_managed_worker(job.id, paths, _env(paths))
+
+    assert exit_code == 1
+    stored = read_job(paths, job.id)
+    assert stored.state == "failed"
+    events = _events(paths, job.id)
+    conflict = next(event for event in events if event["event"] == "lock-conflict")
+    assert conflict["lock_name"] == "target:claude"
+    assert conflict["conflict"]["error"] == "lock-conflict"
+    assert conflict["conflict"]["requested_job_id"] == job.id
+
+
+def test_worker_global_active_lock_blocks_disjoint_target(tmp_path, monkeypatch):
+    paths = _paths(tmp_path)
+    scenarios_root = tmp_path / "scenarios"
+    coding_agents_dir = tmp_path / "coding-agents"
+    _scenario(scenarios_root)
+    _agent(coding_agents_dir, "claude")
+    job = managed_commands.create_job(
+        "smoke",
+        "claude",
+        [
+            "--scenarios-root",
+            str(scenarios_root),
+            "--coding-agents-dir",
+            str(coding_agents_dir),
+        ],
+        paths,
+        owner="drew",
+    )
+    held = acquire_locks(
+        paths,
+        [LockRequest("global:active")],
+        "job-20260612T230000Z-a111",
+        ["quorum", "smoke", "gemini"],
+    )
+
+    def fake_run_scenario_in_dir(**_kwargs):
+        return paths.artifact_root / "unused", _pass_verdict("pass")
+
+    monkeypatch.setattr(managed_commands, "run_scenario_in_dir", fake_run_scenario_in_dir)
+    try:
+        exit_code = managed_commands.run_managed_worker(job.id, paths, _env(paths))
+    finally:
+        release_locks(held)
+
+    assert exit_code == 1
+    stored = read_job(paths, job.id)
+    assert stored.state == "failed"
+    conflict = next(event for event in _events(paths, job.id) if event["event"] == "lock-conflict")
+    assert conflict["lock_name"] == "global:active"
+
+
+def test_batch_executor_preserves_rate_limit_skip_and_writes_cooldown(tmp_path, monkeypatch):
+    paths = _paths(tmp_path)
+    scenarios_root = tmp_path / "scenarios"
+    coding_agents_dir = tmp_path / "coding-agents"
+    scenario_dir = _scenario(scenarios_root, "alpha")
+    _agent(coding_agents_dir, "antigravity")
+    job = managed_commands.create_job(
+        "batch",
+        None,
+        [
+            "--coding-agents",
+            "antigravity",
+            "--scenarios-root",
+            str(scenarios_root),
+            "--coding-agents-dir",
+            str(coding_agents_dir),
+        ],
+        paths,
+        owner="drew",
+        coding_agents=["antigravity"],
+    )
+    batch_dir = paths.artifact_root / "batches" / "batch-rate-limit"
+
+    def fake_run_batch(**kwargs):
+        kwargs["on_batch_allocated"](batch_dir)
+        entry = MatrixEntry(
+            scenario="alpha",
+            coding_agent="antigravity",
+            scenario_dir=scenario_dir,
+            skipped_reason=None,
+            tier="sentinel",
+            status="ready",
+        )
+        kwargs["on_child_started"]("child-0001", entry, ["uv", "run", "quorum", "run"])
+        run_id = "alpha-antigravity-x"
+        run_dir = paths.artifact_root / run_id
+        run_dir.mkdir(parents=True)
+        (run_dir / "verdict.json").write_text(
+            json.dumps(
+                {
+                    "final": "indeterminate",
+                    "error": {"message": "Code Assist rate limit: throttled"},
+                }
+            )
+        )
+        kwargs["on_child_finished"](
+            "child-0001",
+            ChildResult(run_id=run_id, exit_code=2, error=None),
+        )
+        kwargs["on_child_finished"](
+            "child-0002",
+            ChildResult(run_id=None, exit_code=0, error="agy-rate-limit-skip"),
+        )
+        return batch_dir
+
+    monkeypatch.setattr(managed_commands, "run_batch", fake_run_batch)
+
+    exit_code = managed_commands.run_managed_worker(job.id, paths, _env(paths))
+
+    assert exit_code == 0
+    stored = read_job(paths, job.id)
+    assert stored.result_rollup is not None
+    assert stored.result_rollup["final"] == "indeterminate"
+    run_children = [child for child in stored.children if child["kind"] == "run"]
+    assert run_children[0]["final"] == "indeterminate"
+    assert run_children[1]["state"] == "skipped"
+    assert run_children[1]["skipped"] == "rate-limited"
+    cooldowns = read_active_cooldowns(paths, datetime.now(UTC))
+    assert [(cooldown.provider, cooldown.reason) for cooldown in cooldowns] == [
+        ("gemini", "Code Assist rate limit")
+    ]
+    assert stored.extra["cooldowns"] == [
+        {
+            "provider": "gemini",
+            "reason": "Code Assist rate limit",
+            "source_child_id": "child-0001",
+            "source_job_id": job.id,
+            "source_run_id": "alpha-antigravity-x",
+            "until": cooldowns[0].until.isoformat().replace("+00:00", "Z"),
+        }
+    ]

--- a/tests/quorum/test_managed_commands.py
+++ b/tests/quorum/test_managed_commands.py
@@ -1,0 +1,406 @@
+import json
+import subprocess
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+
+from click.testing import CliRunner
+
+import quorum.managed_commands as managed_commands
+from quorum.cli import main
+from quorum.managed_state import (
+    ManagedJob,
+    append_event,
+    discover_managed_paths,
+    mark_job_state,
+    read_job,
+    write_job_atomic,
+)
+
+
+def _paths(tmp_path):
+    return discover_managed_paths(
+        {
+            "QUORUM_STATE_ROOT": str(tmp_path / "state"),
+            "QUORUM_ARTIFACT_ROOT": str(tmp_path / "artifacts"),
+        }
+    )
+
+
+def _env(paths):
+    return {
+        "QUORUM_STATE_ROOT": str(paths.state_root),
+        "QUORUM_ARTIFACT_ROOT": str(paths.artifact_root),
+    }
+
+
+def _job(
+    job_id: str,
+    *,
+    state: str,
+    created_at: datetime,
+    updated_at: datetime | None = None,
+    children: list[dict[str, object]] | None = None,
+) -> ManagedJob:
+    return ManagedJob(
+        id=job_id,
+        state=state,
+        created_at=created_at,
+        updated_at=updated_at or created_at,
+        command=["quorum", "unit", "claude"],
+        managed_command="unit",
+        coding_agents=["claude"],
+        children=children or [],
+    )
+
+
+def _events(paths, job_id):
+    event_path = paths.events_dir / f"{job_id}.jsonl"
+    return [json.loads(line) for line in event_path.read_text().splitlines()]
+
+
+def test_create_job_writes_planned_state_and_creation_event(tmp_path):
+    paths = _paths(tmp_path)
+
+    job = managed_commands.create_job(
+        "smoke",
+        "claude",
+        ["--jobs", "1"],
+        paths,
+        owner="drew",
+    )
+
+    stored = read_job(paths, job.id)
+    assert stored.state == "planned"
+    assert stored.owner == "drew"
+    assert stored.host
+    assert stored.managed_command == "smoke"
+    assert stored.command == ["quorum", "smoke", "claude", "--jobs", "1"]
+    assert stored.coding_agents == ["claude"]
+    assert stored.out_root == str(paths.artifact_root)
+    assert stored.log_path == str(paths.state_root / "logs" / f"{job.id}.log")
+
+    [event] = _events(paths, job.id)
+    assert event["event"] == "job-created"
+    assert event["job_id"] == job.id
+    assert event["state"] == "planned"
+
+
+def test_inline_supervisor_runs_worker_and_marks_job_succeeded(tmp_path, monkeypatch):
+    paths = _paths(tmp_path)
+
+    def executor(job, worker_paths, env):
+        assert worker_paths == paths
+        assert env["QUORUM_MANAGED_WORKER"] == "1"
+        assert read_job(paths, job.id).state == "running"
+        append_event(paths, job.id, {"event": "unit-executor-ran"})
+        return 0
+
+    monkeypatch.setitem(managed_commands.WORKER_EXECUTORS, "unit", executor)
+    job = managed_commands.create_job("unit", "claude", [], paths, owner="drew")
+
+    result = managed_commands.start_job(
+        job,
+        paths,
+        managed_commands.InlineSupervisor(env=_env(paths)),
+    )
+
+    assert result.exit_code == 0
+    stored = read_job(paths, job.id)
+    assert stored.state == "succeeded"
+    assert stored.started_at is not None
+    assert stored.finished_at is not None
+    assert stored.final_exit_code == 0
+    assert stored.supervisor is not None
+    assert stored.supervisor["kind"] == "inline"
+    assert [event["event"] for event in _events(paths, job.id)] == [
+        "job-created",
+        "job-started",
+        "worker-started",
+        "unit-executor-ran",
+        "worker-succeeded",
+    ]
+
+
+def test_worker_marks_failed_with_exit_code_when_executor_raises(tmp_path, monkeypatch):
+    paths = _paths(tmp_path)
+
+    def executor(job, worker_paths, env):
+        raise subprocess.CalledProcessError(17, job.command, stderr="child exploded")
+
+    monkeypatch.setitem(managed_commands.WORKER_EXECUTORS, "unit", executor)
+    job = managed_commands.create_job("unit", None, [], paths, owner="drew")
+
+    exit_code = managed_commands.run_managed_worker(job.id, paths, _env(paths))
+
+    assert exit_code == 17
+    stored = read_job(paths, job.id)
+    assert stored.state == "failed"
+    assert stored.final_exit_code == 17
+    assert "child exploded" in (stored.failure_reason or "")
+
+
+def test_worker_fails_unknown_job_kind_with_clear_reason(tmp_path):
+    paths = _paths(tmp_path)
+    job = managed_commands.create_job("future-kind", "claude", [], paths, owner="drew")
+
+    exit_code = managed_commands.run_managed_worker(job.id, paths, _env(paths))
+
+    assert exit_code == 2
+    stored = read_job(paths, job.id)
+    assert stored.state == "failed"
+    assert "future-kind" in (stored.failure_reason or "")
+    assert "not implemented" in (stored.failure_reason or "")
+
+
+def test_tmux_supervisor_uses_phase_one_worker_command(tmp_path):
+    paths = _paths(tmp_path)
+    calls = []
+
+    def runner(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0)
+
+    job = managed_commands.create_job("unit", "claude", [], paths, owner="drew")
+
+    result = managed_commands.start_job(
+        job,
+        paths,
+        managed_commands.TmuxSupervisor(runner=runner),
+    )
+
+    assert result.exit_code is None
+    log_path = paths.state_root / "logs" / f"{job.id}.log"
+    assert calls == [
+        (
+            [
+                "tmux",
+                "new-session",
+                "-d",
+                "-s",
+                f"quorum-{job.id}",
+                "--",
+                "sh",
+                "-c",
+                'exec >> "$1" 2>&1; shift; exec "$@"',
+                "quorum-managed-worker",
+                str(log_path),
+                "env",
+                "QUORUM_MANAGED_WORKER=1",
+                f"QUORUM_STATE_ROOT={paths.state_root}",
+                f"QUORUM_ARTIFACT_ROOT={paths.artifact_root}",
+                "uv",
+                "run",
+                "quorum",
+                "managed-worker",
+                job.id,
+            ],
+            {"check": True, "text": True},
+        )
+    ]
+    assert log_path.parent.is_dir()
+    assert log_path.read_text() == ""
+
+
+def test_tmux_supervisor_does_not_interpolate_paths_into_shell_wrapper(tmp_path):
+    paths = _paths(tmp_path)
+    calls = []
+
+    def runner(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0)
+
+    job = managed_commands.create_job(
+        "unit",
+        "claude",
+        [],
+        paths,
+        owner="drew",
+    )
+
+    managed_commands.start_job(
+        job,
+        paths,
+        managed_commands.TmuxSupervisor(runner=runner),
+    )
+
+    command = calls[0][0]
+    shell_script = command[command.index("-c") + 1]
+    assert str(paths.state_root) not in shell_script
+    assert str(paths.artifact_root) not in shell_script
+    assert str(paths.state_root / "logs" / f"{job.id}.log") not in shell_script
+
+
+def test_start_job_marks_failed_when_supervisor_cannot_launch(tmp_path):
+    paths = _paths(tmp_path)
+
+    class BrokenSupervisor:
+        def start(self, job, worker_paths, command):
+            raise FileNotFoundError("tmux")
+
+    job = managed_commands.create_job("unit", "claude", [], paths, owner="drew")
+
+    result = managed_commands.start_job(job, paths, BrokenSupervisor())
+
+    assert result.exit_code == 1
+    stored = read_job(paths, job.id)
+    assert stored.state == "failed"
+    assert stored.final_exit_code == 1
+    assert "tmux" in (stored.failure_reason or "")
+    assert [event["event"] for event in _events(paths, job.id)] == [
+        "job-created",
+        "job-started",
+        "job-start-failed",
+    ]
+
+
+def test_status_summary_sorts_active_before_terminal_jobs(tmp_path):
+    paths = _paths(tmp_path)
+    now = datetime(2026, 6, 12, 20, 0, tzinfo=UTC)
+    terminal_old = _job(
+        "job-20260612T200000Z-a111",
+        state="succeeded",
+        created_at=now,
+        updated_at=now + timedelta(minutes=1),
+    )
+    running = _job(
+        "job-20260612T200001Z-b222",
+        state="running",
+        created_at=now + timedelta(seconds=1),
+        updated_at=now + timedelta(seconds=2),
+    )
+    planned = _job(
+        "job-20260612T200002Z-c333",
+        state="planned",
+        created_at=now + timedelta(seconds=2),
+        updated_at=now + timedelta(seconds=3),
+    )
+    terminal_recent = _job(
+        "job-20260612T200003Z-d444",
+        state="failed",
+        created_at=now + timedelta(seconds=3),
+        updated_at=now + timedelta(minutes=2),
+    )
+    for job in [terminal_old, running, planned, terminal_recent]:
+        write_job_atomic(paths, job)
+
+    summary = managed_commands.status_summary(paths, limit=10, include_finished=True)
+
+    assert [job.id for job in summary] == [
+        planned.id,
+        running.id,
+        terminal_recent.id,
+        terminal_old.id,
+    ]
+
+
+def test_status_json_is_parseable_and_contains_child_records(tmp_path):
+    paths = _paths(tmp_path)
+    job = managed_commands.create_job("unit", "codex", [], paths, owner="drew")
+    write_job_atomic(
+        paths,
+        replace(
+            job,
+            children=[
+                {
+                    "id": "child-1",
+                    "state": "succeeded",
+                    "run_id": "scenario-codex-20260612T200000Z-abcd",
+                }
+            ],
+        ),
+    )
+
+    result = CliRunner().invoke(main, ["status", job.id, "--json"], env=_env(paths))
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["id"] == job.id
+    assert payload["children"] == [
+        {
+            "id": "child-1",
+            "run_id": "scenario-codex-20260612T200000Z-abcd",
+            "state": "succeeded",
+        }
+    ]
+
+
+def test_tail_returns_parent_events_and_log_content(tmp_path):
+    paths = _paths(tmp_path)
+    job = managed_commands.create_job("unit", "claude", [], paths, owner="drew")
+    append_event(paths, job.id, {"event": "custom", "message": "hello"})
+    log_path = paths.state_root / "logs" / f"{job.id}.log"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text("stdout line\nstderr line\n")
+
+    lines = list(managed_commands.tail_job(job.id, paths=paths))
+
+    events = [json.loads(line) for line in lines if line.startswith("{")]
+    assert [event["event"] for event in events] == ["job-created", "custom"]
+    assert "stdout line\n" in lines
+    assert "stderr line\n" in lines
+
+
+def test_tail_returns_child_log_content_when_child_id_is_supplied(tmp_path):
+    paths = _paths(tmp_path)
+    child_log = tmp_path / "child.log"
+    child_log.write_text("child line one\nchild line two\n")
+    job = managed_commands.create_job("unit", "claude", [], paths, owner="drew")
+    write_job_atomic(
+        paths,
+        replace(
+            job,
+            children=[
+                {
+                    "id": "child-1",
+                    "state": "running",
+                    "log_path": str(child_log),
+                }
+            ],
+        ),
+    )
+
+    assert list(managed_commands.tail_job(job.id, child_id="child-1", paths=paths)) == [
+        "child line one\n",
+        "child line two\n",
+    ]
+
+
+def test_hidden_managed_worker_command_is_callable_directly(tmp_path, monkeypatch):
+    paths = _paths(tmp_path)
+
+    def executor(job, worker_paths, env):
+        return 0
+
+    monkeypatch.setitem(managed_commands.WORKER_EXECUTORS, "unit", executor)
+    job = managed_commands.create_job("unit", "claude", [], paths, owner="drew")
+
+    result = CliRunner().invoke(
+        main,
+        ["managed-worker", job.id],
+        env={**_env(paths), "QUORUM_MANAGED_WORKER": "1"},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert read_job(paths, job.id).state == "succeeded"
+
+
+def test_hidden_managed_worker_command_requires_worker_env_marker(tmp_path):
+    paths = _paths(tmp_path)
+    job = managed_commands.create_job("unit", "claude", [], paths, owner="drew")
+
+    result = CliRunner().invoke(main, ["managed-worker", job.id], env=_env(paths))
+
+    assert result.exit_code == 2
+    assert "managed supervisor" in result.output
+    assert read_job(paths, job.id).state == "planned"
+
+
+def test_status_can_hide_finished_jobs(tmp_path):
+    paths = _paths(tmp_path)
+    job = managed_commands.create_job("unit", "claude", [], paths, owner="drew")
+    mark_job_state(paths, job.id, "succeeded", final_exit_code=0)
+
+    result = CliRunner().invoke(main, ["status", "--active-only", "--json"], env=_env(paths))
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == []

--- a/tests/quorum/test_managed_commands.py
+++ b/tests/quorum/test_managed_commands.py
@@ -1,5 +1,6 @@
 import json
 import subprocess
+import threading
 from collections.abc import Mapping
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
@@ -23,6 +24,7 @@ from quorum.managed_state import (
     append_event,
     discover_managed_paths,
     mark_job_state,
+    mark_job_tainted,
     read_job,
     write_job_atomic,
 )
@@ -155,6 +157,186 @@ def test_inline_supervisor_runs_worker_and_marks_job_succeeded(tmp_path, monkeyp
         "unit-executor-ran",
         "worker-succeeded",
     ]
+
+
+def test_worker_marks_job_failed_and_tainted_when_final_scan_finds_secret(
+    tmp_path, monkeypatch
+):
+    paths = _paths(tmp_path)
+    profile_root = tmp_path / "profiles"
+    profile_root.mkdir()
+    secret = "target-secret-value-456"
+    (profile_root / "claude.env").write_text(f"ANTHROPIC_API_KEY={secret}\n")
+
+    def executor(job, worker_paths, env):
+        del env
+        run_dir = worker_paths.artifact_root / "unit-claude-x"
+        run_dir.mkdir(parents=True)
+        (run_dir / "stdout.txt").write_text(f"leaked {secret}\n")
+        managed_commands._upsert_child(
+            worker_paths,
+            job.id,
+            {
+                "id": "child-0001",
+                "kind": "run",
+                "run_dir": str(run_dir),
+                "state": "finished",
+                "final": "pass",
+            },
+        )
+        return 0
+
+    monkeypatch.setitem(managed_commands.WORKER_EXECUTORS, "unit", executor)
+    job = managed_commands.create_job("unit", "claude", [], paths, owner="drew")
+
+    exit_code = managed_commands.run_managed_worker(
+        job.id,
+        paths,
+        {**_env(paths), "QUORUM_TARGET_PROFILE_ROOT": str(profile_root)},
+    )
+
+    assert exit_code == 1
+    stored = read_job(paths, job.id)
+    assert stored.state == "failed"
+    assert stored.final_exit_code == 1
+    assert stored.failure_reason == "secret-like material detected in managed artifacts"
+    assert stored.tainted is True
+    assert stored.taint_matches == [
+        {
+            "path": str(paths.artifact_root / "unit-claude-x" / "stdout.txt"),
+            "offset": len("leaked "),
+            "pattern": "ANTHROPIC_API_KEY",
+            "digest": stored.taint_matches[0]["digest"],
+        }
+    ]
+    assert secret not in json.dumps(stored.taint_matches, sort_keys=True)
+    assert [event["event"] for event in _events(paths, job.id)][-2:] == [
+        "job-tainted",
+        "worker-tainted",
+    ]
+
+
+def test_worker_final_scan_leaves_clean_artifacts_unchanged(tmp_path, monkeypatch):
+    paths = _paths(tmp_path)
+    profile_root = tmp_path / "profiles"
+    profile_root.mkdir()
+    (profile_root / "claude.env").write_text("ANTHROPIC_API_KEY=target-secret-value-789\n")
+
+    def executor(job, worker_paths, env):
+        del env
+        run_dir = worker_paths.artifact_root / "unit-claude-clean"
+        run_dir.mkdir(parents=True)
+        (run_dir / "stdout.txt").write_text("clean artifact\n")
+        managed_commands._upsert_child(
+            worker_paths,
+            job.id,
+            {
+                "id": "child-0001",
+                "kind": "run",
+                "run_dir": str(run_dir),
+                "state": "finished",
+                "final": "pass",
+            },
+        )
+        return 0
+
+    monkeypatch.setitem(managed_commands.WORKER_EXECUTORS, "unit", executor)
+    job = managed_commands.create_job("unit", "claude", [], paths, owner="drew")
+
+    exit_code = managed_commands.run_managed_worker(
+        job.id,
+        paths,
+        {**_env(paths), "QUORUM_TARGET_PROFILE_ROOT": str(profile_root)},
+    )
+
+    assert exit_code == 0
+    stored = read_job(paths, job.id)
+    assert stored.state == "succeeded"
+    assert stored.final_exit_code == 0
+    assert stored.tainted is False
+    assert stored.taint_matches == []
+    assert "job-tainted" not in [event["event"] for event in _events(paths, job.id)]
+
+
+def test_worker_token_value_is_not_used_as_secret_scan_pattern(tmp_path, monkeypatch):
+    paths = _paths(tmp_path)
+    worker_token = "worker-token-not-provider-shaped"
+
+    def executor(job, worker_paths, env):
+        assert env["QUORUM_MANAGED_WORKER_TOKEN"] == worker_token
+        run_dir = worker_paths.artifact_root / "unit-claude-worker-token"
+        run_dir.mkdir(parents=True)
+        (run_dir / "stdout.txt").write_text(worker_token)
+        managed_commands._upsert_child(
+            worker_paths,
+            job.id,
+            {
+                "id": "child-0001",
+                "kind": "run",
+                "run_dir": str(run_dir),
+                "state": "finished",
+                "final": "pass",
+            },
+        )
+        return 0
+
+    monkeypatch.setitem(managed_commands.WORKER_EXECUTORS, "unit", executor)
+    job = managed_commands.create_job("unit", "claude", [], paths, owner="drew")
+
+    exit_code = managed_commands.run_managed_worker(
+        job.id,
+        paths,
+        {**_env(paths), "QUORUM_MANAGED_WORKER_TOKEN": worker_token},
+    )
+
+    stored = read_job(paths, job.id)
+    assert exit_code == 0
+    assert stored.state == "succeeded"
+    assert stored.tainted is False
+    assert stored.taint_matches == []
+    assert worker_token not in (paths.jobs_dir / f"{job.id}.json").read_text()
+
+
+def test_record_child_finished_taints_job_when_child_artifact_leaks_secret(tmp_path):
+    paths = _paths(tmp_path)
+    profile_root = tmp_path / "profiles"
+    profile_root.mkdir()
+    secret = "child-artifact-secret-123"
+    (profile_root / "claude.env").write_text(f"ANTHROPIC_API_KEY={secret}\n")
+    run_dir = paths.artifact_root / "scenario-claude-x"
+    run_dir.mkdir(parents=True)
+    (run_dir / "stdout.txt").write_text(secret)
+    job = managed_commands.create_job(
+        "batch",
+        None,
+        [],
+        paths,
+        owner="drew",
+        coding_agents=["claude"],
+    )
+    mark_job_state(paths, job.id, "running")
+
+    tainted = managed_commands._record_child_finished(
+        paths,
+        job.id,
+        "child-0001",
+        ChildResult(run_id=run_dir.name, exit_code=0, error=None),
+        artifact_root=paths.artifact_root,
+        batch={},
+        secret_patterns=managed_commands._secret_patterns_for_job(
+            job,
+            {**_env(paths), "QUORUM_TARGET_PROFILE_ROOT": str(profile_root)},
+        ),
+        lock=threading.Lock(),
+    )
+
+    stored = read_job(paths, job.id)
+    assert tainted is True
+    assert stored.state == "running"
+    assert stored.tainted is True
+    assert stored.taint_matches[0]["path"] == str(run_dir / "stdout.txt")
+    assert secret not in (paths.jobs_dir / f"{job.id}.json").read_text()
+    assert secret not in (paths.events_dir / f"{job.id}.jsonl").read_text()
 
 
 def test_worker_marks_failed_with_exit_code_when_executor_raises(tmp_path, monkeypatch):
@@ -402,6 +584,33 @@ def test_status_json_is_parseable_and_contains_child_records(tmp_path):
     ]
 
 
+def test_status_text_surfaces_tainted_jobs(tmp_path):
+    paths = _paths(tmp_path)
+    job = managed_commands.create_job("unit", "claude", [], paths, owner="drew")
+    mark_job_state(
+        paths,
+        job.id,
+        "failed",
+        final_exit_code=1,
+        failure_reason="secret-like material detected in managed artifacts",
+    )
+    mark_job_tainted(
+        paths,
+        job.id,
+        "secret-like material detected in managed artifacts",
+        [{"path": "run/stdout.txt", "offset": 0, "pattern": "ANTHROPIC_API_KEY"}],
+    )
+
+    detail = CliRunner().invoke(main, ["status", job.id], env=_env(paths))
+    summary = CliRunner().invoke(main, ["status"], env=_env(paths))
+
+    assert detail.exit_code == 0, detail.output
+    assert "tainted: true" in detail.output
+    assert "taint_reason: secret-like material detected in managed artifacts" in detail.output
+    assert summary.exit_code == 0, summary.output
+    assert "tainted" in summary.output
+
+
 def test_tail_returns_parent_events_and_log_content(tmp_path):
     paths = _paths(tmp_path)
     job = managed_commands.create_job("unit", "claude", [], paths, owner="drew")
@@ -643,6 +852,93 @@ def test_column_executor_calls_run_batch_and_rolls_up_child_results(tmp_path, mo
             "state": "finished",
         }
     ]
+
+
+def test_column_executor_taints_job_and_aborts_after_child_secret_leak(tmp_path, monkeypatch):
+    paths = _paths(tmp_path)
+    scenarios_root = tmp_path / "scenarios"
+    coding_agents_dir = tmp_path / "coding-agents"
+    profile_root = tmp_path / "profiles"
+    profile_root.mkdir()
+    secret = "column-child-secret-123"
+    (profile_root / "claude.env").write_text(f"ANTHROPIC_API_KEY={secret}\n")
+    alpha = _scenario(scenarios_root, "alpha")
+    beta = _scenario(scenarios_root, "beta")
+    _agent(coding_agents_dir, "claude")
+    job = managed_commands.create_job(
+        "column",
+        "claude",
+        [
+            "--scenarios-root",
+            str(scenarios_root),
+            "--coding-agents-dir",
+            str(coding_agents_dir),
+        ],
+        paths,
+        owner="drew",
+    )
+    batch_dir = paths.artifact_root / "batches" / "batch-tainted"
+
+    def fake_run_batch(**kwargs):
+        abort_event = kwargs["abort_event"]
+        assert abort_event.is_set() is False
+        kwargs["on_batch_allocated"](batch_dir)
+        alpha_entry = MatrixEntry(
+            scenario="alpha",
+            coding_agent="claude",
+            scenario_dir=alpha,
+            skipped_reason=None,
+            tier="sentinel",
+            status="ready",
+        )
+        kwargs["on_child_started"]("child-0001", alpha_entry, ["uv", "run", "quorum", "run"])
+        run_id = "alpha-claude-x"
+        run_dir = paths.artifact_root / run_id
+        run_dir.mkdir(parents=True)
+        (run_dir / "verdict.json").write_text(json.dumps({"final": "pass"}))
+        (run_dir / "stdout.txt").write_text(secret)
+        kwargs["on_child_finished"](
+            "child-0001",
+            ChildResult(run_id=run_id, exit_code=0, error=None),
+        )
+        assert abort_event.is_set() is True
+        beta_entry = MatrixEntry(
+            scenario="beta",
+            coding_agent="claude",
+            scenario_dir=beta,
+            skipped_reason=None,
+            tier="sentinel",
+            status="ready",
+        )
+        kwargs["on_child_started"]("child-0002", beta_entry, ["uv", "run", "quorum", "run"])
+        kwargs["on_child_finished"](
+            "child-0002",
+            ChildResult(run_id=None, exit_code=0, error=managed_commands.ABORT_SKIP_SENTINEL),
+        )
+        return batch_dir
+
+    monkeypatch.setattr(managed_commands, "run_batch", fake_run_batch)
+
+    exit_code = managed_commands.run_managed_worker(
+        job.id,
+        paths,
+        {**_env(paths), "QUORUM_TARGET_PROFILE_ROOT": str(profile_root)},
+    )
+
+    assert exit_code == 1
+    stored = read_job(paths, job.id)
+    assert stored.state == "failed"
+    assert stored.final_exit_code == 1
+    assert stored.tainted is True
+    assert stored.taint_matches[0]["path"] == str(
+        paths.artifact_root / "alpha-claude-x" / "stdout.txt"
+    )
+    run_children = [child for child in stored.children if child["kind"] == "run"]
+    assert run_children[0]["state"] == "finished"
+    assert run_children[1]["state"] == "skipped"
+    assert run_children[1]["skipped"] == "aborted"
+    assert secret not in (paths.jobs_dir / f"{job.id}.json").read_text()
+    assert secret not in (paths.events_dir / f"{job.id}.jsonl").read_text()
 
 
 def test_column_executor_records_children_under_configured_out_root(tmp_path, monkeypatch):

--- a/tests/quorum/test_managed_state.py
+++ b/tests/quorum/test_managed_state.py
@@ -1,0 +1,295 @@
+import json
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from quorum.managed_state import (
+    ManagedJob,
+    append_event,
+    discover_managed_paths,
+    heartbeat_job,
+    list_jobs,
+    mark_job_state,
+    mark_job_tainted,
+    new_job_id,
+    read_job,
+    write_job_atomic,
+)
+
+
+def _job(job_id: str = "job-20260612T190000Z-a1b2") -> ManagedJob:
+    now = datetime(2026, 6, 12, 19, 0, tzinfo=UTC)
+    return ManagedJob(
+        id=job_id,
+        state="planned",
+        result_rollup=None,
+        created_at=now,
+        updated_at=now,
+        command=["quorum", "smoke", "claude"],
+        managed_command="smoke",
+        coding_agents=["claude"],
+    )
+
+
+def test_discovered_paths_are_created_lazily(tmp_path):
+    paths = discover_managed_paths(
+        {
+            "QUORUM_STATE_ROOT": str(tmp_path / "state"),
+            "QUORUM_ARTIFACT_ROOT": str(tmp_path / "artifacts"),
+        }
+    )
+
+    assert paths.state_root == tmp_path / "state"
+    assert paths.artifact_root == tmp_path / "artifacts"
+    assert paths.jobs_dir == tmp_path / "state" / "jobs"
+    assert paths.events_dir == tmp_path / "state" / "events"
+    assert paths.locks_dir == tmp_path / "state" / "locks"
+    assert paths.cooldowns_dir == tmp_path / "state" / "cooldowns"
+    assert paths.taints_dir == tmp_path / "state" / "taints"
+    assert not paths.state_root.exists()
+
+    write_job_atomic(paths, _job())
+    append_event(paths, _job().id, {"level": "info", "message": "created"})
+
+    assert paths.jobs_dir.is_dir()
+    assert paths.events_dir.is_dir()
+    assert not paths.locks_dir.exists()
+
+
+def test_job_ids_are_unique_sortable_and_use_spec_shape():
+    now = datetime(2026, 6, 12, 19, 0, tzinfo=UTC)
+
+    ids = [
+        new_job_id(now, "smoke", "claude"),
+        new_job_id(now + timedelta(seconds=1), "smoke", "kimi/code"),
+        new_job_id(now + timedelta(seconds=2), "batch", None),
+    ]
+
+    assert len(set(ids)) == 3
+    assert ids == sorted(ids)
+    assert all(job_id.startswith("job-20260612T19000") for job_id in ids)
+    assert all(len(job_id.rsplit("-", maxsplit=1)[1]) == 4 for job_id in ids)
+
+
+def test_atomic_write_failure_leaves_existing_job_json_intact(tmp_path, monkeypatch):
+    paths = discover_managed_paths({"QUORUM_STATE_ROOT": str(tmp_path / "state")})
+    original = _job()
+    replacement = replace(original, state="running")
+
+    write_job_atomic(paths, original)
+
+    def fail_replace(src: str, dst: str) -> None:
+        raise OSError(f"refusing to replace {src} -> {dst}")
+
+    monkeypatch.setattr("quorum.managed_state.os.replace", fail_replace)
+
+    with pytest.raises(OSError):
+        write_job_atomic(paths, replacement)
+
+    assert read_job(paths, original.id) == original
+    json.loads((paths.jobs_dir / f"{original.id}.json").read_text())
+
+
+def test_atomic_write_fsyncs_jobs_directory_after_replace(tmp_path, monkeypatch):
+    paths = discover_managed_paths({"QUORUM_STATE_ROOT": str(tmp_path / "state")})
+    fsynced: list[Path] = []
+
+    monkeypatch.setattr("quorum.managed_state._fsync_directory", fsynced.append)
+
+    write_job_atomic(paths, _job())
+
+    assert fsynced == [paths.jobs_dir]
+
+
+@pytest.mark.parametrize("job_id", ["../escape", "/tmp/escape", "job-20260612T190000Z-a1b2/child"])
+def test_job_id_path_traversal_is_rejected(tmp_path, job_id):
+    paths = discover_managed_paths({"QUORUM_STATE_ROOT": str(tmp_path / "state")})
+
+    with pytest.raises(ValueError, match="invalid managed job id"):
+        write_job_atomic(paths, replace(_job(), id=job_id))
+    with pytest.raises(ValueError, match="invalid managed job id"):
+        read_job(paths, job_id)
+    with pytest.raises(ValueError, match="invalid managed job id"):
+        append_event(paths, job_id, {"level": "info"})
+
+    assert not (tmp_path / "escape.json").exists()
+
+
+@pytest.mark.parametrize("state", ["orphaned", "waiting", "queued"])
+def test_write_job_rejects_non_worker_lifecycle_states(tmp_path, state):
+    paths = discover_managed_paths({"QUORUM_STATE_ROOT": str(tmp_path / "state")})
+
+    with pytest.raises(ValueError, match="unsupported managed job state"):
+        write_job_atomic(paths, replace(_job(), state=state))
+
+    assert not paths.jobs_dir.exists()
+
+
+def test_read_job_rejects_invalid_persisted_state(tmp_path):
+    paths = discover_managed_paths({"QUORUM_STATE_ROOT": str(tmp_path / "state")})
+    write_job_atomic(paths, _job())
+    job_path = paths.jobs_dir / f"{_job().id}.json"
+    payload = json.loads(job_path.read_text())
+    payload["state"] = "queued"
+    job_path.write_text(json.dumps(payload))
+
+    with pytest.raises(ValueError, match="unsupported managed job state"):
+        read_job(paths, _job().id)
+
+
+def test_list_jobs_reports_invalid_persisted_state_as_malformed(tmp_path):
+    paths = discover_managed_paths({"QUORUM_STATE_ROOT": str(tmp_path / "state")})
+    write_job_atomic(paths, _job("job-20260612T190000Z-cafe"))
+    bad = replace(_job("job-20260612T190001Z-bad1"), state="running")
+    write_job_atomic(paths, bad)
+    bad_path = paths.jobs_dir / f"{bad.id}.json"
+    payload = json.loads(bad_path.read_text())
+    payload["state"] = "orphaned"
+    bad_path.write_text(json.dumps(payload))
+
+    result = list_jobs(paths)
+
+    assert [job.id for job in result.jobs] == ["job-20260612T190000Z-cafe"]
+    assert len(result.diagnostics.warnings) == 1
+    assert result.diagnostics.warnings[0]["event"] == "malformed-job-json"
+    assert "unsupported managed job state" in str(result.diagnostics.warnings[0]["message"])
+
+
+def test_list_jobs_ignores_malformed_files_and_records_diagnostic_warning(tmp_path):
+    paths = discover_managed_paths({"QUORUM_STATE_ROOT": str(tmp_path / "state")})
+    write_job_atomic(paths, _job("job-20260612T190000Z-cafe"))
+    paths.jobs_dir.mkdir(parents=True, exist_ok=True)
+    (paths.jobs_dir / "broken.json").write_text("{not-json")
+
+    result = list_jobs(paths)
+
+    assert [job.id for job in result.jobs] == ["job-20260612T190000Z-cafe"]
+    assert len(result.diagnostics.warnings) == 1
+    assert result.diagnostics.warnings[0]["level"] == "warning"
+    warning_path = result.diagnostics.warnings[0]["path"]
+    assert isinstance(warning_path, str)
+    assert warning_path.endswith("broken.json")
+
+
+def test_append_event_normalizes_datetime_and_path_fields(tmp_path):
+    paths = discover_managed_paths({"QUORUM_STATE_ROOT": str(tmp_path / "state")})
+    occurred_at = datetime(2026, 6, 12, 20, 0, tzinfo=UTC)
+
+    append_event(
+        paths,
+        _job().id,
+        {"level": "info", "occurred_at": occurred_at, "path": tmp_path / "artifact.txt"},
+    )
+
+    event = json.loads((paths.events_dir / f"{_job().id}.jsonl").read_text())
+    assert event["occurred_at"] == "2026-06-12T20:00:00Z"
+    assert event["path"] == str(tmp_path / "artifact.txt")
+
+
+def test_heartbeat_updates_updated_at_without_mutating_immutable_fields(tmp_path):
+    paths = discover_managed_paths({"QUORUM_STATE_ROOT": str(tmp_path / "state")})
+    job = _job()
+    write_job_atomic(paths, job)
+    heartbeat_at = job.updated_at + timedelta(minutes=5)
+
+    updated = heartbeat_job(paths, job.id, heartbeat_at)
+
+    assert updated.updated_at == heartbeat_at
+    assert updated.id == job.id
+    assert updated.state == job.state
+    assert updated.created_at == job.created_at
+    assert updated.command == job.command
+    assert updated.managed_command == job.managed_command
+    assert updated.coding_agents == job.coding_agents
+    assert read_job(paths, job.id) == updated
+
+
+def test_mark_job_state_sets_started_at_when_entering_running(tmp_path):
+    paths = discover_managed_paths({"QUORUM_STATE_ROOT": str(tmp_path / "state")})
+    job = _job()
+    write_job_atomic(paths, job)
+
+    updated = mark_job_state(paths, job.id, "running")
+
+    assert updated.state == "running"
+    assert updated.started_at == updated.updated_at
+    assert updated.finished_at is None
+
+
+def test_mark_job_tainted_preserves_state_and_previous_result_rollup(tmp_path):
+    paths = discover_managed_paths({"QUORUM_STATE_ROOT": str(tmp_path / "state")})
+    job = _job()
+    write_job_atomic(paths, job)
+    mark_job_state(
+        paths,
+        job.id,
+        "succeeded",
+        result_rollup={"result": "pass", "failed": 0},
+        final_exit_code=0,
+    )
+
+    tainted = mark_job_tainted(
+        paths,
+        job.id,
+        "secret-like material in transcript",
+        [{"path": "transcript.txt", "line": 7}],
+    )
+
+    assert tainted.state == "succeeded"
+    assert tainted.tainted is True
+    assert tainted.result_rollup == {"result": "pass", "failed": 0}
+    assert tainted.taint_reason == "secret-like material in transcript"
+    assert tainted.taint_matches == [{"path": "transcript.txt", "line": 7}]
+
+
+def test_mark_job_state_records_result_rollup_and_final_exit_code(tmp_path):
+    paths = discover_managed_paths({"QUORUM_STATE_ROOT": str(tmp_path / "state")})
+    job = _job()
+    write_job_atomic(paths, job)
+
+    updated = mark_job_state(
+        paths,
+        job.id,
+        "failed",
+        result_rollup={"result": "fail", "failed": 1},
+        final_exit_code=17,
+        failure_reason="child failed",
+    )
+
+    assert updated.state == "failed"
+    assert updated.result_rollup == {"result": "fail", "failed": 1}
+    assert updated.final_exit_code == 17
+    assert updated.failure_reason == "child failed"
+    assert updated.finished_at == updated.updated_at
+
+
+def test_artifact_bytes_round_trips_through_job_json(tmp_path):
+    paths = discover_managed_paths({"QUORUM_STATE_ROOT": str(tmp_path / "state")})
+    job = replace(_job(), artifact_bytes=1234)
+
+    write_job_atomic(paths, job)
+
+    assert read_job(paths, job.id).artifact_bytes == 1234
+
+
+def test_extra_fields_preserve_unknowns_without_overriding_canonical_fields(tmp_path):
+    paths = discover_managed_paths({"QUORUM_STATE_ROOT": str(tmp_path / "state")})
+    job = replace(
+        _job(),
+        extra={
+            "state": "queued",
+            "id": "../escape",
+            "future_field": {"enabled": True},
+        },
+    )
+
+    write_job_atomic(paths, job)
+    payload = json.loads((paths.jobs_dir / f"{job.id}.json").read_text())
+    restored = read_job(paths, job.id)
+
+    assert payload["id"] == job.id
+    assert payload["state"] == "planned"
+    assert payload["future_field"] == {"enabled": True}
+    assert restored.extra == {"future_field": {"enabled": True}}

--- a/tests/quorum/test_opencode_capture.py
+++ b/tests/quorum/test_opencode_capture.py
@@ -45,6 +45,58 @@ def test_opencode_run_env_scrubs_harness_paths_and_preserves_provider_env(tmp_pa
     assert "QUORUM_AGENT_CWD" not in env
 
 
+def test_opencode_run_env_managed_mode_ignores_ambient_provider_poison(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("QUORUM_MANAGED_HOST", "1")
+    monkeypatch.setenv("OPENAI_API_KEY", "ambient-poison")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "ambient-poison")
+    monkeypatch.setenv("PATH", "/bin")
+
+    env = opencode_run_env(home)
+
+    assert env["PATH"] == "/bin"
+    assert "OPENAI_API_KEY" not in env
+    assert "ANTHROPIC_API_KEY" not in env
+
+
+def test_opencode_run_env_managed_mode_uses_explicit_env_base(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("QUORUM_MANAGED_HOST", "1")
+    monkeypatch.setenv("OPENAI_API_KEY", "ambient-poison")
+
+    env = opencode_run_env(
+        home,
+        env_base={
+            "PATH": "/usr/bin:/bin",
+            "OPENAI_API_KEY": "profile-key",
+            "QUORUM_TARGET_ENV_KEYS": "OPENAI_API_KEY",
+        },
+    )
+
+    assert env["OPENAI_API_KEY"] == "profile-key"
+
+
+def test_opencode_run_env_managed_env_base_keeps_only_target_provider_keys(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "home"
+    monkeypatch.setenv("QUORUM_MANAGED_HOST", "1")
+    monkeypatch.setenv("OPENAI_API_KEY", "ambient-poison")
+
+    env = opencode_run_env(
+        home,
+        env_base={
+            "PATH": "/usr/bin:/bin",
+            "ANTHROPIC_API_KEY": "profile-key",
+            "OPENAI_API_KEY": "wrong-target-key",
+            "QUORUM_TARGET_ENV_KEYS": "ANTHROPIC_API_KEY",
+        },
+    )
+
+    assert env["ANTHROPIC_API_KEY"] == "profile-key"
+    assert "OPENAI_API_KEY" not in env
+
+
 def _completed(cmd, kwargs, stdout, stderr="", returncode=0):
     """Mimic run_opencode_command's seam: stdout goes to the file, not the pipe."""
     kwargs["stdout"].write(stdout)

--- a/tests/quorum/test_run_all.py
+++ b/tests/quorum/test_run_all.py
@@ -307,6 +307,24 @@ def test_invoke_child_merges_extra_env(tmp_path):
     assert env["QUORUM_KIMI_PREFLIGHT_SENTINEL"] == str(tmp_path / "sentinel.json")
 
 
+def test_invoke_child_env_base_replaces_ambient_poison(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "ambient-poison")
+    fake_stdout = "run-id: foo-claude-20260526T180001Z-abcd\n"
+    completed = CompletedProcess(args=[], returncode=0, stdout=fake_stdout, stderr="")
+    with patch("quorum.run_all.subprocess.run", return_value=completed) as mock:
+        invoke_child(
+            scenario_dir=tmp_path / "foo",
+            coding_agent="claude",
+            coding_agents_dir=tmp_path / "agents",
+            out_root=tmp_path / "results",
+            env_base={"PATH": "/usr/bin:/bin", "QUORUM_MANAGED_WORKER": "1"},
+        )
+
+    env = mock.call_args.kwargs["env"]
+    assert env["QUORUM_MANAGED_WORKER"] == "1"
+    assert "OPENAI_API_KEY" not in env
+
+
 def test_invoke_child_records_nonzero_exit_with_run_id_when_present(tmp_path):
     """A fail verdict exits 1 but still emits run-id. We record both."""
     completed = CompletedProcess(
@@ -535,6 +553,42 @@ def test_run_batch_writes_batch_json_header_and_footer(tmp_path):
     assert data["finished_at"] is not None
 
 
+def test_run_batch_passes_env_base_to_children(tmp_path, monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "ambient-poison")
+    scenarios = tmp_path / "scenarios"
+    agents = tmp_path / "agents"
+    _scenario(scenarios, "alpha")
+    _agent(agents, "claude")
+    out_root = tmp_path / "results"
+    seen_env_base = []
+
+    def fake_invoke(
+        *,
+        scenario_dir,
+        coding_agent,
+        coding_agents_dir,
+        out_root,
+        extra_env=None,
+        env_base=None,
+        timeout_seconds=None,
+    ):
+        seen_env_base.append(env_base)
+        return ChildResult(run_id="alpha-claude-fake", exit_code=0, error=None)
+
+    run_batch(
+        scenarios_root=scenarios,
+        coding_agents_dir=agents,
+        out_root=out_root,
+        jobs=1,
+        agent_filter=None,
+        invoke=fake_invoke,
+        use_cursor=False,
+        env_base={"PATH": "/usr/bin:/bin"},
+    )
+
+    assert seen_env_base == [{"PATH": "/usr/bin:/bin"}]
+
+
 def test_run_batch_jobs_gt_one_runs_all_pairs(tmp_path):
     scenarios = tmp_path / "scenarios"
     agents = tmp_path / "agents"
@@ -741,6 +795,78 @@ def test_run_batch_fail_fast_on_agy_rate_limit(tmp_path):
     assert len(rate_limited) == 2
     assert all(r["coding_agent"] == "antigravity" for r in rate_limited)
     assert all(r["run_id"] is None for r in rate_limited)
+
+
+def test_run_batch_redacts_profile_kimi_secret_from_preflight_failure(tmp_path):
+    scenarios = tmp_path / "scenarios"
+    agents = tmp_path / "agents"
+    _scenario(scenarios, "a")
+    _agent(agents, "kimi")
+    out_root = tmp_path / "results"
+    secret = "profile-only-kimi-secret"
+
+    def fail_preflight(**_kwargs):
+        raise RuntimeError(f"bad auth {secret}")
+
+    with patch("quorum.run_all.prepare_kimi_batch_preflight", side_effect=fail_preflight):
+        batch_dir = run_batch(
+            scenarios_root=scenarios,
+            coding_agents_dir=agents,
+            out_root=out_root,
+            jobs=1,
+            agent_filter=None,
+            use_cursor=False,
+            env_base={"PATH": "/usr/bin:/bin", "KIMI_MODEL_API_KEY": secret},
+        )
+
+    record = json.loads((batch_dir / "results.jsonl").read_text().splitlines()[0])
+    artifacts = [batch_dir / "results.jsonl", out_root / record["run_id"] / "verdict.json"]
+    combined = "\n".join(path.read_text() for path in artifacts)
+    assert secret not in combined
+    assert "<redacted>" in combined
+
+
+def test_run_batch_kimi_preflight_uses_managed_target_profile(tmp_path, monkeypatch):
+    scenarios = tmp_path / "scenarios"
+    agents = tmp_path / "agents"
+    _scenario(scenarios, "a")
+    custom_kimi = tmp_path / "custom-kimi"
+    custom_kimi.write_text("#!/usr/bin/env bash\nexit 0\n")
+    custom_kimi.chmod(0o755)
+    _agent(agents, "kimi", binary=str(custom_kimi))
+    profile_root = tmp_path / "profiles"
+    profile_root.mkdir()
+    (profile_root / "kimi.env").write_text("KIMI_MODEL_API_KEY=profile-kimi-key\n")
+    out_root = tmp_path / "results"
+    seen_model_envs: list[dict[str, str]] = []
+
+    def fake_preflight(*, kimi_model_env, **_kwargs):
+        seen_model_envs.append(dict(kimi_model_env))
+
+    def fake_invoke(**_kwargs):
+        return ChildResult(run_id="a-kimi-x", exit_code=0, error=None)
+
+    monkeypatch.delenv("KIMI_MODEL_API_KEY", raising=False)
+    with patch("quorum.run_all.run_kimi_auth_preflight", side_effect=fake_preflight):
+        run_batch(
+            scenarios_root=scenarios,
+            coding_agents_dir=agents,
+            out_root=out_root,
+            jobs=1,
+            agent_filter=["kimi"],
+            invoke=fake_invoke,
+            use_cursor=False,
+            env_base={
+                "PATH": "/usr/bin:/bin",
+                "QUORUM_MANAGED_HOST": "1",
+                "QUORUM_TARGET_PROFILE_ROOT": str(profile_root),
+                "QUORUM_STATE_ROOT": str(tmp_path / "state"),
+                "QUORUM_ARTIFACT_ROOT": str(out_root),
+            },
+        )
+
+    assert seen_model_envs
+    assert seen_model_envs[0]["KIMI_MODEL_API_KEY"] == "profile-kimi-key"
 
 
 def test_run_batch_preflights_kimi_once_for_multiple_cells(tmp_path):

--- a/tests/quorum/test_run_all.py
+++ b/tests/quorum/test_run_all.py
@@ -589,6 +589,173 @@ def test_run_batch_passes_env_base_to_children(tmp_path, monkeypatch):
     assert seen_env_base == [{"PATH": "/usr/bin:/bin"}]
 
 
+def test_run_batch_lifecycle_callbacks_observe_allocation_start_and_finish(tmp_path):
+    scenarios = tmp_path / "scenarios"
+    agents = tmp_path / "agents"
+    _scenario(scenarios, "alpha")
+    _agent(agents, "claude")
+    out_root = tmp_path / "results"
+    allocated: list[Path] = []
+    started: list[tuple[str, str, str, list[str]]] = []
+    finished: list[tuple[str, ChildResult]] = []
+
+    def fake_invoke(
+        *,
+        scenario_dir,
+        coding_agent,
+        coding_agents_dir,
+        out_root,
+        extra_env=None,
+        timeout_seconds=None,
+    ):
+        run_id = f"{scenario_dir.name}-{coding_agent}-x"
+        run_dir = out_root / run_id
+        run_dir.mkdir(parents=True)
+        (run_dir / "verdict.json").write_text(json.dumps({"final": "pass"}))
+        return ChildResult(run_id=run_id, exit_code=0, error=None)
+
+    batch_dir = run_batch(
+        scenarios_root=scenarios,
+        coding_agents_dir=agents,
+        out_root=out_root,
+        jobs=1,
+        agent_filter=["claude"],
+        invoke=fake_invoke,
+        use_cursor=False,
+        on_batch_allocated=lambda path: allocated.append(path),
+        on_child_started=lambda child_id, entry, command: started.append(
+            (child_id, entry.scenario, entry.coding_agent, command)
+        ),
+        on_child_finished=lambda child_id, result: finished.append((child_id, result)),
+    )
+
+    assert allocated == [batch_dir]
+    assert started == [
+        (
+            "child-0001",
+            "alpha",
+            "claude",
+            [
+                "uv",
+                "run",
+                "quorum",
+                "run",
+                str(scenarios / "alpha"),
+                "--coding-agent",
+                "claude",
+                "--coding-agents-dir",
+                str(agents),
+                "--out-root",
+                str(out_root),
+            ],
+        )
+    ]
+    assert finished == [
+        ("child-0001", ChildResult(run_id="alpha-claude-x", exit_code=0, error=None))
+    ]
+
+
+def test_run_batch_child_finished_callback_observes_rate_limit_skips(tmp_path):
+    scenarios = tmp_path / "scenarios"
+    agents = tmp_path / "agents"
+    _scenario(scenarios, "alpha")
+    _scenario(scenarios, "beta")
+    _agent(agents, "antigravity", max_concurrency=1)
+    out_root = tmp_path / "results"
+    finished: list[tuple[str, ChildResult]] = []
+
+    def fake_invoke(
+        *,
+        scenario_dir,
+        coding_agent,
+        coding_agents_dir,
+        out_root,
+        extra_env=None,
+        timeout_seconds=None,
+    ):
+        run_id = f"{scenario_dir.name}-{coding_agent}-x"
+        run_dir = out_root / run_id
+        run_dir.mkdir(parents=True)
+        (run_dir / "verdict.json").write_text(
+            json.dumps(
+                {
+                    "final": "indeterminate",
+                    "error": {
+                        "stage": "setup",
+                        "message": f"{ANTIGRAVITY_RATE_LIMIT_MARKER}: throttled",
+                    },
+                }
+            )
+        )
+        return ChildResult(run_id=run_id, exit_code=2, error=None)
+
+    run_batch(
+        scenarios_root=scenarios,
+        coding_agents_dir=agents,
+        out_root=out_root,
+        jobs=1,
+        agent_filter=["antigravity"],
+        invoke=fake_invoke,
+        use_cursor=False,
+        on_child_finished=lambda child_id, result: finished.append((child_id, result)),
+    )
+
+    assert finished == [
+        (
+            "child-0001",
+            ChildResult(run_id="alpha-antigravity-x", exit_code=2, error=None),
+        ),
+        (
+            "child-0002",
+            ChildResult(run_id=None, exit_code=0, error="agy-rate-limit-skip"),
+        ),
+    ]
+
+
+def test_run_batch_callbacks_observe_static_skips(tmp_path):
+    scenarios = tmp_path / "scenarios"
+    agents = tmp_path / "agents"
+    _scenario(scenarios, "alpha", directive="codex")
+    _agent(agents, "claude")
+    out_root = tmp_path / "results"
+    started: list[tuple[str, str, str]] = []
+    finished: list[tuple[str, ChildResult]] = []
+    order: list[str] = []
+
+    def on_child_started(child_id, entry, command):
+        del command
+        order.append("started")
+        batch_dirs = sorted((out_root / "batches").glob("batch-*"))
+        assert len(batch_dirs) == 1
+        assert not (batch_dirs[0] / "results.jsonl").exists()
+        started.append((child_id, entry.scenario, entry.coding_agent))
+
+    def on_child_finished(child_id, result):
+        order.append("finished")
+        finished.append((child_id, result))
+
+    run_batch(
+        scenarios_root=scenarios,
+        coding_agents_dir=agents,
+        out_root=out_root,
+        jobs=1,
+        agent_filter=["claude"],
+        invoke=lambda **_kwargs: ChildResult(run_id=None, exit_code=99, error="should not run"),
+        use_cursor=False,
+        on_child_started=on_child_started,
+        on_child_finished=on_child_finished,
+    )
+
+    assert order == ["started", "finished"]
+    assert started == [("child-0001", "alpha", "claude")]
+    assert finished == [
+        (
+            "child-0001",
+            ChildResult(run_id=None, exit_code=0, error="skipped:directive"),
+        )
+    ]
+
+
 def test_run_batch_jobs_gt_one_runs_all_pairs(tmp_path):
     scenarios = tmp_path / "scenarios"
     agents = tmp_path / "agents"
@@ -971,6 +1138,48 @@ def test_run_batch_kimi_preflight_failure_writes_indeterminate_runs(tmp_path):
     assert all(v["final"] == "indeterminate" for v in verdicts)
     assert all(v["error"]["stage"] == "setup" for v in verdicts)
     assert all("kimi auth failed" in v["error"]["message"] for v in verdicts)
+
+
+def test_run_batch_callbacks_observe_kimi_parent_preflight_failures(tmp_path):
+    scenarios = tmp_path / "scenarios"
+    agents = tmp_path / "agents"
+    _scenario(scenarios, "a")
+    _scenario(scenarios, "b")
+    _agent(agents, "kimi")
+    out_root = tmp_path / "results"
+    started: list[tuple[str, str, str, list[str]]] = []
+    finished: list[tuple[str, ChildResult]] = []
+
+    with patch(
+        "quorum.run_all.prepare_kimi_batch_preflight",
+        side_effect=RuntimeError("kimi auth failed"),
+    ):
+        run_batch(
+            scenarios_root=scenarios,
+            coding_agents_dir=agents,
+            out_root=out_root,
+            jobs=1,
+            agent_filter=["kimi"],
+            invoke=lambda **_kwargs: ChildResult(
+                run_id=None,
+                exit_code=99,
+                error="should not run",
+            ),
+            use_cursor=False,
+            on_child_started=lambda child_id, entry, command: started.append(
+                (child_id, entry.scenario, entry.coding_agent, command)
+            ),
+            on_child_finished=lambda child_id, result: finished.append((child_id, result)),
+        )
+
+    assert [(child_id, scenario, agent) for child_id, scenario, agent, _ in started] == [
+        ("child-0001", "a", "kimi"),
+        ("child-0002", "b", "kimi"),
+    ]
+    assert all(command[:4] == ["uv", "run", "quorum", "run"] for *_, command in started)
+    assert [child_id for child_id, _ in finished] == ["child-0001", "child-0002"]
+    assert all(result.run_id for _, result in finished)
+    assert all(result.exit_code == 2 and result.error is None for _, result in finished)
 
 
 def test_run_batch_kimi_parent_preflight_uses_configured_binary(tmp_path, monkeypatch):

--- a/tests/quorum/test_run_all.py
+++ b/tests/quorum/test_run_all.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import threading
 from datetime import UTC, datetime
 from pathlib import Path
 from subprocess import CompletedProcess
@@ -653,6 +654,56 @@ def test_run_batch_lifecycle_callbacks_observe_allocation_start_and_finish(tmp_p
     assert finished == [
         ("child-0001", ChildResult(run_id="alpha-claude-x", exit_code=0, error=None))
     ]
+
+
+def test_run_batch_abort_event_skips_queued_children_and_writes_footer(tmp_path):
+    scenarios = tmp_path / "scenarios"
+    agents = tmp_path / "agents"
+    for name in ("alpha", "beta", "gamma"):
+        _scenario(scenarios, name)
+    _agent(agents, "claude")
+    out_root = tmp_path / "results"
+    abort_event = threading.Event()
+    invoked: list[str] = []
+
+    def fake_invoke(
+        *,
+        scenario_dir,
+        coding_agent,
+        coding_agents_dir,
+        out_root,
+        extra_env=None,
+        timeout_seconds=None,
+    ):
+        del coding_agent, coding_agents_dir, extra_env, timeout_seconds
+        invoked.append(scenario_dir.name)
+        run_id = f"{scenario_dir.name}-claude-x"
+        run_dir = out_root / run_id
+        run_dir.mkdir(parents=True)
+        (run_dir / "verdict.json").write_text(json.dumps({"final": "pass"}))
+        return ChildResult(run_id=run_id, exit_code=0, error=None)
+
+    def on_child_finished(child_id: str, result: ChildResult) -> None:
+        del child_id
+        if result.run_id == "alpha-claude-x":
+            abort_event.set()
+
+    batch_dir = run_batch(
+        scenarios_root=scenarios,
+        coding_agents_dir=agents,
+        out_root=out_root,
+        jobs=1,
+        agent_filter=["claude"],
+        invoke=fake_invoke,
+        use_cursor=False,
+        abort_event=abort_event,
+        on_child_finished=on_child_finished,
+    )
+
+    assert invoked == ["alpha"]
+    records = [json.loads(line) for line in (batch_dir / "results.jsonl").read_text().splitlines()]
+    assert [record.get("skipped") for record in records] == [None, "aborted", "aborted"]
+    assert json.loads((batch_dir / "batch.json").read_text())["finished_at"] is not None
 
 
 def test_run_batch_child_finished_callback_observes_rate_limit_skips(tmp_path):

--- a/tests/quorum/test_runner.py
+++ b/tests/quorum/test_runner.py
@@ -20,6 +20,7 @@ from quorum.runner import (
     COPILOT_PROVIDER_ENV_NAMES,
     COPILOT_REQUIRED_SUPERPOWERS_FILES,
     COPILOT_SECRET_ENV_NAMES,
+    GEMINI_ENV_FILE_NAME,
     AgentRuntime,
     CopilotProvisioning,
     GauntletResult,
@@ -38,11 +39,13 @@ from quorum.runner import (
     _scan_copilot_secret_leaks,
     _seed_agent_config_dir,
     _seed_antigravity_config,
+    _seed_codex_plugin_hooks,
     _seed_copilot_config,
     _seed_gemini_config,
     _seed_kimi_config,
     _shell_single_quote,
     _stage_copilot_superpowers_plugin,
+    _which,
     _write_antigravity_settings,
     _write_copilot_env_file,
     _write_gemini_env_file,
@@ -1519,6 +1522,36 @@ class TestSeedAgentConfigDir:
         assert claude_config["customApiKeyResponses"]["approved"] == ["sk-test-key"]
         assert claude_config["customApiKeyResponses"]["rejected"] == []
 
+    def test_claude_target_env_file_uses_env_base_instead_of_ambient(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "ambient-poison")
+        cfg = CodingAgentConfig(
+            name="claude",
+            runtime_family="claude",
+            binary="claude",
+            agent_config_env="CLAUDE_CONFIG_DIR",
+            session_log_dir="${CLAUDE_CONFIG_DIR}/projects",
+            session_log_glob="**/*.jsonl",
+            normalizer="claude",
+            required_env=("ANTHROPIC_API_KEY",),
+            model="opus",
+            max_time=None,
+            project_prompt=None,
+        )
+        dest = tmp_path / "agent-config"
+
+        _seed_agent_config_dir(
+            cfg,
+            _empty_skeleton(tmp_path),
+            dest,
+            tmp_path / "workdir",
+            run_dir=tmp_path / "run-dir",
+            env_base={"ANTHROPIC_API_KEY": "profile-key"},
+        )
+
+        assert (dest / CLAUDE_ENV_FILE_NAME).read_text() == "ANTHROPIC_API_KEY='profile-key'\n"
+
     def test_claude_seed_raises_without_api_key_when_required(self, tmp_path, monkeypatch):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         cfg = CodingAgentConfig(
@@ -1640,6 +1673,24 @@ class TestSeedAgentConfigDir:
                 run_dir=tmp_path / "run-dir",
             )
 
+    def test_codex_plugin_hook_uses_env_base_superpowers_root(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SUPERPOWERS_ROOT", raising=False)
+        superpowers = tmp_path / "superpowers"
+        superpowers.mkdir()
+
+        with patch("quorum.runner.install_codex_superpowers_plugin_hooks") as install:
+            _seed_codex_plugin_hooks(
+                tmp_path / "codex-home",
+                tmp_path / "workdir",
+                env_base={"SUPERPOWERS_ROOT": str(superpowers)},
+            )
+
+        install.assert_called_once_with(
+            tmp_path / "workdir",
+            str(superpowers),
+            codex_home=tmp_path / "codex-home",
+        )
+
     def test_codex_target_installs_plugin_hooks(self, tmp_path, monkeypatch):
         # The runner stages Superpowers as a trusted plugin hook into the
         # per-run CODEX_HOME — the codex equivalent of claude's Superpowers
@@ -1696,6 +1747,36 @@ class TestSeedAgentConfigDir:
             )
         mock_seed.assert_called_once_with(dest, tmp_path / "wd")
 
+    def test_antigravity_seed_uses_env_base_for_superpowers_and_install_env(
+        self, tmp_path, monkeypatch
+    ):
+        superpowers = _make_gemini_superpowers_root(tmp_path)
+        monkeypatch.delenv("SUPERPOWERS_ROOT", raising=False)
+        monkeypatch.setattr("quorum.runner.shutil.which", lambda name, path=None: "/usr/bin/agy")
+        seen_envs: list[dict[str, str]] = []
+
+        def fake_run(cmd, **kwargs):
+            seen_envs.append(kwargs["env"])
+            root = tmp_path / "cfg" / ".gemini" / "config" / "plugins" / "superpowers"
+            (root / "skills" / "using-superpowers").mkdir(parents=True, exist_ok=True)
+            (root / "plugin.json").write_text("{}")
+            (root / "hooks.json").write_text("{}")
+            (root / "skills" / "using-superpowers" / "SKILL.md").write_text("skill")
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        with (
+            patch("quorum.runner._run_antigravity_auth_preflight"),
+            patch("quorum.runner.subprocess.run", side_effect=fake_run),
+        ):
+            _seed_antigravity_config(
+                tmp_path / "cfg",
+                tmp_path / "wd",
+                env_base={"PATH": "/usr/bin:/bin", "SUPERPOWERS_ROOT": str(superpowers)},
+            )
+
+        assert seen_envs
+        assert seen_envs[0]["SUPERPOWERS_ROOT"] == str(superpowers)
+
     def test_pi_target_seeds_run_local_auth_files(self, tmp_path, monkeypatch):
         superpowers = _make_superpowers_pi_root(tmp_path)
         monkeypatch.setenv("SUPERPOWERS_ROOT", str(superpowers))
@@ -1705,7 +1786,7 @@ class TestSeedAgentConfigDir:
         monkeypatch.setenv("AZURE_OPENAI_BASE_URL", "https://example.openai.azure.com")
         monkeypatch.setattr(
             "quorum.runner.shutil.which",
-            lambda name: "/usr/bin/pi" if name == "pi" else None,
+            lambda name, path=None: "/usr/bin/pi" if name == "pi" else None,
         )
 
         dest = tmp_path / "cfg"
@@ -1733,6 +1814,42 @@ class TestSeedAgentConfigDir:
         assert "AZURE_OPENAI_BASE_URL=https://example.openai.azure.com" in env_text
         assert oct(env_path.stat().st_mode & 0o777) == "0o600"
         assert (dest / "sessions").is_dir()
+
+    def test_pi_seed_uses_env_base_for_profile_values(self, tmp_path, monkeypatch):
+        superpowers = _make_superpowers_pi_root(tmp_path)
+        for name in (
+            "SUPERPOWERS_ROOT",
+            "PI_PROVIDER",
+            "PI_MODEL",
+            "PI_API_KEY",
+            "AZURE_OPENAI_BASE_URL",
+        ):
+            monkeypatch.delenv(name, raising=False)
+        monkeypatch.setattr(
+            "quorum.runner.shutil.which",
+            lambda name, path=None: "/usr/bin/pi" if name == "pi" else None,
+        )
+
+        dest = tmp_path / "cfg"
+        _seed_agent_config_dir(
+            _pi_tcfg(),
+            tmp_path,
+            dest,
+            tmp_path / "wd",
+            run_dir=tmp_path / "run-dir",
+            env_base={
+                "PATH": "/usr/bin:/bin",
+                "SUPERPOWERS_ROOT": str(superpowers),
+                "PI_PROVIDER": "azure-openai-responses",
+                "PI_MODEL": "gpt-5.4",
+                "PI_API_KEY": "profile-pi-key",
+                "AZURE_OPENAI_BASE_URL": "https://example.openai.azure.com",
+            },
+        )
+
+        env_text = (dest / "pi.env").read_text()
+        assert "profile-pi-key" in env_text
+        assert "AZURE_OPENAI_BASE_URL=https://example.openai.azure.com" in env_text
 
     def test_pi_seed_requires_superpowers_root(self, tmp_path, monkeypatch):
         monkeypatch.delenv("SUPERPOWERS_ROOT", raising=False)
@@ -1807,12 +1924,55 @@ class TestSeedAgentConfigDir:
         sp = _make_gemini_superpowers_root(tmp_path)
         monkeypatch.setenv("SUPERPOWERS_ROOT", str(sp))
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
-        monkeypatch.setattr("quorum.runner.shutil.which", lambda name: "/usr/bin/gemini")
+        monkeypatch.setattr(
+            "quorum.runner.shutil.which",
+            lambda name, path=None: "/usr/bin/gemini",
+        )
 
         with pytest.raises(RunnerError, match="GEMINI_API_KEY") as excinfo:
             _seed_gemini_config(tmp_path / "cfg", tmp_path / "wd")
 
         assert excinfo.value.stage == "setup"
+
+    def test_gemini_seed_uses_env_base_for_auth_and_subprocess_env(
+        self, tmp_path, monkeypatch
+    ):
+        sp = _make_gemini_superpowers_root(tmp_path)
+        monkeypatch.delenv("SUPERPOWERS_ROOT", raising=False)
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.setattr(
+            "quorum.runner.shutil.which",
+            lambda name, path=None: "/usr/bin/gemini",
+        )
+        seen_envs: list[dict[str, str]] = []
+
+        def fake_run(cmd, **kwargs):
+            seen_envs.append(kwargs["env"])
+            cfg = Path(kwargs["env"]["GEMINI_CLI_HOME"])
+            if "link" in cmd:
+                metadata_root = cfg / ".gemini" / "extensions" / "superpowers"
+                metadata_root.mkdir(parents=True)
+                (metadata_root / ".gemini-extension-install.json").write_text("{}")
+                (cfg / ".gemini" / "extensions" / "extension-enablement.json").write_text("{}")
+                (cfg / ".gemini" / "extension_integrity.json").write_text("{}")
+            return subprocess.CompletedProcess(cmd, 0, "superpowers\n", "")
+
+        with patch("quorum.runner.subprocess.run", side_effect=fake_run):
+            _seed_gemini_config(
+                tmp_path / "cfg",
+                tmp_path / "wd",
+                env_base={
+                    "PATH": "/usr/bin:/bin",
+                    "SUPERPOWERS_ROOT": str(sp),
+                    "GEMINI_API_KEY": "profile-gemini-key",
+                },
+            )
+
+        assert (tmp_path / "cfg" / GEMINI_ENV_FILE_NAME).read_text() == (
+            "GEMINI_API_KEY='profile-gemini-key'\n"
+        )
+        assert seen_envs
+        assert all(env["GEMINI_API_KEY"] == "profile-gemini-key" for env in seen_envs)
 
     def test_gemini_seed_requires_superpowers_root(self, tmp_path, monkeypatch):
         monkeypatch.setenv("GEMINI_API_KEY", "test-key")
@@ -1891,6 +2051,12 @@ class TestSeedAgentConfigDir:
         assert values == {"COPILOT_GITHUB_TOKEN": "gh-token"}
         assert secret_names == ("COPILOT_GITHUB_TOKEN",)
         assert secret_values == ("gh-token",)
+
+    def test_copilot_auth_can_disable_gh_auth_token_fallback(self, monkeypatch):
+        monkeypatch.setattr("quorum.runner._gh_auth_token", lambda: "ambient-gh-token")
+
+        with pytest.raises(RunnerError, match="no Copilot auth found"):
+            _resolve_copilot_auth_env({}, allow_gh_fallback=False)
 
     def test_copilot_auth_provider_mode_does_not_require_github_token(self):
         values, secret_names, secret_values = _resolve_copilot_auth_env(
@@ -2048,6 +2214,39 @@ class TestSeedAgentConfigDir:
         assert not (extra_staged / "SKILL.md").exists()
         for rel in (".quorum", ".cache", "logs", "plugins", "session-state"):
             assert (cfg / rel).is_dir()
+
+    def test_copilot_seed_uses_env_base_for_superpowers_and_auth(self, tmp_path, monkeypatch):
+        sp = _make_superpowers_copilot_root(tmp_path)
+        _clear_copilot_auth_env(monkeypatch)
+        monkeypatch.delenv("SUPERPOWERS_ROOT", raising=False)
+        seen_paths: list[str | None] = []
+
+        def fake_which(name, path=None):
+            seen_paths.append(path)
+            return "/profile/bin/copilot" if name == "copilot" else None
+
+        monkeypatch.setattr("quorum.runner.shutil.which", fake_which)
+        cfg = tmp_path / "cfg"
+        session_id = str(uuid.uuid4())
+
+        provisioning = _seed_copilot_config(
+            cfg,
+            tmp_path / "wd",
+            session_id,
+            env_base={
+                "PATH": "/profile/bin",
+                "SUPERPOWERS_ROOT": str(sp),
+                "COPILOT_PROVIDER_BASE_URL": "http://127.0.0.1:4000",
+                "COPILOT_PROVIDER_TYPE": "openai",
+                "COPILOT_PROVIDER_API_KEY": "profile-provider-key",
+            },
+        )
+
+        assert seen_paths == ["/profile/bin"]
+        assert provisioning.secret_values == ("profile-provider-key",)
+        assert "profile-provider-key" in provisioning.env_file.read_text()
+        for rel in COPILOT_REQUIRED_SUPERPOWERS_FILES:
+            assert (cfg / "plugins" / "superpowers" / rel).is_file()
 
     def test_copilot_seed_errors_when_required_plugin_file_missing(self, tmp_path):
         sp = _make_superpowers_copilot_root(tmp_path)
@@ -2464,7 +2663,7 @@ class TestSeedAgentConfigDir:
         superpowers = _make_kimi_superpowers_root(tmp_path)
 
         dest = tmp_path / "agent-config"
-        monkeypatch.setattr("quorum.kimi.shutil.which", lambda name: "/usr/bin/kimi")
+        monkeypatch.setattr("quorum.kimi.shutil.which", lambda name, path=None: "/usr/bin/kimi")
 
         with (
             patch.dict(
@@ -2493,6 +2692,32 @@ class TestSeedAgentConfigDir:
         assert plugin["enabled"] is True
         assert runtime.env_file is not None
         assert runtime.env_file.exists()
+
+    def test_kimi_seed_uses_env_base_for_auth_and_runtime_env(self, tmp_path, monkeypatch):
+        superpowers = _make_kimi_superpowers_root(tmp_path)
+        monkeypatch.delenv("SUPERPOWERS_ROOT", raising=False)
+        monkeypatch.delenv("KIMI_MODEL_API_KEY", raising=False)
+        monkeypatch.setattr("quorum.kimi.shutil.which", lambda name, path=None: "/usr/bin/kimi")
+
+        with patch("quorum.runner.run_kimi_auth_preflight") as mock_preflight:
+            runtime = _seed_kimi_config(
+                tmp_path / "cfg",
+                run_dir=tmp_path / "run",
+                binary="kimi",
+                env_base={
+                    "PATH": "/usr/bin:/bin",
+                    "SUPERPOWERS_ROOT": str(superpowers),
+                    "KIMI_MODEL_API_KEY": "profile-kimi-key",
+                },
+            )
+
+        assert runtime.env_file is not None
+        runtime_env_text = runtime.env_file.read_text()
+        assert "profile-kimi-key" in runtime_env_text
+        mock_preflight.assert_called_once()
+        assert mock_preflight.call_args.kwargs["base_env"]["KIMI_MODEL_API_KEY"] == (
+            "profile-kimi-key"
+        )
 
     def test_kimi_seed_runs_auth_preflight_without_sentinel(self, tmp_path, monkeypatch):
         superpowers = _make_kimi_superpowers_root(tmp_path)
@@ -2854,6 +3079,18 @@ class TestSeedAgentConfigDir:
 
         assert mock_run.call_count == 2
 
+    def test_which_uses_os_defpath_for_explicit_env_without_path(self, monkeypatch):
+        seen_paths: list[str | None] = []
+
+        def fake_which(name, path=None):
+            seen_paths.append(path)
+            return None
+
+        monkeypatch.setattr("quorum.runner.shutil.which", fake_which)
+
+        assert _which("opencode", {}) is None
+        assert seen_paths == [os.defpath]
+
     def test_opencode_seed_requires_superpowers_root(self, tmp_path, monkeypatch):
         monkeypatch.delenv("SUPERPOWERS_ROOT", raising=False)
         monkeypatch.setattr("quorum.runner.shutil.which", lambda name: "/usr/bin/opencode")
@@ -2925,6 +3162,46 @@ class TestSeedAgentConfigDir:
         # provider keys are ambient (it picked claude-sonnet over GPT).
         seeded_config = json.loads((config_dir / "opencode.json").read_text())
         assert seeded_config["model"] == "openai/gpt-5.5"
+
+    def test_opencode_seed_uses_env_base_superpowers_root(self, tmp_path, monkeypatch):
+        sp = _make_superpowers_opencode_root(tmp_path)
+        plugin_src = sp / ".opencode" / "plugins" / "superpowers.js"
+        ambient_poison = tmp_path / "ambient-poison"
+        ambient_poison.mkdir()
+        monkeypatch.setenv("SUPERPOWERS_ROOT", str(ambient_poison))
+        monkeypatch.setattr(
+            "quorum.runner.shutil.which",
+            lambda name, path=None: f"/profile/bin/{name}",
+        )
+        monkeypatch.setattr(
+            "quorum.runner.subprocess.run",
+            lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, "OK\n", ""),
+        )
+        monkeypatch.setattr(
+            "quorum.runner.run_opencode_command",
+            lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, "OK\n", ""),
+        )
+
+        dest = tmp_path / "cfg"
+        _seed_agent_config_dir(
+            _opencode_tcfg(),
+            tmp_path,
+            dest,
+            tmp_path / "wd",
+            run_dir=tmp_path / "run-dir",
+            env_base={"PATH": "/profile/bin", "SUPERPOWERS_ROOT": str(sp)},
+        )
+
+        staged_plugin = (
+            dest
+            / ".config"
+            / "opencode"
+            / "superpowers"
+            / ".opencode"
+            / "plugins"
+            / "superpowers.js"
+        )
+        assert staged_plugin.read_text() == plugin_src.read_text()
 
     def test_opencode_seed_rejects_skill_tree_symlinks(self, tmp_path, monkeypatch):
         sp = _make_superpowers_opencode_root(tmp_path)
@@ -4270,6 +4547,99 @@ class TestRunScenario:
             "AWS_SECRET_ACCESS_KEY",
         ):
             assert name not in env_base
+
+    def test_run_scenario_passes_env_base_to_setup_checks_and_gauntlet(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "ambient-poison")
+        coding_agents_dir = tmp_path / "coding-agents"
+        scenarios_dir = tmp_path / "scenarios"
+        session_log_dir = tmp_path / "logs"
+        session_log_dir.mkdir()
+        _make_coding_agent(coding_agents_dir, "claude", session_log_dir)
+        (coding_agents_dir / "claude-context").mkdir()
+        sd = _make_scenario(scenarios_dir, "x", with_checks=False)
+        marker_dir = tmp_path / "markers"
+        marker_dir.mkdir()
+        (sd / "setup.sh").write_text(
+            "#!/usr/bin/env bash\n"
+            f'printf "%s" "${{OPENAI_API_KEY:-unset}}" > {marker_dir / "setup"}\n'
+        )
+        (sd / "setup.sh").chmod(0o755)
+        (sd / "checks.sh").write_text(
+            "pre() { command-succeeds 'test -z \"${OPENAI_API_KEY:-}\"'; }\n"
+            "post() { :; }\n"
+        )
+        captured: dict[str, dict[str, str] | None] = {}
+
+        def fake_invoke(*, run_dir, env_base, **_kwargs):
+            captured["gauntlet_env_base"] = env_base
+            result_dir = run_dir / "gauntlet-agent" / "results" / "run-1"
+            result_dir.mkdir(parents=True)
+            (result_dir / "result.json").write_text(json.dumps({"status": "pass"}))
+            (session_log_dir / "trace.jsonl").write_text(_claude_log_line())
+            return GauntletResult(status="pass")
+
+        with patch("quorum.runner.invoke_gauntlet", side_effect=fake_invoke):
+            _run_dir, verdict = run_scenario(
+                scenario_dir=sd,
+                coding_agent="claude",
+                coding_agents_dir=coding_agents_dir,
+                out_root=tmp_path / "results",
+                skeleton_root=_empty_skeleton(tmp_path),
+                env_base={"PATH": "/usr/bin:/bin", "LANG": "C.UTF-8"},
+            )
+
+        assert verdict.final == "pass"
+        assert (marker_dir / "setup").read_text() == "unset"
+        assert captured["gauntlet_env_base"] == {"PATH": "/usr/bin:/bin", "LANG": "C.UTF-8"}
+
+    def test_run_scenario_required_env_comes_from_env_base(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        coding_agents_dir = tmp_path / "coding-agents"
+        scenarios_dir = tmp_path / "scenarios"
+        session_log_dir = tmp_path / "logs"
+        session_log_dir.mkdir()
+        coding_agents_dir.mkdir()
+        (coding_agents_dir / "claude.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "name": "claude",
+                    "runtime_family": "claude",
+                    "binary": "echo",
+                    "agent_config_env": "CLAUDE_CONFIG_DIR",
+                    "session_log_dir": str(session_log_dir),
+                    "session_log_glob": "*.jsonl",
+                    "normalizer": "claude",
+                    "required_env": ["ANTHROPIC_API_KEY"],
+                    "model": "opus",
+                }
+            )
+        )
+        (coding_agents_dir / "claude-context").mkdir()
+        sd = _make_scenario(scenarios_dir, "x", with_checks=False)
+        (sd / "checks.sh").write_text("pre() { :; }\npost() { :; }\n")
+
+        def fake_invoke(*, run_dir, **_kwargs):
+            result_dir = run_dir / "gauntlet-agent" / "results" / "run-1"
+            result_dir.mkdir(parents=True)
+            (result_dir / "result.json").write_text(json.dumps({"status": "pass"}))
+            (session_log_dir / "trace.jsonl").write_text(_claude_log_line())
+            return GauntletResult(status="pass")
+
+        with patch("quorum.runner.invoke_gauntlet", side_effect=fake_invoke):
+            _run_dir, verdict = run_scenario(
+                scenario_dir=sd,
+                coding_agent="claude",
+                coding_agents_dir=coding_agents_dir,
+                out_root=tmp_path / "results",
+                skeleton_root=_empty_skeleton(tmp_path),
+                env_base={
+                    "PATH": "/usr/bin:/bin",
+                    "ANTHROPIC_API_KEY": "profile-key",
+                    "SUPERPOWERS_ROOT": str(tmp_path / "superpowers"),
+                },
+            )
+
+        assert verdict.final == "pass"
 
     def test_copilot_missing_transcript_is_indeterminate(self, tmp_path):
         coding_agents_dir = tmp_path / "coding-agents"

--- a/tests/quorum/test_runner.py
+++ b/tests/quorum/test_runner.py
@@ -52,6 +52,7 @@ from quorum.runner import (
     _write_gemini_settings,
     invoke_gauntlet,
     run_scenario,
+    run_scenario_in_dir,
 )
 
 
@@ -3432,6 +3433,31 @@ class TestAntigravityProjectMarkerExclusion:
 
 
 class TestRunScenario:
+    def test_run_scenario_in_dir_uses_preallocated_dir_and_maps_exceptions(self, tmp_path):
+        coding_agents_dir = tmp_path / "coding-agents"
+        scenarios_dir = tmp_path / "scenarios"
+        coding_agents_dir.mkdir(parents=True)
+        (coding_agents_dir / "broken.yaml").write_text("name: broken\n")
+        sd = _make_scenario(scenarios_dir, "x", with_checks=False)
+        (sd / "checks.sh").write_text("pre() { :; }\npost() { :; }\n")
+        run_dir = tmp_path / "results" / "managed-smoke-run"
+        run_dir.mkdir(parents=True)
+
+        returned_dir, verdict = run_scenario_in_dir(
+            run_dir=run_dir,
+            scenario_dir=sd,
+            coding_agent="broken",
+            coding_agents_dir=coding_agents_dir,
+            out_root=tmp_path / "results",
+            skeleton_root=_empty_skeleton(tmp_path),
+        )
+
+        assert returned_dir == run_dir
+        assert verdict.final == "indeterminate"
+        assert verdict.error is not None
+        assert verdict.error.stage == "setup"
+        assert (run_dir / "verdict.json").exists()
+
     def test_claude_family_missing_binary_fails_before_writing_env(self, tmp_path, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
         monkeypatch.setenv("SUPERPOWERS_ROOT", str(tmp_path / "superpowers"))

--- a/tests/quorum/test_runtime_env.py
+++ b/tests/quorum/test_runtime_env.py
@@ -1,0 +1,186 @@
+from pathlib import Path
+
+import pytest
+
+from quorum.managed_state import discover_managed_paths
+from quorum.runtime_env import (
+    TargetProfile,
+    TargetProfileError,
+    assert_raw_command_allowed,
+    build_managed_env,
+    is_managed_host,
+    is_managed_worker,
+    load_target_profile,
+    redact_env_for_logs,
+)
+
+
+def test_managed_host_and_worker_flags_are_exact() -> None:
+    assert is_managed_host({"QUORUM_MANAGED_HOST": "1"})
+    assert not is_managed_host({"QUORUM_MANAGED_HOST": "true"})
+    assert is_managed_worker({"QUORUM_MANAGED_WORKER": "1"})
+    assert not is_managed_worker({"QUORUM_MANAGED_WORKER": "true"})
+
+
+def test_load_target_profile_reads_shell_fragment(tmp_path: Path) -> None:
+    profile_root = tmp_path / "profiles"
+    profile_root.mkdir()
+    (profile_root / "claude.env").write_text(
+        "# comment\n"
+        "ANTHROPIC_API_KEY='sk-ant-test value'\n"
+        "export ANTHROPIC_BASE_URL=https://anthropic.example\n"
+    )
+
+    profile = load_target_profile(profile_root, "claude")
+
+    assert profile == TargetProfile(
+        target="claude",
+        path=profile_root / "claude.env",
+        env={
+            "ANTHROPIC_API_KEY": "sk-ant-test value",
+            "ANTHROPIC_BASE_URL": "https://anthropic.example",
+        },
+    )
+
+
+def test_load_target_profile_rejects_unsupported_lines(tmp_path: Path) -> None:
+    profile_root = tmp_path / "profiles"
+    profile_root.mkdir()
+    (profile_root / "claude.env").write_text("echo nope\n")
+
+    with pytest.raises(TargetProfileError, match="unsupported"):
+        load_target_profile(profile_root, "claude")
+
+
+def test_build_managed_env_uses_profile_not_ambient_poison(tmp_path: Path) -> None:
+    paths = discover_managed_paths(
+        {
+            "QUORUM_STATE_ROOT": str(tmp_path / "state"),
+            "QUORUM_ARTIFACT_ROOT": str(tmp_path / "artifacts"),
+        }
+    )
+    profile = TargetProfile(
+        target="claude",
+        path=tmp_path / "profiles" / "claude.env",
+        env={"ANTHROPIC_API_KEY": "profile-key"},
+    )
+
+    env = build_managed_env(
+        {
+            "PATH": "/usr/bin",
+            "HOME": "/home/quorum",
+            "LANG": "C.UTF-8",
+            "QUORUM_MANAGED_WORKER_TOKEN": "worker-secret",
+            "OPENAI_API_KEY": "ambient-poison",
+            "ANTHROPIC_API_KEY": "ambient-poison",
+        },
+        paths,
+        profile,
+        runtime_vars={"QUORUM_WORKDIR": "/work", "OPENAI_API_KEY": "runtime-value"},
+    )
+
+    assert env["PATH"] == "/usr/bin"
+    assert env["HOME"] == "/home/quorum"
+    assert env["QUORUM_ARTIFACT_ROOT"] == str(paths.artifact_root)
+    assert env["QUORUM_STATE_ROOT"] == str(paths.state_root)
+    assert env["ANTHROPIC_API_KEY"] == "profile-key"
+    assert "QUORUM_MANAGED_WORKER_TOKEN" not in env
+    assert "OPENAI_API_KEY" not in env
+    assert env["QUORUM_WORKDIR"] == "/work"
+    assert env["QUORUM_TARGET_ENV_KEYS"] == "ANTHROPIC_API_KEY"
+
+
+def test_build_managed_env_keeps_controller_owned_paths(tmp_path: Path) -> None:
+    paths = discover_managed_paths(
+        {
+            "QUORUM_STATE_ROOT": str(tmp_path / "state"),
+            "QUORUM_ARTIFACT_ROOT": str(tmp_path / "artifacts"),
+        }
+    )
+    profile = TargetProfile(
+        target="claude",
+        path=tmp_path / "profiles" / "claude.env",
+        env={"ANTHROPIC_API_KEY": "profile-key"},
+    )
+
+    env = build_managed_env(
+        {"PATH": "/usr/bin"},
+        paths,
+        profile,
+        runtime_vars={
+            "QUORUM_STATE_ROOT": "/tmp/evil-state",
+            "QUORUM_ARTIFACT_ROOT": "/tmp/evil-artifacts",
+            "QUORUM_TARGET": "evil",
+            "QUORUM_TARGET_ENV_KEYS": "OPENAI_API_KEY",
+            "QUORUM_WORKDIR": "/work",
+        },
+    )
+
+    assert env["QUORUM_STATE_ROOT"] == str(paths.state_root)
+    assert env["QUORUM_ARTIFACT_ROOT"] == str(paths.artifact_root)
+    assert env["QUORUM_TARGET"] == "claude"
+    assert env["QUORUM_TARGET_ENV_KEYS"] == "ANTHROPIC_API_KEY"
+    assert env["QUORUM_WORKDIR"] == "/work"
+
+
+def test_redact_env_for_logs_preserves_keys() -> None:
+    assert redact_env_for_logs({"OPENAI_API_KEY": "sk-test", "PATH": "/bin"}) == {
+        "OPENAI_API_KEY": "[redacted]",
+        "PATH": "[redacted]",
+    }
+
+
+def test_raw_command_gate_blocks_host_without_worker() -> None:
+    with pytest.raises(PermissionError, match="raw live eval commands are disabled"):
+        assert_raw_command_allowed("run", {"QUORUM_MANAGED_HOST": "1"})
+
+
+def test_raw_command_gate_blocks_worker_flag_without_token(tmp_path: Path) -> None:
+    with pytest.raises(PermissionError, match="raw live eval commands are disabled"):
+        assert_raw_command_allowed(
+            "run",
+            {
+                "QUORUM_MANAGED_HOST": "1",
+                "QUORUM_MANAGED_WORKER": "1",
+                "QUORUM_STATE_ROOT": str(tmp_path / "state"),
+            },
+        )
+
+
+def test_raw_command_gate_rejects_caller_controlled_state_root_token(tmp_path: Path) -> None:
+    state_root = tmp_path / "state"
+    state_root.mkdir()
+    token_file = state_root / "worker-token"
+    token_file.write_text("worker-secret\n")
+    token_file.chmod(0o600)
+
+    with pytest.raises(PermissionError, match="raw live eval commands are disabled"):
+        assert_raw_command_allowed(
+            "run",
+            {
+                "QUORUM_MANAGED_HOST": "1",
+                "QUORUM_MANAGED_WORKER": "1",
+                "QUORUM_MANAGED_WORKER_TOKEN": "worker-secret",
+                "QUORUM_STATE_ROOT": str(state_root),
+            },
+        )
+
+
+def test_raw_command_gate_allows_worker_with_matching_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state_root = tmp_path / "state"
+    state_root.mkdir()
+    token_file = state_root / "worker-token"
+    token_file.write_text("worker-secret\n")
+    token_file.chmod(0o600)
+    monkeypatch.setattr("quorum.runtime_env.MANAGED_WORKER_TOKEN_PATH", token_file)
+
+    assert_raw_command_allowed(
+        "run",
+        {
+            "QUORUM_MANAGED_HOST": "1",
+            "QUORUM_MANAGED_WORKER": "1",
+            "QUORUM_MANAGED_WORKER_TOKEN": "worker-secret",
+        },
+    )

--- a/tests/quorum/test_secret_scan.py
+++ b/tests/quorum/test_secret_scan.py
@@ -1,0 +1,214 @@
+import json
+from dataclasses import replace
+from pathlib import Path
+
+from quorum.managed_commands import create_job
+from quorum.managed_state import discover_managed_paths, read_job, write_job_atomic
+from quorum.runtime_env import TargetProfile
+from quorum.secret_scan import (
+    build_secret_patterns,
+    scan_job_artifacts,
+    scan_path_for_secrets,
+    taint_job_on_secret_match,
+)
+
+
+def test_exact_profile_secret_is_detected_in_nested_artifact_file(tmp_path):
+    secret = "target-secret-value-123"
+    artifacts = tmp_path / "artifacts"
+    nested = artifacts / "run-1" / "gauntlet-agent" / "results"
+    nested.mkdir(parents=True)
+    transcript = nested / "transcript.txt"
+    prefix = b"before "
+    transcript.write_bytes(prefix + secret.encode() + b" after")
+    profile = TargetProfile(
+        target="claude",
+        path=tmp_path / "profiles" / "claude.env",
+        env={"ANTHROPIC_API_KEY": secret},
+    )
+
+    result = scan_path_for_secrets(artifacts, build_secret_patterns(profile))
+
+    assert len(result.matches) == 1
+    match = result.matches[0]
+    assert match.path == str(transcript)
+    assert match.offset == len(prefix)
+    assert match.pattern == "ANTHROPIC_API_KEY"
+    assert match.digest.startswith("sha256:")
+    assert secret not in json.dumps(result.to_json(), sort_keys=True)
+
+
+def test_provider_pattern_is_detected_without_profile_value(tmp_path):
+    leaked_key = "sk-ant-api03-" + ("A" * 32)
+    artifact = tmp_path / "stdout.txt"
+    artifact.write_text(f"provider wrote {leaked_key}\n")
+    profile = TargetProfile(target="claude", path=None, env={})
+
+    result = scan_path_for_secrets(artifact, build_secret_patterns(profile))
+
+    assert len(result.matches) == 1
+    assert result.matches[0].pattern == "anthropic-api-key"
+    assert leaked_key not in json.dumps(result.to_json(), sort_keys=True)
+
+
+def test_large_text_artifact_is_scanned_in_chunks(tmp_path):
+    secret = "large-artifact-secret-123"
+    artifact = tmp_path / "large-transcript.txt"
+    artifact.write_bytes((b"x" * (1024 * 1024 + 32)) + secret.encode())
+    profile = TargetProfile(target="claude", path=None, env={"ANTHROPIC_API_KEY": secret})
+
+    result = scan_path_for_secrets(artifact, build_secret_patterns(profile))
+
+    assert len(result.matches) == 1
+    assert result.matches[0].path == str(artifact)
+    assert result.matches[0].offset == 1024 * 1024 + 32
+    assert secret not in json.dumps(result.to_json(), sort_keys=True)
+
+
+def test_non_secret_profile_values_are_not_exact_match_patterns(tmp_path):
+    value = "claude-3-5-sonnet"
+    artifact = tmp_path / "stdout.txt"
+    artifact.write_text(value)
+    profile = TargetProfile(
+        target="claude",
+        path=None,
+        env={"ANTHROPIC_MODEL": value, "ANTHROPIC_API_KEY": "target-secret-value"},
+    )
+
+    result = scan_path_for_secrets(artifact, build_secret_patterns(profile))
+
+    assert result.matches == []
+
+
+def test_scan_job_artifacts_scans_recorded_run_and_batch_dirs(tmp_path):
+    secret = "job-artifact-secret-123"
+    paths = discover_managed_paths(
+        {
+            "QUORUM_STATE_ROOT": str(tmp_path / "state"),
+            "QUORUM_ARTIFACT_ROOT": str(tmp_path / "artifacts"),
+        }
+    )
+    run_dir = paths.artifact_root / "scenario-claude-x"
+    batch_dir = paths.artifact_root / "batches" / "batch-x"
+    (run_dir / "gauntlet-agent").mkdir(parents=True)
+    batch_dir.mkdir(parents=True)
+    (run_dir / "gauntlet-agent" / "transcript.txt").write_text("clean\n")
+    (batch_dir / "results.jsonl").write_text(f"{secret}\n")
+    job = create_job("batch", None, [], paths, owner="drew", coding_agents=["claude"])
+    job = replace(
+        read_job(paths, job.id),
+        children=[
+            {
+                "id": "batch",
+                "kind": "batch",
+                "batch_dir": str(batch_dir),
+            },
+            {
+                "id": "child-0001",
+                "kind": "run",
+                "run_dir": str(run_dir),
+            },
+        ],
+    )
+
+    result = scan_job_artifacts(
+        job,
+        build_secret_patterns(
+            TargetProfile(target="claude", path=None, env={"ANTHROPIC_API_KEY": secret})
+        ),
+    )
+
+    assert [match.path for match in result.matches] == [str(batch_dir / "results.jsonl")]
+
+
+def test_scan_job_artifacts_includes_job_metadata_and_durable_log(tmp_path):
+    secret = "metadata-secret-value-123"
+    paths = discover_managed_paths(
+        {
+            "QUORUM_STATE_ROOT": str(tmp_path / "state"),
+            "QUORUM_ARTIFACT_ROOT": str(tmp_path / "artifacts"),
+        }
+    )
+    job = create_job("unit", "claude", [], paths, owner="drew")
+    log_path = Path(read_job(paths, job.id).log_path or "")
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text(f"log leaked {secret}\n")
+    write_job_atomic(
+        paths,
+        replace(read_job(paths, job.id), command=["quorum", "unit", secret]),
+    )
+
+    result = scan_job_artifacts(
+        read_job(paths, job.id),
+        build_secret_patterns(
+            TargetProfile(target="claude", path=None, env={"ANTHROPIC_API_KEY": secret})
+        ),
+        paths,
+    )
+
+    match_paths = {match.path for match in result.matches}
+    assert str(paths.jobs_dir / f"{job.id}.json") in match_paths
+    assert str(log_path) in match_paths
+    assert secret not in json.dumps(result.to_json(), sort_keys=True)
+
+
+def test_taint_job_on_secret_match_marks_and_events_only_when_matches_exist(tmp_path):
+    secret = "taint-secret-value-123"
+    paths = discover_managed_paths(
+        {
+            "QUORUM_STATE_ROOT": str(tmp_path / "state"),
+            "QUORUM_ARTIFACT_ROOT": str(tmp_path / "artifacts"),
+        }
+    )
+    job = create_job("smoke", "claude", [], paths, owner="drew")
+    clean_result = scan_path_for_secrets(
+        tmp_path / "missing",
+        build_secret_patterns(TargetProfile(target="claude", path=None, env={})),
+    )
+
+    unchanged = taint_job_on_secret_match(paths, job, clean_result)
+
+    assert unchanged == job
+    assert read_job(paths, job.id).tainted is False
+
+    artifact = paths.artifact_root / "run" / "stdout.txt"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text(secret)
+    result = scan_path_for_secrets(
+        paths.artifact_root,
+        build_secret_patterns(
+            TargetProfile(target="claude", path=None, env={"ANTHROPIC_API_KEY": secret})
+        ),
+    )
+
+    tainted = taint_job_on_secret_match(paths, read_job(paths, job.id), result)
+
+    assert tainted.state == "planned"
+    assert tainted.tainted is True
+    assert tainted.taint_reason == "secret-like material detected in managed artifacts"
+    assert tainted.taint_matches == result.to_json()["matches"]
+    events = (paths.events_dir / f"{job.id}.jsonl").read_text().splitlines()
+    assert any(json.loads(line)["event"] == "job-tainted" for line in events)
+    assert secret not in (paths.jobs_dir / f"{job.id}.json").read_text()
+    assert secret not in (paths.events_dir / f"{job.id}.jsonl").read_text()
+
+
+def test_worker_token_value_is_not_a_pattern_unless_in_target_profile(tmp_path):
+    worker_token = "worker-token-not-provider-shaped"
+    artifact = tmp_path / "worker.log"
+    artifact.write_text(worker_token)
+
+    no_profile_result = scan_path_for_secrets(
+        artifact,
+        build_secret_patterns(TargetProfile(target="claude", path=None, env={})),
+    )
+    profile_result = scan_path_for_secrets(
+        artifact,
+        build_secret_patterns(
+            TargetProfile(target="claude", path=None, env={"SESSION_TOKEN": worker_token})
+        ),
+    )
+
+    assert no_profile_result.matches == []
+    assert len(profile_result.matches) == 1
+    assert profile_result.matches[0].pattern == "SESSION_TOKEN"

--- a/tests/quorum/test_setup_step.py
+++ b/tests/quorum/test_setup_step.py
@@ -70,3 +70,20 @@ class TestRunSetup:
         )
         run_setup(scenario_dir, workdir, env_extra={"QUORUM_REPO_ROOT": "/fake/root"})
         assert marker_path.read_text().strip() == "/fake/root"
+
+    def test_env_base_replaces_ambient_environment(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "ambient-poison")
+        scenario_dir = tmp_path / "scenario"
+        scenario_dir.mkdir()
+        workdir = tmp_path / "wd"
+        workdir.mkdir()
+        marker_path = tmp_path / "captured_env"
+        _make_executable(
+            scenario_dir / "setup.sh",
+            "#!/usr/bin/env bash\n"
+            f'printf "%s" "${{OPENAI_API_KEY:-unset}}" > {marker_path}\n',
+        )
+
+        run_setup(scenario_dir, workdir, env_base={"PATH": "/usr/bin:/bin"})
+
+        assert marker_path.read_text() == "unset"


### PR DESCRIPTION
Lands the **managed-quorum Phase 1** work (AWS shared-host eval runner) that had accumulated **unpushed on local `main`**, rebased cleanly onto current `origin/main` (which now has #14/#15/#16).

## What's in the stack (13 commits)
**Design docs** — AWS eval-runner design, review revisions, and the normative Phase 1 spec.
**Managed-quorum runtime:**
- `managed_state.py` — durable atomic job state (planned/running/succeeded/…, heartbeats, taint).
- `locks.py` — host-global `fcntl` locks + cooldowns (deterministic order; cross-session quota guard).
- `managed_commands.py` — supervisor/worker model (survives SSH disconnect).
- `doctor.py` — target readiness (`ready`/`blocked`/`failed`) without personal auth.
- `runtime_env.py` — allowlisted/sanitized runtime env (no full `os.environ` passthrough) + fail-closed raw-command gate.
- `secret_scan.py` — finalization secret-leak scan that taints jobs.
- smoke / column / batch managed commands.
**Cleanup:** `test(doctor)` narrows `DoctorPaths.profile_root` (Optional) + the `to_dict()` payload so `ty` is clean.

## Checks
`ruff` ✓ · `ty` ✓ (0) · `quorum check` ✓ · `pytest` **842 passed / 1 skipped**.

## Notes
- This is the **shared-host** Phase 1. The container-per-cell direction (the in-flight isolation spec) is its named graduation path, tracked separately — not superseded by this PR, which lands the foundational managed-job/lock/state/secret machinery the container model will reuse.
- Live `quorum run` stays a trusted-maintainer op (not added to CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)