### PR TITLE
dashboard: cost ⇄ walltime metric toggle + grid fills viewport (PRI-2222)

### DIFF
--- a/src/dashboard/contracts.ts
+++ b/src/dashboard/contracts.ts
@@ -50,10 +50,10 @@ export const DashboardVerdictSchema = z.object({
   economics: z
     .object({
       total_est_cost_usd: z.number().nullable().optional().catch(null),
-      // The Gauntlet-Agent's session span. Empirically ≈ the run's end-to-end
-      // wall-clock (within ~1s, since the Gauntlet-Agent is alive for the whole
-      // run), and far more widely populated than the top-level finished_at — so
-      // it's the walltime fallback when finished_at is absent. `.catch`-guarded
+      // The Gauntlet-Agent's session span — the walltime fallback when the
+      // top-level finished_at is absent (see view.runWallMs). Close to end-to-end
+      // on light-setup runs, but undercounts the setup+capture overhead outside
+      // the gauntlet; far more widely populated than finished_at. `.catch`-guarded
       // like the rest: a malformed value degrades to null, never sinks the parse.
       gauntlet: z
         .object({
@@ -130,14 +130,17 @@ export interface SlotView {
   readonly wallHeight: number;
 }
 
-// One row in the detail hover card (one prior run). The card shows cost AND wall
-// side by side (detail view — both metrics, not toggled), so each row carries
-// both a cost string ('$X.XX' | '$—') and a wall string ('1m18s' | '—').
+// One row in the detail hover card (one prior run). Rendered left-to-right as
+// date · nonce · cost · wall · status. The card shows cost AND wall side by side
+// (detail view — both metrics, not toggled). `nonce` is the short run
+// disambiguator shown in the row; `run_id` is the full dir name, carried for a
+// copy-on-hover title only (not shown inline).
 export interface CardRow {
   readonly verdict: RunFinal;
   readonly cost: string;
   readonly wall: string;
   readonly timestamp: string;
+  readonly nonce: string;
   readonly run_id: string;
 }
 

--- a/src/dashboard/contracts.ts
+++ b/src/dashboard/contracts.ts
@@ -104,16 +104,24 @@ export function cellId(scenario: string, agent: string): string {
   return `cell-${scenario}-${agent}`;
 }
 
-// One verdict ribbon slot: a kind plus a normalized cost-bar height (0..1).
+// One verdict ribbon slot: a kind plus two normalized bar heights (0..1), one
+// per metric. Both are rendered in every cell so the client-side cost/walltime
+// toggle (an SSE swap keeps it) can pick which bar to show without a re-fetch.
 export interface SlotView {
   readonly kind: SlotKind;
+  // Cost-bar height, normalized to the window's peak cost.
   readonly height: number;
+  // Walltime-bar height, normalized to the window's peak run wall-clock.
+  readonly wallHeight: number;
 }
 
-// One row in the detail hover card (one prior run).
+// One row in the detail hover card (one prior run). The card shows cost AND wall
+// side by side (detail view — both metrics, not toggled), so each row carries
+// both a cost string ('$X.XX' | '$—') and a wall string ('1m18s' | '—').
 export interface CardRow {
   readonly verdict: RunFinal;
   readonly cost: string;
+  readonly wall: string;
   readonly timestamp: string;
   readonly run_id: string;
 }
@@ -127,15 +135,21 @@ export interface CardView {
 }
 
 // The render-ready cell. `slots` is always length 5 (ghost-padded left, newest
-// rightmost). `bottom` is '$X.XX' | '—' | 'queued' | a phase word. `opacity` is
-// 1.0 (running) | 0.5 (queued) | stale-fade (done).
+// rightmost). `bottom`/`bottomWall` are the cost/walltime figures (see fields).
+// `opacity` is 1.0 (running) | 0.5 (queued) | stale-fade (done).
 export interface CellView {
   readonly cell_id: string;
   readonly scenario: string;
   readonly agent: string;
   readonly state: CellState;
   readonly slots: readonly SlotView[];
+  // The cost bottom line: '$X.XX' | '$—' | 'queued' | a phase word | '—'.
   readonly bottom: string;
+  // The walltime bottom line: '1m18s' | '—' | 'queued' | a phase word. For
+  // non-done states it mirrors `bottom` (the same phase/queued/em-dash word);
+  // only on a resolved cell do the two diverge ($ vs duration). Both are
+  // rendered; CSS shows one based on the active metric.
+  readonly bottomWall: string;
   readonly drift: boolean;
   readonly opacity: number;
   readonly card: CardView | null;

--- a/src/dashboard/contracts.ts
+++ b/src/dashboard/contracts.ts
@@ -50,6 +50,18 @@ export const DashboardVerdictSchema = z.object({
   economics: z
     .object({
       total_est_cost_usd: z.number().nullable().optional().catch(null),
+      // The Gauntlet-Agent's session span. Empirically ≈ the run's end-to-end
+      // wall-clock (within ~1s, since the Gauntlet-Agent is alive for the whole
+      // run), and far more widely populated than the top-level finished_at — so
+      // it's the walltime fallback when finished_at is absent. `.catch`-guarded
+      // like the rest: a malformed value degrades to null, never sinks the parse.
+      gauntlet: z
+        .object({
+          duration_ms: z.number().nullable().optional().catch(null),
+        })
+        .nullable()
+        .optional()
+        .catch(null),
     })
     .nullable()
     .optional()
@@ -69,6 +81,9 @@ export interface RunRecord {
   readonly final: RunFinal;
   readonly cost_usd: number | null;
   readonly finished_at: string | null;
+  // The Gauntlet-Agent's span (ms), or null. The walltime fallback used when the
+  // precise finished_at − started_at span can't be computed (see view.runWallMs).
+  readonly gauntlet_duration_ms: number | null;
 }
 
 // An in-flight run: a dir with phase.json + a live pid and no verdict yet.

--- a/src/dashboard/scan.ts
+++ b/src/dashboard/scan.ts
@@ -189,6 +189,7 @@ export function scanResults(
           final: finalOf(verdict),
           cost_usd: economics?.total_est_cost_usd ?? null,
           finished_at: verdict.finished_at ?? null,
+          gauntlet_duration_ms: economics?.gauntlet?.duration_ms ?? null,
         });
         continue;
       }

--- a/src/dashboard/static/app.js
+++ b/src/dashboard/static/app.js
@@ -146,4 +146,19 @@
       fetch("/stop", { method: "POST" });
     }
   });
+
+  // Cost / walltime metric toggle. Flip html[data-metric] (CSS shows the matching
+  // figure + bar across every cell) and persist so the choice survives reloads;
+  // the FOUC-free read happens in the inline <head> script at layout.html.
+  document.addEventListener("click", (e) => {
+    const btn = e.target.closest(".mt-btn");
+    if (!btn) return;
+    const metric = btn.dataset.metric === "wall" ? "wall" : "cost";
+    document.documentElement.dataset.metric = metric;
+    try {
+      localStorage.setItem("quorum-metric", metric);
+    } catch (_e) {
+      // localStorage can throw in private mode; the in-session toggle still works.
+    }
+  });
 })();

--- a/src/dashboard/static/styles.css
+++ b/src/dashboard/static/styles.css
@@ -146,9 +146,10 @@ html[data-metric="wall"] .cb-slot { height: calc(2px + var(--hw, 0) * 12px); }
 }
 .cell-card-age { color: var(--text-label); font-weight: 600; margin-bottom: 8px; }
 .cell-card-rows { display: flex; flex-direction: column; gap: 5px; }
-/* The card shows cost AND wall side by side (detail view, both metrics): verdict
-   · cost · wall · time, with the run id spanning the full row beneath. */
-.cell-card-row { display: grid; grid-template-columns: auto auto auto 1fr; gap: 4px 10px; align-items: baseline; }
+/* One row per prior run, flowing date · nonce · cost · wall · status. The card
+   shows cost AND wall together (detail view, both metrics). The nonce stands in
+   for the full run id (which is the span's title), so the row stays one line. */
+.cell-card-row { display: grid; grid-template-columns: auto auto auto auto auto; gap: 4px 12px; align-items: baseline; justify-content: start; }
 .ccr-verdict { font-weight: 600; }
 .v-pass { color: var(--verdict-pass); }
 .v-fail { color: var(--verdict-fail); }
@@ -156,5 +157,5 @@ html[data-metric="wall"] .cb-slot { height: calc(2px + var(--hw, 0) * 12px); }
 .ccr-cost { color: var(--text-primary); }
 .ccr-wall { color: var(--accent); }
 .ccr-time { color: var(--text-label); }
-.ccr-id { grid-column: 1 / -1; color: var(--text-label); font-size: 11px; user-select: all; word-break: break-all; }
+.ccr-nonce { color: var(--text-label); font-size: 11px; user-select: all; }
 .card-drift { margin-top: 8px; padding-top: 7px; border-top: 1px solid var(--border-grid); color: var(--verdict-fail); }

--- a/src/dashboard/static/styles.css
+++ b/src/dashboard/static/styles.css
@@ -40,19 +40,43 @@
 body {
   margin: 0;
   padding: 24px;
+  box-sizing: border-box;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
   background: var(--surface-page);
   color: var(--text-primary);
   font-family: var(--font);
 }
 
-.pghead { font-size: 13px; color: var(--text-label); margin-bottom: 12px; }
+.pghead { display: flex; align-items: center; gap: 12px; font-size: 13px; color: var(--text-label); margin-bottom: 12px; }
+#tally { min-width: 0; }
+
+/* cost / walltime metric toggle (right of the tally) */
+.metric-toggle { margin-left: auto; flex: none; display: inline-flex; border: 1px solid var(--border-grid); border-radius: 7px; overflow: hidden; }
+.mt-btn { font: inherit; font-size: 12px; line-height: 1; color: var(--text-label); background: transparent; border: 0; padding: 4px 11px; cursor: pointer; }
+.mt-btn + .mt-btn { border-left: 1px solid var(--border-grid); }
+.mt-btn:hover { color: var(--text-primary); }
+html[data-metric="cost"] .mt-btn[data-metric="cost"],
+html[data-metric="wall"] .mt-btn[data-metric="wall"] { color: var(--accent); background: var(--accent-wash); }
+
+/* Metric visibility. Every cell renders both the $ and the ⏱ figure; the active
+   metric (html[data-metric]) decides which shows, so an SSE cell swap keeps the
+   toggle. Default is cost. The drift ▲ is a cost anomaly — hidden in wall mode. */
+.m-wall { display: none; }
+html[data-metric="wall"] .m-cost { display: none; }
+html[data-metric="wall"] .m-wall { display: inline; }
+html[data-metric="wall"] .drift { display: none; }
 .pghead b { color: var(--text-primary); font-weight: 600; font-size: 15px; }
 .pghead .sep { color: var(--border-grid); margin: 0 8px; }
 .kpass { color: var(--verdict-pass); }
 .kfail { color: var(--verdict-fail); }
 .kindet { color: var(--verdict-indet); }
 
-.mxwrap { background: var(--surface-panel); border-radius: 8px; padding: 16px 18px; overflow: auto; max-height: 80vh; }
+/* The grid panel flexes to fill the viewport below the header (body is a 100vh
+   flex column). It stays the scroll container (overflow:auto + min-height:0) so
+   the sticky <th> header keeps working. */
+.mxwrap { background: var(--surface-panel); border-radius: 8px; padding: 16px 18px; overflow: auto; flex: 1; min-height: 0; }
 .mx { border-collapse: collapse; font-variant-numeric: tabular-nums; }
 .mx th {
   color: var(--text-label); font-weight: 600; padding: 6px 0 10px; font-size: 12px;
@@ -86,6 +110,7 @@ body {
 
 .cb { display: flex; align-items: flex-end; gap: 3px; height: 14px; }
 .cb-slot { display: inline-block; width: 11px; background: var(--cost-bar); border-radius: 1px 1px 0 0; height: calc(2px + var(--h, 0) * 12px); }
+html[data-metric="wall"] .cb-slot { height: calc(2px + var(--hw, 0) * 12px); }
 .cb-slot.gh { background: var(--cost-bar-none); }
 
 .dc { font-size: 12px; color: var(--text-primary); white-space: nowrap; text-align: right; }
@@ -121,12 +146,15 @@ body {
 }
 .cell-card-age { color: var(--text-label); font-weight: 600; margin-bottom: 8px; }
 .cell-card-rows { display: flex; flex-direction: column; gap: 5px; }
-.cell-card-row { display: grid; grid-template-columns: auto auto 1fr; gap: 4px 10px; align-items: baseline; }
+/* The card shows cost AND wall side by side (detail view, both metrics): verdict
+   · cost · wall · time, with the run id spanning the full row beneath. */
+.cell-card-row { display: grid; grid-template-columns: auto auto auto 1fr; gap: 4px 10px; align-items: baseline; }
 .ccr-verdict { font-weight: 600; }
 .v-pass { color: var(--verdict-pass); }
 .v-fail { color: var(--verdict-fail); }
 .v-indeterminate, .v-unknown { color: var(--verdict-indet); }
 .ccr-cost { color: var(--text-primary); }
+.ccr-wall { color: var(--accent); }
 .ccr-time { color: var(--text-label); }
 .ccr-id { grid-column: 1 / -1; color: var(--text-label); font-size: 11px; user-select: all; word-break: break-all; }
 .card-drift { margin-top: 8px; padding-top: 7px; border-top: 1px solid var(--border-grid); color: var(--verdict-fail); }

--- a/src/dashboard/templates.ts
+++ b/src/dashboard/templates.ts
@@ -100,13 +100,16 @@ function costBarHtml(slots: readonly SlotView[]): string {
 function cardHtml(card: CardView): string {
   const rows = card.rows
     .map(
+      // Columns flow date · nonce · cost · wall · status. The nonce is the only
+      // run id shown; the full dir name is the title (copy-on-hover) so it stays
+      // recoverable without cluttering the row.
       (row) =>
         `<div class="cell-card-row">` +
-        `<span class="ccr-verdict v-${esc(row.verdict)}">${esc(row.verdict)}</span>` +
+        `<span class="ccr-time">${esc(row.timestamp)}</span>` +
+        `<span class="ccr-nonce" title="${esc(row.run_id)}">${esc(row.nonce)}</span>` +
         `<span class="ccr-cost">${esc(row.cost)}</span>` +
         `<span class="ccr-wall">${esc(row.wall)}</span>` +
-        `<span class="ccr-time">${esc(row.timestamp)}</span>` +
-        `<span class="ccr-id">${esc(row.run_id)}</span>` +
+        `<span class="ccr-verdict v-${esc(row.verdict)}">${esc(row.verdict)}</span>` +
         `</div>`,
     )
     .join('');

--- a/src/dashboard/templates.ts
+++ b/src/dashboard/templates.ts
@@ -78,16 +78,18 @@ function ribbonHtml(slots: readonly SlotView[]): string {
     .join('');
 }
 
-// The cost-bar row (`.cb`): ghost/running slots use the 0.18 height floor via the
-// `gh` class; resolved slots carry their normalized height in the inline `--h`
-// custom property the CSS reads (height: calc(2px + var(--h) * 12px)).
+// The cost/walltime bar row (`.cb`): ghost/running slots use the 0.18 height floor
+// via the `gh` class; resolved slots carry BOTH normalized heights in inline
+// custom properties — `--h` (cost) and `--hw` (wall). CSS reads `--h` by default
+// and `--hw` under html[data-metric="wall"], so the bar follows the active metric
+// with no re-fetch (height: calc(2px + var(--h|--hw) * 12px)).
 function costBarHtml(slots: readonly SlotView[]): string {
   return slots
     .map((slot) => {
       if (slot.kind === 'ghost' || slot.kind === 'running') {
-        return '<i class="cb-slot gh" style="--h:0.180"></i>';
+        return '<i class="cb-slot gh" style="--h:0.180;--hw:0.180"></i>';
       }
-      return `<i class="cb-slot" style="--h:${f3(slot.height)}"></i>`;
+      return `<i class="cb-slot" style="--h:${f3(slot.height)};--hw:${f3(slot.wallHeight)}"></i>`;
     })
     .join('');
 }
@@ -102,6 +104,7 @@ function cardHtml(card: CardView): string {
         `<div class="cell-card-row">` +
         `<span class="ccr-verdict v-${esc(row.verdict)}">${esc(row.verdict)}</span>` +
         `<span class="ccr-cost">${esc(row.cost)}</span>` +
+        `<span class="ccr-wall">${esc(row.wall)}</span>` +
         `<span class="ccr-time">${esc(row.timestamp)}</span>` +
         `<span class="ccr-id">${esc(row.run_id)}</span>` +
         `</div>`,
@@ -158,7 +161,7 @@ export function cellHtml(view: CellView): string {
     `<div class="inner">` +
     `<div class="vs">${ribbonHtml(view.slots)}</div>` +
     `<div class="cb">${costBarHtml(view.slots)}</div>` +
-    `<div class="dc">${drift}${esc(view.bottom)}</div>` +
+    `<div class="dc">${drift}<span class="m-cost">${esc(view.bottom)}</span><span class="m-wall">${esc(view.bottomWall)}</span></div>` +
     `</div>` +
     card +
     `</div>` +
@@ -265,6 +268,7 @@ export function gridHtml(args: GridArgs): string {
               state: 'empty',
               slots: [],
               bottom: '—',
+              bottomWall: '—',
               drift: false,
               opacity: 1,
               card: null,
@@ -294,6 +298,19 @@ export function gridHtml(args: GridArgs): string {
   );
 }
 
+// The cost/walltime metric toggle (header, right-aligned). Two segmented buttons
+// keyed by data-metric; app.js flips html[data-metric] + persists to localStorage
+// on click, and CSS lights the active button. Static markup — never SSE-swapped —
+// so the control itself survives cell/strip swaps.
+function metricToggleHtml(): string {
+  return (
+    `<span class="metric-toggle" role="group" aria-label="cost or walltime">` +
+    `<button type="button" class="mt-btn" data-metric="cost" title="show cost" aria-label="cost">$</button>` +
+    `<button type="button" class="mt-btn" data-metric="wall" title="show walltime" aria-label="walltime">⏱</button>` +
+    `</span>`
+  );
+}
+
 // The full page (`layout.html.j2`). References the vendored static assets and
 // wires the SSE extension on <body> (hx-ext="sse" + sse-connect="/events"). The
 // tally + grid bodies are already-rendered HTML inlined unescaped (the Jinja
@@ -306,17 +323,21 @@ export interface LayoutArgs {
 export function layoutHtml(args: LayoutArgs): string {
   return (
     `<!doctype html>\n` +
-    `<html lang="en" data-theme="dark">\n` +
+    `<html lang="en" data-theme="dark" data-metric="cost">\n` +
     `<head>\n` +
     `  <meta charset="utf-8">\n` +
     `  <meta name="viewport" content="width=device-width, initial-scale=1">\n` +
     `  <title>quorum dashboard</title>\n` +
+    // Apply the saved metric before first paint so the toggle never flashes the
+    // default $ view for users who left it on walltime. Static literal — no user
+    // data interpolated, so no XSS surface.
+    `  <script>try{var m=localStorage.getItem('quorum-metric');if(m==='cost'||m==='wall'){document.documentElement.dataset.metric=m;}}catch(e){}</script>\n` +
     `  <link rel="stylesheet" href="/static/styles.css">\n` +
     `  <script src="/static/htmx.min.js" defer></script>\n` +
     `  <script src="/static/htmx-ext-sse.js" defer></script>\n` +
     `</head>\n` +
     `<body hx-ext="sse" sse-connect="/events">\n` +
-    `  <div class="pghead" id="tally">${args.tallyHtml}</div>\n` +
+    `  <div class="pghead"><span id="tally">${args.tallyHtml}</span>${metricToggleHtml()}</div>\n` +
     `  <div class="runbar-slot" id="runbar" sse-swap="strip" hx-swap="innerHTML"></div>\n` +
     `  <div class="mxwrap">${args.gridHtml}</div>\n` +
     `  <div id="confirm-host"></div>\n` +

--- a/src/dashboard/view.ts
+++ b/src/dashboard/view.ts
@@ -70,6 +70,45 @@ export function costBarHeights(costs: readonly number[]): number[] {
   return costs.map((c) => c / peak);
 }
 
+// Compact wall-clock label from a millisecond span. `<60s -> "42s"`; `<60m ->
+// "5m"` (exact minute) or `"1m17s"` (keeps the seconds part, so a 77s run is not
+// a lossy "1m"); `>=60m -> "1h19m"` (drops seconds at the hour scale, minutes
+// zero-padded). Parallels rowCost: the cell-bottom analogue of "$X.XX".
+export function formatWall(ms: number): string {
+  const totalSeconds = Math.max(0, Math.round(ms / 1000));
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`;
+  }
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  if (totalMinutes < 60) {
+    const secs = totalSeconds % 60;
+    return secs === 0 ? `${totalMinutes}m` : `${totalMinutes}m${secs}s`;
+  }
+  const hours = Math.floor(totalMinutes / 60);
+  const mins = totalMinutes % 60;
+  return `${hours}h${mins.toString().padStart(2, '0')}m`;
+}
+
+// End-to-end run wall-clock in ms: the dir-stamp started_at (always present) to
+// the verdict's finished_at. null when finished_at is missing/unparseable or the
+// span is negative (clock skew). This is the only walltime source that survives
+// the no-cost case (timing is captured independently of obol pricing), and it
+// needs no new RunRecord field — both ends already live on the record.
+export function runWallMs(rec: RunRecord): number | null {
+  if (rec.finished_at === null) {
+    return null;
+  }
+  const start = parseDirStamp(rec.started_at);
+  if (start === null) {
+    return null;
+  }
+  const end = Date.parse(rec.finished_at);
+  if (Number.isNaN(end) || end < start) {
+    return null;
+  }
+  return end - start;
+}
+
 // Human-coarse single-unit age: `45s`, `12m`, `3h`, `21d`. Sub-minute reads in
 // seconds; the unit steps up at each natural boundary. Each unit is an integer
 // floor (data.py `int()`). Negative/zero clamps to `0s`.
@@ -219,6 +258,14 @@ function rowCost(costUsd: number | null): string {
   return costUsd !== null ? `$${costUsd.toFixed(2)}` : '$—';
 }
 
+// A wall-clock figure for a run, or "—" when its span can't be computed. The
+// walltime analogue of rowCost's "$—": "—" reads as an unknown duration, never a
+// misleading "0s".
+function rowWall(rec: RunRecord): string {
+  const ms = runWallMs(rec);
+  return ms !== null ? formatWall(ms) : '—';
+}
+
 // Compact card-row timestamp. Prefers the dir-name started_at (always present)
 // rendered as `YYYY-MM-DD HH:MM`; falls back to finished_at when the stamp is
 // unparseable.
@@ -251,6 +298,7 @@ function cardView(
   const rows: CardRow[] = cell.window.map((r) => ({
     verdict: r.final,
     cost: rowCost(r.cost_usd),
+    wall: rowWall(r),
     timestamp: rowTimestamp(r),
     run_id: r.run_id,
   }));
@@ -292,6 +340,7 @@ export function cellView(
       state: 'queued',
       slots,
       bottom: 'queued',
+      bottomWall: 'queued',
       drift: false,
       opacity: QUEUED_OPACITY,
       card: cardView(cell, false, now),
@@ -301,7 +350,7 @@ export function cellView(
   if (cell.running !== null && cell.window.length === 0) {
     // Pure running cell (no resolved history yet): shimmer the newest slot.
     const slots: SlotView[] = ghostSlots(4);
-    slots.push({ kind: 'running', height: 0 });
+    slots.push({ kind: 'running', height: 0, wallHeight: 0 });
     return {
       cell_id: id,
       scenario,
@@ -309,6 +358,7 @@ export function cellView(
       state: 'running',
       slots,
       bottom: cell.running.phase,
+      bottomWall: cell.running.phase,
       drift: false,
       opacity: 1.0,
       card: null,
@@ -323,6 +373,7 @@ export function cellView(
       state: 'empty',
       slots: [],
       bottom: '—',
+      bottomWall: '—',
       drift: false,
       opacity: 1.0,
       card: null,
@@ -331,15 +382,18 @@ export function cellView(
 
   let slots = paddedSlots(cell.window);
   let bottom: string;
+  let bottomWall: string;
   let drift: boolean;
   if (cell.running !== null) {
-    // In-flight on top of history: newest slot shimmers, no latest $ yet.
-    slots = [...slots.slice(1), { kind: 'running', height: 0 }];
+    // In-flight on top of history: newest slot shimmers, no latest $/wall yet.
+    slots = [...slots.slice(1), { kind: 'running', height: 0, wallHeight: 0 }];
     bottom = cell.running.phase;
+    bottomWall = cell.running.phase;
     drift = false;
   } else {
     const latest = cell.window[cell.window.length - 1] as RunRecord;
     bottom = latest.cost_usd !== null ? `$${latest.cost_usd.toFixed(2)}` : '$—';
+    bottomWall = rowWall(latest);
     drift = driftFlag(cellCosts(cell));
   }
   const state = cell.running !== null ? 'running' : 'done';
@@ -352,6 +406,7 @@ export function cellView(
     state,
     slots,
     bottom,
+    bottomWall,
     drift,
     opacity,
     card: cardView(cell, drift, now),
@@ -361,19 +416,22 @@ export function cellView(
 function ghostSlots(n: number): SlotView[] {
   const out: SlotView[] = [];
   for (let i = 0; i < n; i++) {
-    out.push({ kind: 'ghost', height: 0 });
+    out.push({ kind: 'ghost', height: 0, wallHeight: 0 });
   }
   return out;
 }
 
-// Real slots for the window, ghost-padded on the left to length 5. Cost-bar
-// heights normalize to the window peak (missing costs count as 0).
+// Real slots for the window, ghost-padded on the left to length 5. Each slot
+// carries BOTH a cost-bar height and a wall-bar height, each normalized to its
+// own window peak (missing cost / uncomputable wall count as 0). The active
+// metric's bar is selected in CSS, so a cell never re-fetches to switch.
 function paddedSlots(window: readonly RunRecord[]): SlotView[] {
-  const costsAll = window.map((r) => r.cost_usd ?? 0);
-  const heights = costBarHeights(costsAll);
+  const costHeights = costBarHeights(window.map((r) => r.cost_usd ?? 0));
+  const wallHeights = costBarHeights(window.map((r) => runWallMs(r) ?? 0));
   const real: SlotView[] = window.map((r, i) => ({
     kind: r.final,
-    height: heights[i] as number,
+    height: costHeights[i] as number,
+    wallHeight: wallHeights[i] as number,
   }));
   const pad = 5 - real.length;
   return [...ghostSlots(pad), ...real];

--- a/src/dashboard/view.ts
+++ b/src/dashboard/view.ts
@@ -89,24 +89,27 @@ export function formatWall(ms: number): string {
   return `${hours}h${mins.toString().padStart(2, '0')}m`;
 }
 
-// End-to-end run wall-clock in ms: the dir-stamp started_at (always present) to
-// the verdict's finished_at. null when finished_at is missing/unparseable or the
-// span is negative (clock skew). This is the only walltime source that survives
-// the no-cost case (timing is captured independently of obol pricing), and it
-// needs no new RunRecord field — both ends already live on the record.
+// Run wall-clock in ms, by a two-step cascade (both express the same thing — how
+// long the run took — so the metric stays consistent across cells):
+//   1. PRECISE: dir-stamp started_at -> verdict finished_at. Survives the no-cost
+//      case (timing is independent of obol pricing), but the top-level timestamps
+//      are a recent schema addition (~18% of verdicts).
+//   2. FALLBACK: economics.gauntlet.duration_ms — the Gauntlet-Agent's span, which
+//      brackets the run within ~1s of the precise value and is populated for ~71%
+//      of verdicts, so most historical runs still get a duration instead of "—".
+// null only when neither is available (e.g. an errored run with no timing).
 export function runWallMs(rec: RunRecord): number | null {
-  if (rec.finished_at === null) {
-    return null;
-  }
   const start = parseDirStamp(rec.started_at);
-  if (start === null) {
-    return null;
+  if (rec.finished_at !== null && start !== null) {
+    const end = Date.parse(rec.finished_at);
+    if (!Number.isNaN(end) && end >= start) {
+      return end - start;
+    }
   }
-  const end = Date.parse(rec.finished_at);
-  if (Number.isNaN(end) || end < start) {
-    return null;
+  if (rec.gauntlet_duration_ms !== null && rec.gauntlet_duration_ms >= 0) {
+    return rec.gauntlet_duration_ms;
   }
-  return end - start;
+  return null;
 }
 
 // Human-coarse single-unit age: `45s`, `12m`, `3h`, `21d`. Sub-minute reads in

--- a/src/dashboard/view.ts
+++ b/src/dashboard/view.ts
@@ -94,9 +94,12 @@ export function formatWall(ms: number): string {
 //   1. PRECISE: dir-stamp started_at -> verdict finished_at. Survives the no-cost
 //      case (timing is independent of obol pricing), but the top-level timestamps
 //      are a recent schema addition (~18% of verdicts).
-//   2. FALLBACK: economics.gauntlet.duration_ms — the Gauntlet-Agent's span, which
-//      brackets the run within ~1s of the precise value and is populated for ~71%
-//      of verdicts, so most historical runs still get a duration instead of "—".
+//   2. FALLBACK: economics.gauntlet.duration_ms — the Gauntlet-Agent's span. It
+//      UNDER-reports end-to-end by the quorum-side setup before the gauntlet runs
+//      and the capture/post-checks after it: ≈1s on warm light-setup runs, but up
+//      to tens of seconds on cold venv/plugin-provision runs. Still an honest
+//      coarse signal, and populated for ~71% of verdicts (vs ~18% for finished_at)
+//      — far better than "—" for the bulk of historical runs.
 // null only when neither is available (e.g. an errored run with no timing).
 export function runWallMs(rec: RunRecord): number | null {
   const start = parseDirStamp(rec.started_at);
@@ -269,6 +272,14 @@ function rowWall(rec: RunRecord): string {
   return ms !== null ? formatWall(ms) : '—';
 }
 
+// The short run nonce — the final `-`-delimited segment of the run id
+// (`<scenario>-<agent>-<stamp>-<nonce>`), e.g. `1e55`. Shown in the card row in
+// place of the full quad; the full id rides along as a copy-on-hover title.
+function runNonce(runId: string): string {
+  const i = runId.lastIndexOf('-');
+  return i === -1 ? runId : runId.slice(i + 1);
+}
+
 // Compact card-row timestamp. Prefers the dir-name started_at (always present)
 // rendered as `YYYY-MM-DD HH:MM`; falls back to finished_at when the stamp is
 // unparseable.
@@ -303,6 +314,7 @@ function cardView(
     cost: rowCost(r.cost_usd),
     wall: rowWall(r),
     timestamp: rowTimestamp(r),
+    nonce: runNonce(r.run_id),
     run_id: r.run_id,
   }));
   const age = formatAge(latestAgeDays(cell, now));

--- a/test/dashboard-contracts.test.ts
+++ b/test/dashboard-contracts.test.ts
@@ -68,6 +68,27 @@ test('DashboardVerdictSchema: a non-object economics degrades to null', () => {
   expect(v.economics).toBeNull();
 });
 
+test('DashboardVerdictSchema reads economics.gauntlet.duration_ms (wall fallback)', () => {
+  const v = DashboardVerdictSchema.parse({
+    final: 'pass',
+    economics: {
+      total_est_cost_usd: 1.25,
+      gauntlet: { duration_ms: 144_696 },
+    },
+  });
+  expect(v.economics?.gauntlet?.duration_ms).toBe(144_696);
+});
+
+test('DashboardVerdictSchema: a malformed gauntlet duration degrades to null', () => {
+  const v = DashboardVerdictSchema.parse({
+    final: 'pass',
+    economics: { total_est_cost_usd: 1, gauntlet: { duration_ms: 'nope' } },
+  });
+  // The bad field degrades but the verdict still reads as present.
+  expect(v.economics?.gauntlet?.duration_ms).toBeNull();
+  expect(v.economics?.total_est_cost_usd).toBe(1);
+});
+
 test('cellKey + cellId form the composite key and DOM id', () => {
   expect(cellKey('s', 'claude')).toBe('s\tclaude');
   expect(cellId('s', 'claude')).toBe('cell-s-claude');

--- a/test/dashboard-diff.test.ts
+++ b/test/dashboard-diff.test.ts
@@ -10,6 +10,7 @@ function rec(runId: string): RunRecord {
     final: 'pass',
     cost_usd: 1,
     finished_at: null,
+    gauntlet_duration_ms: null,
   };
 }
 

--- a/test/dashboard-scan.test.ts
+++ b/test/dashboard-scan.test.ts
@@ -159,6 +159,27 @@ test('scanResults reads final/cost/finished_at off the verdict', () => {
   expect(rec?.started_at).toBe('20260612T000000Z');
 });
 
+test('scanResults surfaces economics.gauntlet.duration_ms onto the record', () => {
+  const root = mkdtempSync(join(tmpdir(), 'res-'));
+  writeRun(root, 's-claude-20260612T000000Z-aaaa', {
+    verdict: {
+      final: 'pass',
+      economics: { total_est_cost_usd: 1, gauntlet: { duration_ms: 77_000 } },
+    },
+  });
+  const cell = scanResults(root, AGENTS).cells.get(cellKey('s', 'claude'));
+  expect(cell?.window[0]?.gauntlet_duration_ms).toBe(77_000);
+});
+
+test('scanResults: a verdict with no gauntlet span yields a null duration', () => {
+  const root = mkdtempSync(join(tmpdir(), 'res-'));
+  writeRun(root, 's-claude-20260612T000000Z-aaaa', {
+    verdict: { final: 'pass', economics: { total_est_cost_usd: 1 } },
+  });
+  const cell = scanResults(root, AGENTS).cells.get(cellKey('s', 'claude'));
+  expect(cell?.window[0]?.gauntlet_duration_ms).toBeNull();
+});
+
 test('scanResults collapses an unknown final to "unknown"', () => {
   const root = mkdtempSync(join(tmpdir(), 'res-'));
   writeRun(root, 's-claude-20260612T000000Z-aaaa', {

--- a/test/dashboard-templates.test.ts
+++ b/test/dashboard-templates.test.ts
@@ -21,7 +21,11 @@ import {
 // --- small helpers to build views without IO ----------------------------------
 
 function ghostSlots(): SlotView[] {
-  return Array.from({ length: 5 }, () => ({ kind: 'ghost', height: 0.18 }));
+  return Array.from({ length: 5 }, () => ({
+    kind: 'ghost',
+    height: 0.18,
+    wallHeight: 0.18,
+  }));
 }
 
 function doneView(over: Partial<CellView> = {}): CellView {
@@ -31,13 +35,14 @@ function doneView(over: Partial<CellView> = {}): CellView {
     agent: 'claude',
     state: 'done',
     slots: [
-      { kind: 'ghost', height: 0.18 },
-      { kind: 'ghost', height: 0.18 },
-      { kind: 'pass', height: 0.25 },
-      { kind: 'fail', height: 0.5 },
-      { kind: 'pass', height: 1 },
+      { kind: 'ghost', height: 0.18, wallHeight: 0.18 },
+      { kind: 'ghost', height: 0.18, wallHeight: 0.18 },
+      { kind: 'pass', height: 0.25, wallHeight: 0.6 },
+      { kind: 'fail', height: 0.5, wallHeight: 0.3 },
+      { kind: 'pass', height: 1, wallHeight: 0.4 },
     ],
     bottom: '$1.25',
+    bottomWall: '1m18s',
     drift: false,
     opacity: 0.84,
     card: null,
@@ -93,6 +98,7 @@ test('empty cell renders the em-dash placeholder and no inner ribbon', () => {
     state: 'empty',
     slots: ghostSlots(),
     bottom: '—',
+    bottomWall: '—',
     drift: false,
     opacity: 1,
     card: null,
@@ -111,6 +117,7 @@ test('not-applicable cell (title set) renders dimmed n/a + tooltip, not the em-d
     state: 'empty',
     slots: ghostSlots(),
     bottom: '—',
+    bottomWall: '—',
     drift: false,
     opacity: 0.3,
     card: null,
@@ -128,11 +135,25 @@ test('done cell carries solid bands, a cost-bar with --h, and the cost bottom', 
   expect(html).toContain('class="vs-slot b-pass"');
   expect(html).toContain('class="vs-slot b-fail"'); // fail hatch band
   expect(html).toContain('class="vs-slot ghost"'); // left padding
-  // cost-bar slots: ghosts use the 0.18 floor, real slots carry their height.
-  expect(html).toContain('class="cb-slot gh" style="--h:0.180"');
-  expect(html).toContain('class="cb-slot" style="--h:1.000"');
-  expect(html).toContain('$1.25');
+  // cost-bar slots: ghosts use the 0.18 floor, real slots carry BOTH heights
+  // (--h cost, --hw wall) so the bar follows the active metric without a refetch.
+  expect(html).toContain('class="cb-slot gh" style="--h:0.180;--hw:0.180"');
+  expect(html).toContain('class="cb-slot" style="--h:1.000;--hw:0.400"');
+  // the cost figure lives in the m-cost span; the wall figure in m-wall.
+  expect(html).toContain('<span class="m-cost">$1.25</span>');
+  expect(html).toContain('<span class="m-wall">1m18s</span>');
   expect(html).not.toContain('class="drift"'); // no drift marker
+});
+
+test('done cell renders both metric bars and both bottom figures (toggle-ready)', () => {
+  // A real slot carries --h (cost) and --hw (wall) so CSS can pick per metric.
+  const html = cellHtml(doneView());
+  expect(html).toContain('--h:0.250;--hw:0.600');
+  expect(html).toContain('--h:0.500;--hw:0.300');
+  // Both figures are always in the DOM; CSS shows one by html[data-metric].
+  expect(html.indexOf('class="m-cost"')).toBeLessThan(
+    html.indexOf('class="m-wall"'),
+  );
 });
 
 test('done cell with drift shows the ▲ marker before the cost', () => {
@@ -154,21 +175,22 @@ test('running cell carries the running class, a shimmer runslot, and the phase b
     agent: 'claude',
     state: 'running',
     slots: [
-      { kind: 'ghost', height: 0.18 },
-      { kind: 'ghost', height: 0.18 },
-      { kind: 'pass', height: 0.5 },
-      { kind: 'pass', height: 1 },
-      { kind: 'running', height: 0.18 },
+      { kind: 'ghost', height: 0.18, wallHeight: 0.18 },
+      { kind: 'ghost', height: 0.18, wallHeight: 0.18 },
+      { kind: 'pass', height: 0.5, wallHeight: 0.5 },
+      { kind: 'pass', height: 1, wallHeight: 1 },
+      { kind: 'running', height: 0.18, wallHeight: 0.18 },
     ],
     bottom: 'agent',
+    bottomWall: 'agent',
     drift: false,
     opacity: 1,
     card: null,
   });
   expect(html).toContain('class="cell running"');
   expect(html).toContain('class="vs-slot runslot"'); // shimmer band
-  // the running slot in the cost-bar also uses the gh/0.18 floor.
-  expect(html).toContain('class="cb-slot gh" style="--h:0.180"');
+  // the running slot in the cost-bar also uses the gh/0.18 floor (both metrics).
+  expect(html).toContain('class="cb-slot gh" style="--h:0.180;--hw:0.180"');
   expect(html).toContain('agent'); // phase word, not a cost
   expect(html).not.toContain('$'); // no cost while in flight
 });
@@ -182,6 +204,7 @@ test('running cell renders the queued-phase word verbatim for each phase', () =>
       state: 'running',
       slots: ghostSlots(),
       bottom: phase,
+      bottomWall: phase,
       drift: false,
       opacity: 1,
       card: null,
@@ -198,6 +221,7 @@ test('queued cell carries the queued class and the queued bottom word', () => {
     state: 'queued',
     slots: ghostSlots(),
     bottom: 'queued',
+    bottomWall: 'queued',
     drift: false,
     opacity: 0.5,
     card: null,
@@ -213,11 +237,11 @@ test('a padded <5-window cell left-pads ghosts (newest rightmost)', () => {
   const html = cellHtml(
     doneView({
       slots: [
-        { kind: 'ghost', height: 0.18 },
-        { kind: 'ghost', height: 0.18 },
-        { kind: 'ghost', height: 0.18 },
-        { kind: 'pass', height: 0.4 },
-        { kind: 'pass', height: 1 },
+        { kind: 'ghost', height: 0.18, wallHeight: 0.18 },
+        { kind: 'ghost', height: 0.18, wallHeight: 0.18 },
+        { kind: 'ghost', height: 0.18, wallHeight: 0.18 },
+        { kind: 'pass', height: 0.4, wallHeight: 0.4 },
+        { kind: 'pass', height: 1, wallHeight: 1 },
       ],
     }),
   );
@@ -231,11 +255,11 @@ test('indeterminate and unknown bands map to b-indet / b-unknown', () => {
   const html = cellHtml(
     doneView({
       slots: [
-        { kind: 'ghost', height: 0.18 },
-        { kind: 'ghost', height: 0.18 },
-        { kind: 'ghost', height: 0.18 },
-        { kind: 'indeterminate', height: 0.5 },
-        { kind: 'unknown', height: 1 },
+        { kind: 'ghost', height: 0.18, wallHeight: 0.18 },
+        { kind: 'ghost', height: 0.18, wallHeight: 0.18 },
+        { kind: 'ghost', height: 0.18, wallHeight: 0.18 },
+        { kind: 'indeterminate', height: 0.5, wallHeight: 0.5 },
+        { kind: 'unknown', height: 1, wallHeight: 1 },
       ],
     }),
   );
@@ -254,12 +278,14 @@ test('cellHtml renders the detail card markup when card is present', () => {
           {
             verdict: 'pass',
             cost: '$1.25',
+            wall: '1m18s',
             timestamp: '2026-06-12 00:00',
             run_id: '20260612T000000Z-1a2b',
           },
           {
             verdict: 'fail',
             cost: '$0.90',
+            wall: '2m04s',
             timestamp: '2026-06-12 01:00',
             run_id: '20260612T010000Z-3c4d',
           },
@@ -272,6 +298,10 @@ test('cellHtml renders the detail card markup when card is present', () => {
   expect(html).toContain('class="cell-card-age">3h<');
   expect(html).toContain('class="ccr-verdict v-pass">pass<');
   expect(html).toContain('class="ccr-verdict v-fail">fail<');
+  // the card shows cost AND wall columns (both metrics, always — detail view).
+  expect(html).toContain('class="ccr-cost">$1.25<');
+  expect(html).toContain('class="ccr-wall">1m18s<');
+  expect(html).toContain('class="ccr-wall">2m04s<');
   expect(html).toContain('20260612T000000Z-1a2b');
   expect(html).toContain(
     'class="card-drift">last run cost 1.6× the prior median<',
@@ -293,6 +323,7 @@ test('cellHtml escapes card row run_id and drift_line', () => {
           {
             verdict: 'pass',
             cost: '$1.25',
+            wall: '1m18s',
             timestamp: 't',
             run_id: '<script>',
           },
@@ -454,4 +485,24 @@ test('layoutHtml wires htmx + the SSE extension and references the static assets
   // the slotted bodies are inlined unescaped (already-rendered HTML).
   expect(html).toContain('<b>quorum</b>');
   expect(html).toContain('<table></table>');
+});
+
+test('layoutHtml wires the cost/walltime metric toggle, default cost, FOUC-free init', () => {
+  const html = layoutHtml({
+    tallyHtml: '<b>quorum</b>',
+    gridHtml: '<table></table>',
+  });
+  // metric lives on <html> so the inline head script can set it before paint.
+  expect(html).toContain('data-metric="cost"');
+  // the saved-metric init runs in <head>, before the stylesheet, no FOUC.
+  expect(html).toContain("localStorage.getItem('quorum-metric')");
+  expect(html.indexOf('quorum-metric')).toBeLessThan(
+    html.indexOf('href="/static/styles.css"'),
+  );
+  // the toggle: two segmented buttons keyed by data-metric.
+  expect(html).toContain('class="metric-toggle"');
+  expect(html).toContain('class="mt-btn" data-metric="cost"');
+  expect(html).toContain('class="mt-btn" data-metric="wall"');
+  // tally keeps its swap-target id, now wrapped in a span beside the toggle.
+  expect(html).toContain('<span id="tally"><b>quorum</b></span>');
 });

--- a/test/dashboard-templates.test.ts
+++ b/test/dashboard-templates.test.ts
@@ -280,14 +280,16 @@ test('cellHtml renders the detail card markup when card is present', () => {
             cost: '$1.25',
             wall: '1m18s',
             timestamp: '2026-06-12 00:00',
-            run_id: '20260612T000000Z-1a2b',
+            nonce: '1a2b',
+            run_id: 's-claude-20260612T000000Z-1a2b',
           },
           {
             verdict: 'fail',
             cost: '$0.90',
             wall: '2m04s',
             timestamp: '2026-06-12 01:00',
-            run_id: '20260612T010000Z-3c4d',
+            nonce: '3c4d',
+            run_id: 's-claude-20260612T010000Z-3c4d',
           },
         ],
         drift_line: 'last run cost 1.6× the prior median',
@@ -302,7 +304,14 @@ test('cellHtml renders the detail card markup when card is present', () => {
   expect(html).toContain('class="ccr-cost">$1.25<');
   expect(html).toContain('class="ccr-wall">1m18s<');
   expect(html).toContain('class="ccr-wall">2m04s<');
-  expect(html).toContain('20260612T000000Z-1a2b');
+  // the nonce stands in for the run id; the full id is the copy-on-hover title.
+  expect(html).toContain(
+    'class="ccr-nonce" title="s-claude-20260612T000000Z-1a2b">1a2b<',
+  );
+  // columns flow date · nonce · cost · wall · status, left to right.
+  expect(html.indexOf('ccr-time')).toBeLessThan(html.indexOf('ccr-nonce'));
+  expect(html.indexOf('ccr-nonce')).toBeLessThan(html.indexOf('ccr-cost'));
+  expect(html.indexOf('ccr-wall')).toBeLessThan(html.indexOf('ccr-verdict'));
   expect(html).toContain(
     'class="card-drift">last run cost 1.6× the prior median<',
   );
@@ -325,6 +334,7 @@ test('cellHtml escapes card row run_id and drift_line', () => {
             cost: '$1.25',
             wall: '1m18s',
             timestamp: 't',
+            nonce: 'aaaa',
             run_id: '<script>',
           },
         ],

--- a/test/dashboard-view.test.ts
+++ b/test/dashboard-view.test.ts
@@ -546,6 +546,8 @@ test('cellView: card rows carry compact timestamp + run id', () => {
   expect(row?.cost).toBe('$1.50');
   expect(row?.timestamp).toBe('2026-06-12 13:30');
   expect(row?.run_id).toBe('s-claude-20260612T133000Z-aaaa');
+  // the short nonce (final dir-name segment) is shown in place of the full id.
+  expect(row?.nonce).toBe('aaaa');
 });
 
 test('cellView: card rows carry the wall figure (— when no finished_at)', () => {

--- a/test/dashboard-view.test.ts
+++ b/test/dashboard-view.test.ts
@@ -6,10 +6,12 @@ import {
   costBarHeights,
   driftFlag,
   formatAge,
+  formatWall,
   headerTally,
   latestAgeDays,
   launchEstimate,
   median,
+  runWallMs,
   staleOpacity,
 } from '../src/dashboard/view.ts';
 
@@ -108,6 +110,68 @@ test('formatAge boundaries (integer floor, matching data.py int())', () => {
 
 test('formatAge clamps negatives to 0s', () => {
   expect(formatAge(-5)).toBe('0s');
+});
+
+// --- formatWall --------------------------------------------------------------
+
+test('formatWall: seconds below a minute (rounded)', () => {
+  expect(formatWall(0)).toBe('0s');
+  expect(formatWall(42_000)).toBe('42s');
+  expect(formatWall(59_400)).toBe('59s'); // 59.4s rounds down
+});
+
+test('formatWall: minutes keep a seconds part unless exact', () => {
+  expect(formatWall(60_000)).toBe('1m'); // exact minute drops seconds
+  expect(formatWall(77_000)).toBe('1m17s'); // a 77s run is not a lossy "1m"
+  expect(formatWall(300_000)).toBe('5m');
+});
+
+test('formatWall: hours drop seconds, minutes zero-padded', () => {
+  expect(formatWall(3_600_000)).toBe('1h00m');
+  expect(formatWall(4_781_335)).toBe('1h19m'); // the sdd-svelte-todo haiku run
+});
+
+test('formatWall clamps negative spans to 0s', () => {
+  expect(formatWall(-1000)).toBe('0s');
+});
+
+// --- runWallMs ---------------------------------------------------------------
+
+test('runWallMs is null when finished_at is absent', () => {
+  expect(runWallMs(rec({ finished_at: null }))).toBeNull();
+});
+
+test('runWallMs spans the dir-stamp started_at to the verdict finished_at', () => {
+  // 21:03:13.000 (stamp, second-truncated) -> 22:22:54.335 = 4781335 ms.
+  const ms = runWallMs(
+    rec({
+      started_at: '20260613T210313Z',
+      finished_at: '2026-06-13T22:22:54.335Z',
+    }),
+  );
+  expect(ms).toBe(4_781_335);
+  expect(formatWall(ms as number)).toBe('1h19m');
+});
+
+test('runWallMs is null for a negative span (clock skew)', () => {
+  const ms = runWallMs(
+    rec({
+      started_at: '20260613T230000Z',
+      finished_at: '2026-06-13T22:00:00Z',
+    }),
+  );
+  expect(ms).toBeNull();
+});
+
+test('runWallMs is null when the dir stamp or finished_at is unparseable', () => {
+  expect(
+    runWallMs(
+      rec({ started_at: 'not-a-stamp', finished_at: '2026-06-13T22:00:00Z' }),
+    ),
+  ).toBeNull();
+  expect(
+    runWallMs(rec({ started_at: '20260613T210313Z', finished_at: 'garbage' })),
+  ).toBeNull();
 });
 
 // --- latestAgeDays -----------------------------------------------------------
@@ -298,6 +362,52 @@ test('cellView: done cell with unknown cost shows "$—" (never "$0.00")', () =>
   expect(v.bottom).toBe('$—');
 });
 
+test('cellView: done cell carries bottomWall from finished_at − started_at', () => {
+  const c = cell({
+    window: [
+      rec({
+        started_at: '20260612T000000Z',
+        finished_at: '2026-06-12T00:01:18Z', // 78s
+        cost_usd: 0.21,
+        final: 'pass',
+      }),
+    ],
+  });
+  const v = cellView(c, 's', 'claude');
+  expect(v.bottom).toBe('$0.21');
+  expect(v.bottomWall).toBe('1m18s');
+});
+
+test('cellView: done cell with no finished_at shows wall "—" (never "0s")', () => {
+  const c = cell({ window: [rec({ cost_usd: 1, finished_at: null })] });
+  const v = cellView(c, 's', 'claude');
+  expect(v.bottom).toBe('$1.00');
+  expect(v.bottomWall).toBe('—');
+});
+
+test('cellView: slots carry wall-bar heights normalized to the window wall peak', () => {
+  const c = cell({
+    window: [
+      rec({
+        started_at: '20260612T000000Z',
+        finished_at: '2026-06-12T00:00:30Z', // 30s
+        cost_usd: 4,
+      }),
+      rec({
+        started_at: '20260612T000100Z',
+        finished_at: '2026-06-12T00:02:00Z', // 60s
+        cost_usd: 1,
+      }),
+    ],
+  });
+  const v = cellView(c, 's', 'claude');
+  // cost heights normalize to peak 4: [1, 0.25]; wall heights to peak 60s: [0.5, 1].
+  expect(v.slots[3]?.height).toBe(1);
+  expect(v.slots[4]?.height).toBe(0.25);
+  expect(v.slots[3]?.wallHeight).toBe(0.5);
+  expect(v.slots[4]?.wallHeight).toBe(1);
+});
+
 test('cellView: running on top of history shimmers newest, phase bottom', () => {
   const c = cell({
     window: [rec({ cost_usd: 1, final: 'pass' })],
@@ -384,4 +494,20 @@ test('cellView: card rows carry compact timestamp + run id', () => {
   expect(row?.cost).toBe('$1.50');
   expect(row?.timestamp).toBe('2026-06-12 13:30');
   expect(row?.run_id).toBe('s-claude-20260612T133000Z-aaaa');
+});
+
+test('cellView: card rows carry the wall figure (— when no finished_at)', () => {
+  const c = cell({
+    window: [
+      rec({
+        started_at: '20260612T000000Z',
+        finished_at: '2026-06-12T00:00:45Z', // 45s
+        cost_usd: 1,
+      }),
+      rec({ finished_at: null, cost_usd: 1 }), // no end -> wall unknown
+    ],
+  });
+  const v = cellView(c, 's', 'claude');
+  expect(v.card?.rows[0]?.wall).toBe('45s');
+  expect(v.card?.rows[1]?.wall).toBe('—');
 });

--- a/test/dashboard-view.test.ts
+++ b/test/dashboard-view.test.ts
@@ -24,6 +24,7 @@ function rec(over: Partial<RunRecord> = {}): RunRecord {
     final: 'pass',
     cost_usd: 1,
     finished_at: null,
+    gauntlet_duration_ms: null,
     ...over,
   };
 }
@@ -137,8 +138,47 @@ test('formatWall clamps negative spans to 0s', () => {
 
 // --- runWallMs ---------------------------------------------------------------
 
-test('runWallMs is null when finished_at is absent', () => {
-  expect(runWallMs(rec({ finished_at: null }))).toBeNull();
+test('runWallMs is null when neither finished_at nor a gauntlet span is present', () => {
+  expect(
+    runWallMs(rec({ finished_at: null, gauntlet_duration_ms: null })),
+  ).toBeNull();
+});
+
+test('runWallMs falls back to the gauntlet span when finished_at is absent', () => {
+  const ms = runWallMs(
+    rec({ finished_at: null, gauntlet_duration_ms: 144_696 }),
+  );
+  expect(ms).toBe(144_696);
+  expect(formatWall(ms as number)).toBe('2m25s');
+});
+
+test('runWallMs prefers the precise span over the gauntlet fallback', () => {
+  // finished_at − started_at = 78s; gauntlet says 90s. Precise wins.
+  const ms = runWallMs(
+    rec({
+      started_at: '20260612T000000Z',
+      finished_at: '2026-06-12T00:01:18Z',
+      gauntlet_duration_ms: 90_000,
+    }),
+  );
+  expect(ms).toBe(78_000);
+});
+
+test('runWallMs falls through to the gauntlet span on a negative precise span', () => {
+  const ms = runWallMs(
+    rec({
+      started_at: '20260613T230000Z',
+      finished_at: '2026-06-13T22:00:00Z', // before start -> skip
+      gauntlet_duration_ms: 50_000,
+    }),
+  );
+  expect(ms).toBe(50_000);
+});
+
+test('runWallMs ignores a negative gauntlet span', () => {
+  expect(
+    runWallMs(rec({ finished_at: null, gauntlet_duration_ms: -5 })),
+  ).toBeNull();
 });
 
 test('runWallMs spans the dir-stamp started_at to the verdict finished_at', () => {
@@ -383,6 +423,18 @@ test('cellView: done cell with no finished_at shows wall "—" (never "0s")', ()
   const v = cellView(c, 's', 'claude');
   expect(v.bottom).toBe('$1.00');
   expect(v.bottomWall).toBe('—');
+});
+
+test('cellView: done cell with only a gauntlet span still shows a wall figure', () => {
+  // The common historical case: no top-level finished_at, but economics carries
+  // the Gauntlet-Agent span. The cell shows it instead of "—".
+  const c = cell({
+    window: [
+      rec({ cost_usd: 1, finished_at: null, gauntlet_duration_ms: 77_000 }),
+    ],
+  });
+  const v = cellView(c, 's', 'claude');
+  expect(v.bottomWall).toBe('1m17s');
 });
 
 test('cellView: slots carry wall-bar heights normalized to the window wall peak', () => {


### PR DESCRIPTION
## What

Adds a client-side **cost ($) ⇄ walltime (⏱)** toggle to the quorum web dashboard, plus a grid-height bugfix and hover-card polish. (PRI-2222)

A `[ $ | ⏱ ]` control in the header flips `html[data-metric]` (persisted to `localStorage`, FOUC-free via an inline `<head>` init). Every cell renders **both** figures and **both** bar heights; CSS picks which to show by the active metric — so the toggle is instant, needs no reload, and **survives SSE cell swaps**. Especially useful for runs where obol produced no `$` costing but timing is still known.

## Walltime source

"Walltime" = how long the run took, by a two-step cascade (both express the same thing, so the metric stays consistent across cells):

1. **Precise** — `finished_at − started_at` (top-level verdict timestamps). Survives the no-cost case, but the field is a recent schema addition (~18% of verdicts).
2. **Fallback** — `economics.gauntlet.duration_ms` (the Gauntlet-Agent's span). Populated for ~71% of verdicts and empirically ≈ end-to-end (sample ms pairs `396268/397061`, `144696/145907`, `160390/160907`). It *under*-reports by the setup+capture overhead outside the gauntlet (≈1s warm, up to tens of seconds on cold-provision runs) — an honest coarse signal, far better than `—`.

`coding_agent.duration_ms` is deliberately **not** used (subject's span only ≈ half the run wall — would make the metric lie). `mtime` rejected too (`results/` isn't gitignored → checkout-time noise).

**Live coverage of displayed (done) cells: walltime shown rises from ~18% → 97%** (137/141); the remaining 3% are errored runs with no timing at all.

## Scope of the toggle

- Per-cell bottom figure: `$0.21` ⇄ `1m18s`
- Mini bar-chart: bars re-normalize to the active metric (`--h` cost / `--hw` wall)
- Drift ▲ (a *cost* anomaly): hidden in ⏱ mode
- Hover card: shows cost **and** wall together (detail view), reordered to **date · nonce · cost · wall · status**; the row shows just the short nonce with the full run id as a copy-on-hover `title`
- Left cost-only: launch-estimate chip and run-strip "$ spent" (no honest walltime analog — agent spans overlap, can't sum)

## Also: grid fills the viewport (bugfix)

The grid stopped ~2in short of the viewport bottom — `.mxwrap` was capped at `max-height: 80vh`. Body is now a `100vh` flex column and `.mxwrap` flexes to fill (`min-height:0` + `overflow:auto` keep it the scroll container, so the sticky `<th>` header still works).

## Files

`src/dashboard/`: `contracts.ts`, `view.ts`, `scan.ts`, `templates.ts`, `static/styles.css`, `static/app.js`. Walltime needs only one new read-side field (`gauntlet_duration_ms`); the rest is computed in `view.ts`.

## Verification

- Full TS gate green: `biome ci` + `tsc --noEmit` + **495 tests** (+33 new), 0 fail.
- Rendered against **live `results/`**: cells show e.g. `$0.83 ⇄ 6m5s`, `$18.07 ⇄ 1h04m`; card column order confirmed.
- Adversarial review: a 4-lens workflow (logic / render-XSS-SSE / CSS-visual / parity-scope) on the toggle → **0 confirmed defects**; a follow-up reviewer on the walltime cascade → logic + schema clean, prompted the comment-honesty fix included here.

## Dependency

Stacks on the TS-dashboard PR #21 (PRI-2207). **Base is `matt/pri-2207-quorum-ts-spec2`**; retarget `main` once #21 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
