### PR TITLE
docs(experiments): dev-vs-#1744 SDD cost A/B — merge-grade verdict

### DIFF
--- a/docs/experiments/2026-06-13-pr1744-sdd-cost-ab.md
+++ b/docs/experiments/2026-06-13-pr1744-sdd-cost-ab.md
@@ -1,0 +1,148 @@
+# 2026-06-13: PR #1744 (cost-tiering + plan-mandated-defect escalation + pre-flight plan review) — dev-vs-PR SDD cost A/B
+
+**Question:** Is `obra/superpowers` PR #1744 safe to merge? Does it reduce SDD
+token use / cost vs current `dev` without a quality (pass-rate) regression?
+
+**What #1744 is:** "SDD: cost-tiering stack + plan-mandated-defect escalation +
+pre-flight plan review." Head `sdd-l2b-plan-mandated` @ `08447d0d`, **stacked on
+#1717** (base `sdd-review-dispatch`). So **dev-vs-1744 measures 1717 + 1744
+cumulatively** vs dev — the "ship the whole stack?" question, not 1744's marginal
+effect in isolation. (For the marginal effect, the control arm would be 1717, not
+dev — a separate run if wanted.)
+
+**Why now:** the prerequisite was a *trustworthy* runner. Both blockers are fixed
+and merged to `main`: claude empty-capture (`CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1`,
+PR #16) and codex wrong-skills (HOME isolation, PR #14). The 1717 round's verdict
+flips hinged on measurement artifacts; this round runs on the patched harness.
+
+## Configuration
+
+**Arms** — two detached `obra/superpowers` worktrees, pointed at by `SUPERPOWERS_ROOT`
+(only `skills/` differs):
+
+| Arm | Worktree | Commit |
+|---|---|---|
+| control (dev) | `/Users/drewritter/prime-rad/sp-dev` | `93f2ce91` (= current `dev` tip) |
+| treatment (#1744) | `/Users/drewritter/prime-rad/sp-pr1744` | `08447d0d` (head of `sdd-l2b-plan-mandated`) |
+
+**Harness:** `superpowers-evals` @ `main` (`db37d5f`) — capture fix present, no
+launcher edits needed. **Provider: Anthropic API** (obol prices `opus`/`sonnet`
+natively; not Bedrock). Driver: `quorum run`, arms separated by `--out-root`.
+
+## Pilot (this run)
+
+`sdd-go-fractals-elicited` × claude (`opus`) × **n=1 each arm** — a directional
+screen, not a verdict (cost is run-to-run noisy; n=1 cannot clear the ±20% band).
+- dev  → `results/ab-1744-dev/`
+- #1744 → `results/ab-1744-pr/`
+
+## Metrics & decision rule
+
+- **Primary:** coding tokens per *passing* run (input/output/cache); **secondary:**
+  obol `est_cost_usd`, `duration_ms`. Compare **within model only**. Cost is read
+  only from runs that **pass** the fractals gates; pass-rate is the quality signal.
+- A credible "PR reduces cost" verdict needs median tokens down AND consistent
+  across models/variants AND no pass-rate regression — i.e. the **full matrix**
+  (opus/sonnet/codex × elicited/legacy × n≥3), not this pilot. Expand only if the
+  pilot is directional.
+
+## Pre-registered prediction
+
+#1744's cost-tiering should push more work down-tier (haiku/sonnet implementers) →
+**coding tokens/$ ≤ dev** on `fractals-elicited`, but the plan-mandated-defect
+escalation + pre-flight plan review add up-front controller work, so the net is
+likely **flat-to-slightly-cheaper inside the noise band**, not a large win.
+**Pass-rate holds** (both arms green on the 6 fractals gates). The *quality* payoff
+of #1744 (better defect catch) will **not** show here — `fractals-elicited` is a
+cost scenario, not a planted-defect test; that needs `sdd-escalates-broken-plan` /
+`sdd-quality-reviewer-catches-planted-defect` as a follow-up arm.
+
+## Results
+
+### Pilot (n=1, opus, sdd-go-fractals-elicited)
+
+| arm | final | coding $ | coding tokens | duration | model split |
+|---|---|---|---|---|---|
+| dev (`93f2ce91`) | **pass** | **$7.62** | 8.2M | 29m19s | opus 5.0M / sonnet 3.2M / **no haiku** |
+| #1744 (`08447d0d`) | **pass** | **$5.83** | 8.1M | 22m47s | opus 5.3M / sonnet 585K / **haiku 2.2M** |
+
+**Pilot read (n=1, directional):** #1744 **~24% cheaper** ($5.83 vs $7.62) at
+**equal token volume** (8.1M vs 8.2M) and equal pass. The whole delta is tier
+reassignment — #1744 down-tiers implementers to **haiku** (2.2M tok / $0.49) and
+shrinks sonnet to 585K; dev keeps implementers on **sonnet** (3.2M / $2.53). Same
+work, cheaper models. Capture clean at full SDD scale on both arms (the
+`FORCE_SESSION_PERSISTENCE` fix holds — this exact config was `indeterminate`
+pre-fix). Caveat: the win rides entirely on haiku implementers holding quality,
+which a coarse fractals gate can't fully test → escalation arm below. Separation
+is ~24% (outside the ±20% band even at n=1), but cost is noisy → hardening to n=3.
+
+### Cost — n=3, opus, sdd-go-fractals-elicited (all 6 runs PASS)
+
+| rep | dev — coding $ (tier mix) | #1744 — coding $ (tier mix) |
+|---|---|---|
+| 1 | $7.62 (opus 5.0M + sonnet 3.2M) | $5.83 (opus 5.3M + sonnet 0.6M + **haiku 2.2M**) |
+| 2 | **$10.30 (ALL opus)** | $5.08 (opus 4.3M + sonnet 0.5M + **haiku 1.8M**) |
+| 3 | $7.27 (opus 4.5M + sonnet 3.0M + haiku 1.9M) | $5.77 (opus 4.9M + sonnet 0.5M + **haiku 2.0M**) |
+| **median** | **$7.62** | **$5.77** |
+| **mean** | **$8.40** | **$5.56** |
+| range | $7.27 – $10.30 | $5.08 – $5.83 |
+
+### Quality — sdd-escalates-broken-plan, n=1 each (both PASS)
+
+| arm | result | $ | defect gate (`repeat(40)` present, `repeat(30)` absent) |
+|---|---|---|---|
+| dev | **pass** | $2.09 | ✓ caught/corrected the planted broken-plan defect |
+| #1744 | **pass** | $2.16 | ✓ caught/corrected the planted broken-plan defect |
+
+### Cost — sonnet & codex, n=3, sdd-go-fractals-elicited (all PASS)
+
+| rep | dev-sonnet | #1744-sonnet | dev-codex | #1744-codex |
+|---|---|---|---|---|
+| 1 | $4.89 (all sonnet) | $3.19 | $16.86 (all gpt) | $5.99 |
+| 2 | $5.27 (all sonnet) | $3.20 | $19.36 (all gpt) | $7.93 |
+| 3 | $3.82 (sonnet+haiku) | $3.12 | $18.05 (all gpt) | $8.63 |
+| **median** | **$4.89** | **$3.19** | **$18.05** | **$7.93** |
+
+### Cross-model summary (elicited, median coding $/run; escalate = sdd-escalates-broken-plan)
+
+| model | dev median | #1744 median | Δ median | overlap | escalate dev → #1744 |
+|---|---|---|---|---|---|
+| opus | $7.62 | $5.77 | **−24%** | none (5.83 < 7.27) | pass → pass |
+| sonnet | $4.89 | $3.19 | **−35%** | none (3.20 < 3.82) | pass → pass |
+| codex | $18.05 | $7.93 | **−56%** | none (8.63 < 16.86) | **FAIL → pass** |
+
+## Verdict — MERGE-GRADE GREEN
+
+**#1744 reduces SDD cost across all three models — 24% / 35% / 56% cheaper at the
+median, non-overlapping in every model** (PR's *worst* run beats dev's *best*,
+every time). That clears the 1717 protocol's bar: "credible PR-reduces-cost iff
+median down AND consistent across all three models AND no pass-rate regression."
+And it **improves quality** — every escalation arm passed except **dev-codex,
+which shipped the planted broken-plan defect (`repeat(30)` survived); #1744-codex
+caught it.** Only failure in 22 runs.
+
+- **Mechanism:** #1744's cost-tiering down-tiers *implementers* to the cheapest
+  capable tier — **haiku** for claude, a **cheaper gpt tier** for codex —
+  *consistently*. dev's tier choice is a **run-to-run lottery** (opus stayed
+  all-opus once at $10.30; dev-codex ran everything on the expensive gpt tier,
+  $16–19). #1744 wins on level **and** predictability.
+- **Correction to the pilot prediction:** I expected codex to show *no* cost win
+  (the haiku lever being claude-specific). **Wrong** — codex showed the **largest**
+  win (−56%): the tiering generalizes to codex's gpt ladder, and dev-codex's
+  un-tiered baseline was the single most expensive arm.
+- **Quality is where #1744 earns its keep on codex:** the plan-mandated-defect
+  escalation + pre-flight review caught a broken plan that dev-codex implemented
+  as-is. On opus/sonnet both arms already caught it → there #1744 is "cheaper at
+  equal quality"; on codex it's "cheaper *and* safer."
+
+**Limits (honest):** the cost result is solid (n=3, non-overlapping, all 3 models).
+The **escalation result is n=1 per cell**, so the dev-codex miss is a strong signal
+but not yet proven systematic — **2–3 more codex-escalate reps per arm** would
+confirm it isn't run-to-run variance. Comparison is **within-model** (opus/sonnet
+on Anthropic API, codex on gpt/subscription) and **cumulative** (dev vs 1717+1744,
+not 1744's marginal effect). Legacy `sdd-go-fractals` variant not run (elicited is
+the realistic fixture).
+
+**Recommendation: merge #1744.** Cheaper on every model, no regression anywhere,
+and a real defect-catch win on codex. Optional pre-merge hardening: a few more
+codex-escalate reps to lock the quality claim.


### PR DESCRIPTION
Records the dev-vs-PR-#1744 SDD cost A/B campaign run on the **capture-patched** runner (#14 + #16) — the data was untrustworthy before today (claude → silent `indeterminate`, codex → wrong skills).

## Result: merge-grade green for superpowers #1744
22 runs, opus/sonnet/codex × dev vs #1744 (stacked on #1717), `sdd-go-fractals-elicited` (cost, n=3) + `sdd-escalates-broken-plan` (quality, n=1).

| model | dev median $ | #1744 median $ | Δ | overlap | escalate dev→#1744 |
|---|---|---|---|---|---|
| opus | 7.62 | 5.77 | −24% | none | pass→pass |
| sonnet | 4.89 | 3.19 | −35% | none | pass→pass |
| codex | 18.05 | 7.93 | −56% | none | **FAIL→pass** |

- **Cost:** #1744 cheaper across all three models, **non-overlapping** (PR's worst run beats dev's best, every model) — clears the protocol's "consistent across all three models" bar.
- **Quality:** only failure in 22 runs is **dev-codex escalate** (shipped the broken plan's `repeat(30)` defect); **#1744-codex caught it**. #1744 ≥ dev everywhere, strictly better on codex.
- **Mechanism:** #1744 down-tiers implementers consistently (haiku for claude, cheaper gpt for codex); dev's tiering is a run-to-run lottery.

**Limits:** escalation is n=1/cell (dev-codex miss is a strong signal, not yet proven systematic — a few more codex-escalate reps would lock it); within-model comparison; cumulative (dev vs 1717+1744). Run artifacts under `results/` are gitignored (transcripts/cost data not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)