### PR TITLE
Add serf coding-agent harness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ messages.
 
 | Actor | What it is | Where it lives / its files |
 |---|---|---|
-| **Gauntlet** | General-purpose QA framework; the `gauntlet` CLI. A black-box tester. | repo `~/Code/prime/gauntlet`; on `PATH` as `gauntlet` |
+| **Gauntlet** | General-purpose QA framework; the `gauntlet` CLI. A black-box tester. | repo `github.com/prime-radiant-inc/gauntlet`; on `PATH` as `gauntlet` (via `bun link` or `GAUNTLET_ROOT`) |
 | **Gauntlet-Agent** | The LLM inside Gauntlet that drives the Coding-Agent and self-grades against the story's ACs. | model e.g. `claude-sonnet-4-6`; event stream -> `<run>/gauntlet-agent/results/<runId>/run.jsonl`; verdict -> `result.{json,md}` |
 | **Coding-Agent** | The agent under test. Instances: **Claude**, **Claude Haiku**, **Claude Sonnet**, **Codex**, **Antigravity**, **Gemini**, **Kimi**, **OpenCode**, **Pi**, and **Copilot**. | session log -> under the per-run throwaway `$HOME` (`<run>/home/<agent-config-subdir>/...`, e.g. `.claude`/`.codex`); files it writes -> `<run>/coding-agent-workdir/` |
 | **Quorum** | The TypeScript wrapper. Owns setup, Coding-Agent adaptation, deterministic checks, and final verdict composition. | repo `superpowers-evals/src/`; `<run>/verdict.json` |

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ messages.
 
 | Actor | What it is | Where it lives / its files |
 |---|---|---|
-| **Gauntlet** | General-purpose QA framework; the `gauntlet` CLI. A black-box tester. | repo `~/Code/prime/gauntlet`; on `PATH` as `gauntlet` |
+| **Gauntlet** | General-purpose QA framework; the `gauntlet` CLI. A black-box tester. | repo `github.com/prime-radiant-inc/gauntlet`; on `PATH` as `gauntlet` (via `bun link` or `GAUNTLET_ROOT`) |
 | **Gauntlet-Agent** | The LLM *inside* Gauntlet that drives the Coding-Agent and self-grades against the story's ACs. | model e.g. `claude-sonnet-4-6`; event stream → `<run>/gauntlet-agent/results/<runId>/run.jsonl`; verdict → `result.{json,md}` |
 | **Coding-Agent** | The agent under test — the SUT. Instances: **Claude**, **Claude Haiku**, **Claude Sonnet**, **Codex**, **Antigravity**, **Gemini**, **Kimi**, **OpenCode**, **Pi**, **Copilot**. | config + session log under its throwaway `$HOME` at `<run>/home/…`; the files it writes → `<run>/coding-agent-workdir/` |
 | **Quorum** | The TypeScript/Bun wrapper. Owns setup, Coding-Agent adaptation, deterministic checks, and the final verdict. | repo `superpowers-evals/src/`; `<run>/verdict.json` |

--- a/coding-agents/serf-context/HOWTO.md
+++ b/coding-agents/serf-context/HOWTO.md
@@ -1,0 +1,77 @@
+# How to drive serf (the agent under test)
+
+You are driving **serf** in a bash shell inside tmux. serf is itself an AI
+coding agent; its output is its work.
+
+serf is **non-interactive and one-shot**: you give it the task as a single
+argument, and it runs the entire task autonomously — reading files, writing
+files, running commands, and calling tools in a loop — until the work is done,
+then it exits back to the shell prompt. There is no REPL to type into
+turn-by-turn.
+
+## Launch serf with the task as one argument
+
+Your bash starts in a scratch directory, NOT the workdir quorum prepared.
+quorum has generated a launcher that handles everything: it cds into the
+prepared workdir, pins an isolated `$HOME` for the run, points serf's
+`--plugin-dir` at the Superpowers plugin, pins the model, writes serf's native
+ATIF trajectory via `--export-atif`, and isolates serf's provider config and
+state. Pass the task you want serf to do as a single quoted argument:
+
+```
+"$QUORUM_LAUNCH_AGENT" 'Describe the task here, e.g. build a React todo list'
+```
+
+That path is burned into this HOWTO at runtime by quorum; it points at a
+generated executable that runs, in effect:
+
+```
+cd <prepared-workdir> && env -i PATH=<path> HOME=<per-run-isolated-home> ... \
+  SERF_PROVIDERS_CONFIG=<home>/.serf/providers.toml \
+  serf --model <model> --plugin-dir <superpowers-root> \
+       --export-atif <home>/.serf/exports/trajectory.json \
+       --dir <prepared-workdir> --state-dir <home>/.serf \
+       'Describe the task here'
+```
+
+Do not hand-type a bare `serf` or reconstruct the command yourself — the cd,
+isolated environment, plugin dir, model, and export path live inside the
+launcher. Pass only your task string as the argument.
+
+## Following up (answering serf's questions or giving more direction)
+
+serf may finish a turn by asking you a question or reporting back (for example,
+a brainstorming step will ask clarifying questions before writing code). serf
+runs one-shot, so it exits after the turn. To continue the same session —
+answering its questions or steering it — run the launcher again with
+`--resume-last` before your reply:
+
+```
+"$QUORUM_LAUNCH_AGENT" --resume-last 'Your answer or next instruction'
+```
+
+`--resume-last` resumes the most recent serf session from the same isolated
+state, so the conversation continues with full context. Repeat as needed until
+the scenario objective is met.
+
+## Observing what serf is doing
+
+serf streams its progress (thinking, tool calls, results) to the terminal while
+it runs. Wait for it to finish and return to the shell prompt rather than
+interrupting it.
+
+serf writes its native ATIF v1.7 trajectory to:
+
+```
+$QUORUM_AGENT_HOME/.serf/exports/trajectory.json
+```
+
+Each invocation (including `--resume-last`) rewrites that file with the full
+session, so after the final turn it holds the complete trajectory. That file is
+the ground truth for tool calls and is what quorum normalizes into the run's
+`trajectory.json`.
+
+## Shutdown
+
+serf exits on its own after each turn. Once the scenario objective is complete,
+no explicit shutdown is needed.

--- a/coding-agents/serf-context/launch-agent
+++ b/coding-agents/serf-context/launch-agent
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# quorum-generated launcher for serf (the agent under test).
+#
+# serf is a NON-INTERACTIVE, one-shot coding agent: give it the task as an
+# argument and it runs the whole task autonomously (many tool rounds) until done,
+# then exits. There is no REPL to drive turn-by-turn. The QA agent passes the
+# task as a single argument; it arrives here as "$@" and is forwarded to serf.
+#
+# Baked in here (quorum substitutes the $… values at runtime, so the installed
+# copy holds literal absolute paths — tmux strips env from new sessions):
+#   - cd into the prepared workdir
+#   - an isolated $HOME via $QUORUM_HOME_ENV (all serf state under <home>/.serf)
+#   - --plugin-dir pointed straight at SUPERPOWERS_ROOT (like the claude
+#     launcher); serf loads the unmodified Superpowers Claude Code plugin and the
+#     SessionStart bootstrap auto-triggers skills
+#   - --export-atif: serf writes its native ATIF v1.7 trajectory here; capture
+#     normalizes it
+#   - the model pin from serf.yaml ($SERF_MODEL)
+#
+# SERF_PROVIDERS_CONFIG points at a fresh (nonexistent) per-run path so serf
+# re-seeds its provider instances from the environment (ANTHROPIC_API_KEY)
+# rather than reading a host ~/.serf/providers.toml that may not declare the
+# provider. serf reads the API key from the environment; only the keys actually
+# present are forwarded into the otherwise-clean env.
+set -euo pipefail
+cd "$QUORUM_AGENT_CWD" || { echo "launch-agent: cannot cd to $QUORUM_AGENT_CWD" >&2; exit 1; }
+
+env_args=(
+  "PATH=${PATH:-/usr/bin:/bin:/usr/sbin:/sbin}"
+  "TERM=${TERM:-xterm-256color}"
+  "LANG=${LANG:-C.UTF-8}"
+)
+for name in \
+  ANTHROPIC_API_KEY OPENAI_API_KEY \
+  GEMINI_API_KEY GOOGLE_API_KEY OPENROUTER_API_KEY; do
+  if [[ -n "${!name-}" ]]; then
+    env_args+=("$name=${!name}")
+  fi
+done
+
+exec env -i \
+  "${env_args[@]}" \
+  $QUORUM_HOME_ENV \
+  SERF_PROVIDERS_CONFIG="$QUORUM_AGENT_HOME/.serf/providers.toml" \
+  serf \
+    --model "$SERF_MODEL" \
+    --plugin-dir "$SUPERPOWERS_ROOT" \
+    --export-atif "$QUORUM_AGENT_HOME/.serf/exports/trajectory.json" \
+    --dir "$QUORUM_AGENT_CWD" \
+    --state-dir "$QUORUM_AGENT_HOME/.serf" \
+    "$@"

--- a/coding-agents/serf.yaml
+++ b/coding-agents/serf.yaml
@@ -1,0 +1,22 @@
+name: serf
+runtime_family: serf
+binary: serf
+# serf's config/state collapse into the throwaway $HOME at <runHome>/.serf: the
+# launcher pins HOME via $QUORUM_HOME_ENV and passes --state-dir
+# "$QUORUM_AGENT_HOME/.serf", so serf keeps all per-run state there.
+home_config_subdir: ".serf"
+# serf writes its native ATIF trajectory via --export-atif into this dir; capture
+# diffs the dir against a pre-run snapshot and normalizes the new file.
+session_log_dir: "${QUORUM_AGENT_HOME}/.serf/exports"
+session_log_glob: "*.json"
+normalizer: serf
+required_env:
+  - ANTHROPIC_API_KEY
+  - SUPERPOWERS_ROOT
+max_time: 10m
+# Pinned to Claude Sonnet for now; the adapter is model-agnostic, so additional
+# provider/model variants are just sibling YAMLs (serf-gpt5.yaml, …) reusing
+# SerfAgent with a different model pin.
+model: anthropic/claude-sonnet-4-6
+max_concurrency: 1
+os_support: [linux]

--- a/docs/superpowers/specs/2026-05-22-harness-model-design.md
+++ b/docs/superpowers/specs/2026-05-22-harness-model-design.md
@@ -26,7 +26,7 @@ names are used everywhere — docs, CLI output, code, filenames, commit messages
 
 | Actor | What it is | Where it lives / its files |
 |---|---|---|
-| **Gauntlet** | General-purpose QA framework; the `gauntlet` CLI. A black-box tester. | repo `~/Code/prime/gauntlet`; on `PATH` as `gauntlet` |
+| **Gauntlet** | General-purpose QA framework; the `gauntlet` CLI. A black-box tester. | repo `github.com/prime-radiant-inc/gauntlet`; on `PATH` as `gauntlet` (via `bun link` or `GAUNTLET_ROOT`) |
 | **Gauntlet-Agent** | The LLM *inside* Gauntlet that drives the system-under-test and self-grades against the story's ACs. | model e.g. `claude-sonnet-4-6`; event stream → `<run>/gauntlet-agent/results/<runId>/run.jsonl`; verdict → `result.{json,md}` |
 | **Coding-Agent** | The agent under test — the SUT. Instances: **Claude**, **Codex**; future **Gemini**, **Pi**. | session log → `<run>/coding-agent-config/…`; the files it writes → `<run>/coding-agent-workdir/` |
 | **Harness** | The Python wrapper. Owns setup, Coding-Agent adaptation, the deterministic checks, and the final verdict. | repo `superpowers-evals/harness/`; `<run>/verdict.json` |

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -14,6 +14,7 @@ import { KimiAgent } from './kimi.ts';
 import { OpenCodeAgent } from './opencode.ts';
 import { PiAgent } from './pi.ts';
 import { writePrivateFileNoFollow } from './private-file.ts';
+import { SerfAgent } from './serf.ts';
 
 /** The isolated home a run hands an agent to provision. Absence is undefined
  *  (§5.5): a missing skeleton root is undefined, never null. */
@@ -192,6 +193,7 @@ const CUSTOM_AGENTS: Readonly<
   opencode: (config) => new OpenCodeAgent(config),
   kimi: (config) => new KimiAgent(config),
   antigravity: (config) => new AntigravityAgent(config),
+  serf: (config) => new SerfAgent(config),
 };
 
 /** Resolve the agent implementation for a config.

--- a/src/agents/serf.ts
+++ b/src/agents/serf.ts
@@ -1,0 +1,84 @@
+import { mkdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import type { AgentConfig } from '../contracts/agent-config.ts';
+import { envSnapshot, getEnv } from '../env.ts';
+import { type CodingAgent, ProvisionError, type RunHome } from './index.ts';
+
+// Serf provisioning adapter. Like the Claude adapter, serf loads Superpowers by
+// pointing `--plugin-dir` straight at SUPERPOWERS_ROOT (no staging into the
+// isolated home), so provision() is deliberately light: create the isolated
+// config dir, fail fast when the binary is missing or SUPERPOWERS_ROOT is
+// misconfigured, and let the launcher wire auth + the model. serf reads its API
+// key from the environment (ANTHROPIC_API_KEY for the default Sonnet pin) and
+// re-seeds its provider instances from that env because the launcher points
+// SERF_PROVIDERS_CONFIG at a fresh per-run path.
+
+// Plugin files SUPERPOWERS_ROOT must contain for serf to load Superpowers and
+// auto-trigger skills (the SessionStart bootstrap + the two skills the
+// acceptance test exercises).
+const SERF_REQUIRED_SUPERPOWERS_FILES: readonly string[] = [
+  '.claude-plugin/plugin.json',
+  'hooks/hooks.json',
+  'hooks/run-hook.cmd',
+  'hooks/session-start',
+  'skills/using-superpowers/SKILL.md',
+  'skills/brainstorming/SKILL.md',
+];
+
+function isFile(path: string): boolean {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+// Real PATH lookup. Bun.which resolves an actual PATH entry; a `command -v`
+// probe ENOENTs through the no-shell spawn seam and false-fails on Linux. Matches
+// the copilot/opencode adapters.
+function binaryOnPath(binary: string): boolean {
+  return Bun.which(binary, { PATH: envSnapshot()['PATH'] ?? '' }) !== null;
+}
+
+export class SerfAgent implements CodingAgent {
+  readonly config: AgentConfig;
+
+  constructor(config: AgentConfig) {
+    // erasableSyntaxOnly forbids a parameter property; assign in the body.
+    this.config = config;
+  }
+
+  provision(home: RunHome): Record<string, string> {
+    mkdirSync(home.configDir, { recursive: true });
+    // Pre-create the ATIF export dir so the pre-run capture snapshot sees a
+    // clean, empty dir (serf's --export-atif also MkdirAll's it, but the
+    // snapshot is taken before serf runs).
+    mkdirSync(join(home.configDir, 'exports'), { recursive: true });
+
+    if (!binaryOnPath(this.config.binary)) {
+      throw new ProvisionError(
+        `${this.config.binary} not found on PATH; cannot run serf evals`,
+      );
+    }
+
+    const superpowersRoot = getEnv('SUPERPOWERS_ROOT') ?? '';
+    if (superpowersRoot === '') {
+      throw new ProvisionError(
+        'SUPERPOWERS_ROOT not set; cannot point serf --plugin-dir at Superpowers',
+      );
+    }
+    const root = resolve(superpowersRoot);
+    const missing = SERF_REQUIRED_SUPERPOWERS_FILES.filter(
+      (rel) => !isFile(join(root, rel)),
+    );
+    if (missing.length > 0) {
+      throw new ProvisionError(
+        `SUPERPOWERS_ROOT is missing required Superpowers plugin files: ${missing.join(', ')}`,
+      );
+    }
+
+    // No extra env: the launcher forwards ANTHROPIC_API_KEY, sets a fresh
+    // SERF_PROVIDERS_CONFIG, and bakes the model/plugin-dir/export-atif flags.
+    return {};
+  }
+}

--- a/src/capture/index.ts
+++ b/src/capture/index.ts
@@ -27,6 +27,7 @@ import { normalizeOpencode } from '../normalize/opencode.ts';
 import { normalizeOpenhands } from '../normalize/openhands.ts';
 import { normalizePi } from '../normalize/pi.ts';
 import { normalizeQwen } from '../normalize/qwen.ts';
+import { normalizeSerf } from '../normalize/serf.ts';
 import { normalizeSweAgent } from '../normalize/swe-agent.ts';
 import { normalizeTrae } from '../normalize/trae.ts';
 import { estimateTrajectory, kimiToolResultTotalBytes } from '../obol/index.ts';
@@ -58,6 +59,7 @@ const NORMALIZERS: Record<string, AtifNormalizer> = {
   openhands: normalizeOpenhands,
   pi: normalizePi,
   qwen: normalizeQwen,
+  serf: normalizeSerf,
   'swe-agent': normalizeSweAgent,
   trae: normalizeTrae,
 };

--- a/src/capture/index.ts
+++ b/src/capture/index.ts
@@ -621,11 +621,56 @@ function isoToMs(ts: string): number | null {
   return Number.isNaN(ms) ? null : ms;
 }
 
+/** Collect epoch-ms time points from one parsed value into `points`: an ISO-8601
+ *  `timestamp` string (Claude/Codex, parsed via isoToMs) and a numeric epoch-ms
+ *  `time` value (Kimi; booleans excluded). Non-objects are ignored. */
+function collectTimePoints(value: unknown, points: number[]): void {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return;
+  }
+  const row = value as Record<string, unknown>;
+  const ts = row['timestamp'];
+  if (typeof ts === 'string') {
+    const ms = isoToMs(ts);
+    if (ms !== null) {
+      points.push(ms);
+    }
+  }
+  const t = row['time'];
+  if (typeof t === 'number') {
+    points.push(t);
+  }
+}
+
+/** Recursively collect time points from an arbitrarily nested parsed JSON
+ *  document. Used for the single-object (ATIF export) fallback where timestamps
+ *  live on `steps[]` elements rather than on top-level rows. */
+function collectTimePointsDeep(value: unknown, points: number[]): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectTimePointsDeep(item, points);
+    }
+    return;
+  }
+  if (typeof value !== 'object' || value === null) {
+    return;
+  }
+  collectTimePoints(value, points);
+  for (const nested of Object.values(value as Record<string, unknown>)) {
+    if (typeof nested === 'object' && nested !== null) {
+      collectTimePointsDeep(nested, points);
+    }
+  }
+}
+
 /** First-to-last timestamp span (ms) across the given session logs, or null when
  *  no timestamps are found. Scans every JSONL row for an ISO-8601 `timestamp`
  *  string (Claude/Codex, parsed via isoToMs) AND a numeric epoch-ms `time` value
- *  (Kimi; booleans excluded), then returns max(max - min, 0). Unreadable files,
- *  blank/non-JSON lines, and non-object rows are skipped. */
+ *  (Kimi; booleans excluded), then returns max(max - min, 0). When a file yields
+ *  no points line-by-line, it is re-parsed as a single JSON document and walked
+ *  recursively (serf's ATIF export is one pretty-printed object whose `steps[]`
+ *  carry ISO timestamps). Unreadable files, blank/non-JSON lines, and non-object
+ *  rows are skipped. */
 export function sessionDurationMs(files: readonly string[]): number | null {
   const points: number[] = [];
   for (const filePath of files) {
@@ -635,6 +680,7 @@ export function sessionDurationMs(files: readonly string[]): number | null {
     } catch {
       continue;
     }
+    const before = points.length;
     for (const line of text.split('\n')) {
       if (line.trim() === '') {
         continue;
@@ -645,20 +691,13 @@ export function sessionDurationMs(files: readonly string[]): number | null {
       } catch {
         continue;
       }
-      if (typeof rec !== 'object' || rec === null || Array.isArray(rec)) {
-        continue;
-      }
-      const row = rec as Record<string, unknown>;
-      const ts = row['timestamp'];
-      if (typeof ts === 'string') {
-        const ms = isoToMs(ts);
-        if (ms !== null) {
-          points.push(ms);
-        }
-      }
-      const t = row['time'];
-      if (typeof t === 'number') {
-        points.push(t);
+      collectTimePoints(rec, points);
+    }
+    if (points.length === before) {
+      try {
+        collectTimePointsDeep(JSON.parse(text), points);
+      } catch {
+        // Not a single JSON document either; leave this file contributing nothing.
       }
     }
   }

--- a/src/check/fs-verbs.ts
+++ b/src/check/fs-verbs.ts
@@ -767,6 +767,7 @@ const BOOTSTRAP_NO_CHECK = new Set([
   'claude-sonnet',
   'claude-windows',
   'pi',
+  'serf',
 ]);
 
 export function verbBootstrapInstalled(

--- a/src/contracts/agent-config.ts
+++ b/src/contracts/agent-config.ts
@@ -19,6 +19,7 @@ const KNOWN_RUNTIME_FAMILIES: ReadonlySet<string> = new Set([
   'kimi',
   'opencode',
   'pi',
+  'serf',
 ]);
 
 export const AgentConfigSchema = z.object({

--- a/src/normalize/serf.ts
+++ b/src/normalize/serf.ts
@@ -64,7 +64,9 @@ function canonicalizeSerfToolCall(tc: AtifToolCall): AtifToolCall {
   return next;
 }
 
-function canonicalizeStepToolCalls(step: Record<string, unknown>): unknown {
+function canonicalizeStepToolCalls(
+  step: Record<string, unknown>,
+): Record<string, unknown> {
   const toolCalls = step['tool_calls'];
   if (!Array.isArray(toolCalls)) {
     return step;
@@ -77,6 +79,31 @@ function canonicalizeStepToolCalls(step: Record<string, unknown>): unknown {
         : tc,
     ),
   };
+}
+
+// serf records cache-creation tokens under `metrics.extra.cache_write_tokens`,
+// but obol prices cache-creation from the canonical `step.extra.cache_write` key
+// (the same key the claude normalizer writes — src/normalize/claude.ts). Lift it
+// onto step.extra so serf's cost isn't undercounted by the cache-creation
+// (most-expensive) token class.
+function liftSerfCacheWrite(
+  step: Record<string, unknown>,
+): Record<string, unknown> {
+  const metrics = step['metrics'];
+  if (metrics === null || typeof metrics !== 'object' || Array.isArray(metrics))
+    return step;
+  const mExtra = (metrics as Record<string, unknown>)['extra'];
+  if (mExtra === null || typeof mExtra !== 'object' || Array.isArray(mExtra))
+    return step;
+  const cacheWrite = (mExtra as Record<string, unknown>)['cache_write_tokens'];
+  if (typeof cacheWrite !== 'number' || cacheWrite <= 0) return step;
+  const existing =
+    step['extra'] !== null &&
+    typeof step['extra'] === 'object' &&
+    !Array.isArray(step['extra'])
+      ? (step['extra'] as Record<string, unknown>)
+      : {};
+  return { ...step, extra: { ...existing, cache_write: cacheWrite } };
 }
 
 /**
@@ -120,7 +147,9 @@ export function normalizeSerf(raw: string, version: string): AtifTrajectory {
     agent,
     steps: steps.map((step) =>
       step !== null && typeof step === 'object' && !Array.isArray(step)
-        ? canonicalizeStepToolCalls(step as Record<string, unknown>)
+        ? canonicalizeStepToolCalls(
+            liftSerfCacheWrite(step as Record<string, unknown>),
+          )
         : step,
     ),
   } as AtifTrajectory;

--- a/src/normalize/serf.ts
+++ b/src/normalize/serf.ts
@@ -1,0 +1,136 @@
+import type { AtifToolCall, AtifTrajectory } from '../atif/types.ts';
+import { validateTrajectory } from '../atif/validate.ts';
+import { canonicalizeAgentPrompt } from './agent-prompt.ts';
+
+// serf emits ATIF v1.7 natively (serf#8), so this normalizer is a
+// near-passthrough: it parses serf's own export, canonicalizes tool names/args,
+// and re-validates. It never rebuilds the trajectory from a raw session log.
+//
+// serf records native tool names in `function_name` (use_skill, delegate, bash,
+// …). ATIF's `function_name` is free-form and Harbor preserves native names, so
+// canonicalizing to quorum's cross-harness vocabulary is the consumer's job —
+// the same contract every other quorum normalizer honors. serf's file/shell args
+// already use canonical keys (file_path, content, command, pattern), so only the
+// tool name and the two dispatch keys (Skill's `skill`, Agent's `prompt`) need
+// aliasing.
+const SERF_TOOL_MAP: Record<string, string> = {
+  use_skill: 'Skill',
+  delegate: 'Agent',
+  bash: 'Bash',
+  shell: 'Bash',
+  read_file: 'Read',
+  write_file: 'Write',
+  edit_file: 'Edit',
+  apply_patch: 'Edit',
+  grep: 'Grep',
+  glob: 'Glob',
+  web_fetch: 'WebFetch',
+  web_search: 'WebSearch',
+};
+
+// Canonicalize one serf tool call: remap the native function_name, then ADD the
+// cross-harness dispatch arg aliases (Skill's `skill`, Agent's `prompt`). The
+// native args survive untouched — we only add canonical keys.
+function canonicalizeSerfToolCall(tc: AtifToolCall): AtifToolCall {
+  const canonical = SERF_TOOL_MAP[tc.function_name] ?? tc.function_name;
+  let next: AtifToolCall = { ...tc, function_name: canonical };
+
+  if (canonical === 'Skill') {
+    const raw = next.arguments['skill_name'];
+    const skillName = typeof raw === 'string' ? raw : '';
+    if (skillName) {
+      next = {
+        ...next,
+        arguments: {
+          ...next.arguments,
+          // The transcript checks compare against the fully-qualified skill ref
+          // (e.g. `superpowers:brainstorming`); serf emits it qualified already,
+          // but prefix a bare name defensively.
+          skill: skillName.includes(':')
+            ? skillName
+            : `superpowers:${skillName}`,
+          name: skillName.split(':').slice(-1)[0] ?? skillName,
+        },
+      };
+    }
+  }
+
+  if (canonical === 'Agent') {
+    // serf's `delegate` carries the dispatch instruction under `task`; the shared
+    // helper renames it to the canonical `prompt`.
+    next = canonicalizeAgentPrompt(next);
+  }
+
+  return next;
+}
+
+function canonicalizeStepToolCalls(step: Record<string, unknown>): unknown {
+  const toolCalls = step['tool_calls'];
+  if (!Array.isArray(toolCalls)) {
+    return step;
+  }
+  return {
+    ...step,
+    tool_calls: toolCalls.map((tc) =>
+      tc !== null && typeof tc === 'object' && !Array.isArray(tc)
+        ? canonicalizeSerfToolCall(tc as AtifToolCall)
+        : tc,
+    ),
+  };
+}
+
+/**
+ * Convert serf's native ATIF v1.7 export into quorum's canonical ATIF.
+ *
+ * serf already emits a valid ATIF-v1.7 document (root `schema_version`,
+ * `agent`, `steps[]`), so we preserve the whole trajectory and only rewrite
+ * tool-call names/args into the canonical vocabulary, then re-validate. A
+ * non-JSON or non-conformant export is a fail-closed error (capture maps a
+ * normalizer throw to indeterminate, never a silent pass). `version` is the
+ * capture-supplied fallback; serf records its own `agent` block, which we keep.
+ */
+export function normalizeSerf(raw: string, version: string): AtifTrajectory {
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    throw new Error('normalizeSerf: serf ATIF export is not valid JSON');
+  }
+  if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+    throw new Error('normalizeSerf: serf ATIF export is not an object');
+  }
+
+  const obj = data as Record<string, unknown>;
+  const steps = obj['steps'];
+  if (!Array.isArray(steps)) {
+    throw new Error('normalizeSerf: serf ATIF export has no steps array');
+  }
+
+  // Preserve serf's own agent block (its real name/build version); fall back to
+  // the capture-supplied version only if serf omitted it.
+  const agent =
+    obj['agent'] !== null &&
+    typeof obj['agent'] === 'object' &&
+    !Array.isArray(obj['agent'])
+      ? { name: 'serf', version, ...(obj['agent'] as Record<string, unknown>) }
+      : { name: 'serf', version };
+
+  const traj = {
+    ...obj,
+    agent,
+    steps: steps.map((step) =>
+      step !== null && typeof step === 'object' && !Array.isArray(step)
+        ? canonicalizeStepToolCalls(step as Record<string, unknown>)
+        : step,
+    ),
+  } as AtifTrajectory;
+
+  const result = validateTrajectory(traj);
+  if (!result.ok) {
+    throw new Error(
+      `normalizeSerf produced invalid ATIF: ${result.errors.join('; ')}`,
+    );
+  }
+
+  return traj;
+}

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -1229,6 +1229,13 @@ async function runInnerBody(
   if (cfg.name === 'pi') {
     substitutions['$PI_ENV_FILE'] = join(configDir, 'pi.env');
   }
+  if (family === 'serf') {
+    // serf's launcher bakes `--model "$SERF_MODEL"`; resolve it from the YAML
+    // model pin, mirroring the $CLAUDE_MODEL pattern. The model-agnostic adapter
+    // keeps the provider/model entirely in serf.yaml.
+    substitutions['$SERF_MODEL'] = cfg.model ?? '';
+    substitutions['$SERF_MODEL_SH'] = shellSingleQuote(cfg.model ?? '');
+  }
   if (cfg.name === 'copilot' && copilotProvisioning !== undefined) {
     // Use the provisioning record's env file + minted session id so the
     // launcher's `--session-id "$QUORUM_COPILOT_SESSION_ID"` resolves and the
@@ -1255,9 +1262,13 @@ async function runInnerBody(
     codingAgent: contextDirName(cfg, os),
     runDir,
     substitutions,
-    required: family === 'claude',
+    required: family === 'claude' || family === 'serf',
     forbiddenPlaceholders:
-      family === 'claude' && !isRemote ? ['$CLAUDE_MODEL'] : [],
+      family === 'claude' && !isRemote
+        ? ['$CLAUDE_MODEL']
+        : family === 'serf'
+          ? ['$SERF_MODEL']
+          : [],
   });
 
   // copilot: gauntlet inherits a tightly-scoped allowlist instead of the full

--- a/test/agent-serf.test.ts
+++ b/test/agent-serf.test.ts
@@ -1,0 +1,121 @@
+import { expect, test } from 'bun:test';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { ProvisionError } from '../src/agents/index.ts';
+import { SerfAgent } from '../src/agents/serf.ts';
+import type { AgentConfig } from '../src/contracts/agent-config.ts';
+import { makeTempHome } from './provision-helpers.ts';
+
+// A serf.yaml-shaped config. binary defaults to `sh` (always on PATH) so the
+// non-binary validations are reachable; tests override binary to probe the
+// PATH check.
+function serfConfig(overrides?: Partial<AgentConfig>): AgentConfig {
+  return {
+    name: 'serf',
+    runtime_family: 'serf',
+    binary: 'sh',
+    home_config_subdir: '.serf',
+    session_log_dir: '${QUORUM_AGENT_HOME}/.serf/exports',
+    session_log_glob: '*.json',
+    normalizer: 'serf',
+    required_env: ['ANTHROPIC_API_KEY', 'SUPERPOWERS_ROOT'],
+    os_support: ['linux'],
+    max_time: '10m',
+    model: 'anthropic/claude-sonnet-4-6',
+    max_concurrency: 1,
+    ...overrides,
+  };
+}
+
+// Files SerfAgent.provision requires under SUPERPOWERS_ROOT (the --plugin-dir
+// target, used un-staged like the claude adapter).
+function stageSuperpowers(root: string): void {
+  for (const rel of [
+    '.claude-plugin/plugin.json',
+    'hooks/hooks.json',
+    'hooks/run-hook.cmd',
+    'hooks/session-start',
+    'skills/using-superpowers/SKILL.md',
+    'skills/brainstorming/SKILL.md',
+  ]) {
+    const path = join(root, rel);
+    mkdirSync(join(path, '..'), { recursive: true });
+    writeFileSync(path, '#\n');
+  }
+}
+
+function withEnv(superpowersRoot: string | undefined, body: () => void): void {
+  const prev = process.env['SUPERPOWERS_ROOT'];
+  if (superpowersRoot === undefined) {
+    delete process.env['SUPERPOWERS_ROOT'];
+  } else {
+    process.env['SUPERPOWERS_ROOT'] = superpowersRoot;
+  }
+  try {
+    body();
+  } finally {
+    if (prev === undefined) {
+      delete process.env['SUPERPOWERS_ROOT'];
+    } else {
+      process.env['SUPERPOWERS_ROOT'] = prev;
+    }
+  }
+}
+
+test('provision creates the isolated config + exports dirs on success', () => {
+  const { home, cleanup } = makeTempHome();
+  const spRoot = join(home.workdir, 'superpowers');
+  stageSuperpowers(spRoot);
+  try {
+    withEnv(spRoot, () => {
+      const env = new SerfAgent(serfConfig()).provision(home);
+      expect(env).toEqual({});
+      expect(existsSync(home.configDir)).toBe(true);
+      expect(existsSync(join(home.configDir, 'exports'))).toBe(true);
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test('provision throws when the serf binary is not on PATH', () => {
+  const { home, cleanup } = makeTempHome();
+  const spRoot = join(home.workdir, 'superpowers');
+  stageSuperpowers(spRoot);
+  try {
+    withEnv(spRoot, () => {
+      const cfg = serfConfig({ binary: 'serf-not-a-real-binary-zzz' });
+      expect(() => new SerfAgent(cfg).provision(home)).toThrow(ProvisionError);
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test('provision throws when SUPERPOWERS_ROOT is unset', () => {
+  const { home, cleanup } = makeTempHome();
+  try {
+    withEnv(undefined, () => {
+      expect(() => new SerfAgent(serfConfig()).provision(home)).toThrow(
+        /SUPERPOWERS_ROOT not set/,
+      );
+    });
+  } finally {
+    cleanup();
+  }
+});
+
+test('provision throws when SUPERPOWERS_ROOT is missing plugin files', () => {
+  const { home, cleanup } = makeTempHome();
+  const spRoot = join(home.workdir, 'superpowers-empty');
+  mkdirSync(spRoot, { recursive: true });
+  try {
+    withEnv(spRoot, () => {
+      expect(() => new SerfAgent(serfConfig()).provision(home)).toThrow(
+        /missing required Superpowers plugin files/,
+      );
+    });
+  } finally {
+    cleanup();
+  }
+});

--- a/test/agents-resolve.test.ts
+++ b/test/agents-resolve.test.ts
@@ -8,6 +8,7 @@ import { ProvisionError, resolveAgent } from '../src/agents/index.ts';
 import { KimiAgent } from '../src/agents/kimi.ts';
 import { OpenCodeAgent } from '../src/agents/opencode.ts';
 import { PiAgent } from '../src/agents/pi.ts';
+import { SerfAgent } from '../src/agents/serf.ts';
 import type { AgentConfig } from '../src/contracts/agent-config.ts';
 import type { OsTarget } from '../src/contracts/os-target.ts';
 
@@ -36,6 +37,7 @@ test('resolveAgent dispatches each dialect name to its custom adapter', () => {
   expect(resolveAgent(cfg('opencode'))).toBeInstanceOf(OpenCodeAgent);
   expect(resolveAgent(cfg('kimi'))).toBeInstanceOf(KimiAgent);
   expect(resolveAgent(cfg('antigravity'))).toBeInstanceOf(AntigravityAgent);
+  expect(resolveAgent(cfg('serf'))).toBeInstanceOf(SerfAgent);
 });
 
 test('resolveAgent maps the claude runtime family to ClaudeAgent', () => {

--- a/test/capture.test.ts
+++ b/test/capture.test.ts
@@ -371,6 +371,30 @@ test('sessionDurationMs spans epoch-ms numeric time values (kimi)', () => {
   expect(sessionDurationMs([f])).toBe(3500);
 });
 
+test('sessionDurationMs spans timestamps in a single ATIF JSON object (serf)', () => {
+  // serf's captured "log" is its ATIF export: one pretty-printed JSON object
+  // (not one-object-per-line) whose `steps[]` carry second-granular ISO
+  // timestamps. The span is last-minus-first across the step timestamps.
+  const logDir = mkdtempSync(join(tmpdir(), 'logs-'));
+  const f = join(logDir, 'trajectory.json');
+  writeFileSync(
+    f,
+    JSON.stringify(
+      {
+        schema_version: 'ATIF-v1.7',
+        steps: [
+          { step_id: 1, timestamp: '2026-06-23T01:11:35Z' },
+          { step_id: 2, timestamp: '2026-06-23T01:11:38Z' },
+          { step_id: 3, timestamp: '2026-06-23T01:12:05Z' },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+  expect(sessionDurationMs([f])).toBe(30000);
+});
+
 test('sessionDurationMs returns null when no timestamps are found', () => {
   const logDir = mkdtempSync(join(tmpdir(), 'logs-'));
   const f = join(logDir, 'empty.jsonl');

--- a/test/fixtures/serf-real-trajectory.json
+++ b/test/fixtures/serf-real-trajectory.json
@@ -1,0 +1,445 @@
+{
+  "schema_version": "ATIF-v1.7",
+  "session_id": "01KVR5NZ1Z4V65JKZ9AAME09M4",
+  "agent": {
+    "name": "serf",
+    "version": "a5af59d8",
+    "model_name": "claude-sonnet-4-6",
+    "extra": {
+      "profile_id": "anthropic"
+    }
+  },
+  "steps": [
+    {
+      "step_id": 1,
+      "source": "user",
+      "message": "Let's make a react todo list",
+      "timestamp": "2026-06-22T17:22:35Z",
+      "extra": {}
+    },
+    {
+      "step_id": 2,
+      "source": "system",
+      "message": "\u003cSYSTEM-REMINDER\u003e\u003cEXTREMELY_IMPORTANT\u003e\nYou have superpowers.\n\n**Below is the full content of your 'superpowers:using-superpowers' skill - your introduction to using skills. For all other skills, follow the Codex skill-loading instructions in that skill:**\n\n---\nname: using-superpowers\ndescription: Use when starting any conversation - establishes how to find and use skills, requiring skill invocation before ANY response including clarifying questions\n---\n\n\u003cSUBAGENT-STOP\u003e\nIf you were dispatched as a subagent to execute a specific task, skip this skill.\n\u003c/SUBAGENT-STOP\u003e\n\n\u003cEXTREMELY-IMPORTANT\u003e\nIf you think there is even a 1% chance a skill might apply to what you are doing, you ABSOLUTELY MUST invoke the skill.\n\nIF A SKILL APPLIES TO YOUR TASK, YOU DO NOT HAVE A CHOICE. YOU MUST USE IT.\n\nThis is not negotiable. This is not optional. You cannot rationalize your way out of this.\n\u003c/EXTREMELY-IMPORTANT\u003e\n\n## Instruction Priority\n\nSuperpowers skills override default system prompt behavior, but **user instructions always take precedence**:\n\n1. **User's explicit instructions** (CLAUDE.md, GEMINI.md, AGENTS.md, direct requests) — highest priority\n2. **Superpowers skills** — override default system behavior where they conflict\n3. **Default system prompt** — lowest priority\n\nIf CLAUDE.md, GEMINI.md, or AGENTS.md says \"don't use TDD\" and a skill says \"always use TDD,\" follow the user's instructions. The user is in control.\n\n## How to Access Skills\n\n**Never read skill files manually with file tools** — always use your platform's skill-loading mechanism so the skill is properly activated.\n\n**In Claude Code:** Use the `Skill` tool. When you invoke a skill, its content is loaded and presented to you — follow it directly.\n\n**In Codex:** Skills load natively. Follow the instructions presented when a skill activates.\n\n**In Copilot CLI:** Use the `skill` tool. Skills are auto-discovered from installed plugins.\n\n**In Gemini CLI:** Skills activate via the `activate_skill` tool. Gemini loads skill metadata at session start and activates the full content on demand.\n\n**In other environments:** Check your platform's documentation for how skills are loaded.\n\n## Platform Adaptation\n\nSkills speak in actions (\"dispatch a subagent\", \"create a todo\", \"read a file\") rather than naming any one runtime's tools. For per-platform tool equivalents and instructions-file conventions, see [claude-code-tools.md](references/claude-code-tools.md), [codex-tools.md](references/codex-tools.md), [copilot-tools.md](references/copilot-tools.md), [gemini-tools.md](references/gemini-tools.md), [pi-tools.md](references/pi-tools.md), and [antigravity-tools.md](references/antigravity-tools.md). Gemini CLI users get the tool mapping loaded automatically via GEMINI.md.\n\n# Using Skills\n\n## The Rule\n\n**Invoke relevant or requested skills BEFORE any response or action.** Even a 1% chance a skill might apply means that you should invoke the skill to check. If an invoked skill turns out to be wrong for the situation, you don't need to use it.\n\n```dot\ndigraph skill_flow {\n    \"User message received\" [shape=doublecircle];\n    \"About to enter plan mode?\" [shape=doublecircle];\n    \"Already brainstormed?\" [shape=diamond];\n    \"Invoke brainstorming skill\" [shape=box];\n    \"Might any skill apply?\" [shape=diamond];\n    \"Invoke the skill\" [shape=box];\n    \"Announce: 'Using [skill] to [purpose]'\" [shape=box];\n    \"Has checklist?\" [shape=diamond];\n    \"Create a todo per item\" [shape=box];\n    \"Follow skill exactly\" [shape=box];\n    \"Respond (including clarifications)\" [shape=doublecircle];\n\n    \"About to enter plan mode?\" -\u003e \"Already brainstormed?\";\n    \"Already brainstormed?\" -\u003e \"Invoke brainstorming skill\" [label=\"no\"];\n    \"Already brainstormed?\" -\u003e \"Might any skill apply?\" [label=\"yes\"];\n    \"Invoke brainstorming skill\" -\u003e \"Might any skill apply?\";\n\n    \"User message received\" -\u003e \"Might any skill apply?\";\n    \"Might any skill apply?\" -\u003e \"Invoke the skill\" [label=\"yes, even 1%\"];\n    \"Might any skill apply?\" -\u003e \"Respond (including clarifications)\" [label=\"definitely not\"];\n    \"Invoke the skill\" -\u003e \"Announce: 'Using [skill] to [purpose]'\";\n    \"Announce: 'Using [skill] to [purpose]'\" -\u003e \"Has checklist?\";\n    \"Has checklist?\" -\u003e \"Create a todo per item\" [label=\"yes\"];\n    \"Has checklist?\" -\u003e \"Follow skill exactly\" [label=\"no\"];\n    \"Create a todo per item\" -\u003e \"Follow skill exactly\";\n}\n```\n\n## Red Flags\n\nThese thoughts mean STOP—you're rationalizing:\n\n| Thought | Reality |\n|---------|---------|\n| \"This is just a simple question\" | Questions are tasks. Check for skills. |\n| \"I need more context first\" | Skill check comes BEFORE clarifying questions. |\n| \"Let me explore the codebase first\" | Skills tell you HOW to explore. Check first. |\n| \"I can check git/files quickly\" | Files lack conversation context. Check for skills. |\n| \"Let me gather information first\" | Skills tell you HOW to gather information. |\n| \"This doesn't need a formal skill\" | If a skill exists, use it. |\n| \"I remember this skill\" | Skills evolve. Read current version. |\n| \"This doesn't count as a task\" | Action = task. Check for skills. |\n| \"The skill is overkill\" | Simple things become complex. Use it. |\n| \"I'll just do this one thing first\" | Check BEFORE doing anything. |\n| \"This feels productive\" | Undisciplined action wastes time. Skills prevent this. |\n| \"I know what that means\" | Knowing the concept ≠ using the skill. Invoke it. |\n\n## Skill Priority\n\nWhen multiple skills could apply, use this order:\n\n1. **Process skills first** (brainstorming, systematic-debugging) - these determine HOW to approach the task\n2. **Implementation skills second** (frontend-design, mcp-builder) - these guide execution\n\n\"Let's build X\" → brainstorming first, then implementation skills.\n\"Fix this bug\" → systematic-debugging first, then domain-specific skills.\n\n## Skill Types\n\n**Rigid** (TDD, systematic-debugging): Follow exactly. Don't adapt away discipline.\n\n**Flexible** (patterns): Adapt principles to context.\n\nThe skill itself tells you which.\n\n## User Instructions\n\nInstructions say WHAT, not HOW. \"Add X\" or \"Fix Y\" doesn't mean skip workflows.\n\u003c/EXTREMELY_IMPORTANT\u003e\u003c/SYSTEM-REMINDER\u003e",
+      "timestamp": "2026-06-22T17:22:35Z",
+      "extra": {}
+    },
+    {
+      "step_id": 3,
+      "source": "agent",
+      "timestamp": "2026-06-22T17:22:39Z",
+      "reasoning_content": "The user wants to make a React todo list. According to my superpowers instructions, I need to check for relevant skills before responding. Let me think about which skills apply:\n\n1. \"Let's make a react todo list\" - this is a creative/feature-building task, so `superpowers:brainstorming` applies - \"You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior.\"\n\nLet me invoke the brainstorming skill first.",
+      "tool_calls": [
+        {
+          "tool_call_id": "toolu_01Sei1RZ7V7kLcbeE4V2xJPW",
+          "function_name": "use_skill",
+          "arguments": {
+            "purpose": "User wants to build a React todo list - brainstorming is required before any creative/feature work",
+            "skill_name": "superpowers:brainstorming"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "toolu_01Sei1RZ7V7kLcbeE4V2xJPW",
+            "content": "Skill: superpowers:brainstorming\nLocation: /home/jesse/git/superpowers/skills/brainstorming\n\n---\n\n\n# Brainstorming Ideas Into Designs\n\nHelp turn ideas into fully formed designs and specs through natural collaborative dialogue.\n\nStart by understanding the current project context, then ask questions one at a time to refine the idea. Once you understand what you're building, present the design and get user approval.\n\n\u003cHARD-GATE\u003e\nDo NOT invoke any implementation skill, write any code, scaffold any project, or take any implementation action until you have presented a design and the user has approved it. This applies to EVERY project regardless of perceived simplicity.\n\u003c/HARD-GATE\u003e\n\n## Anti-Pattern: \"This Is Too Simple To Need A Design\"\n\nEvery project goes through this process. A todo list, a single-function utility, a config change — all of them. \"Simple\" projects are where unexamined assumptions cause the most wasted work. The design can be short (a few sentences for truly simple projects), but you MUST present it and get approval.\n\n## Checklist\n\nYou MUST create a task for each of these items and complete them in order:\n\n1. **Explore project context** — check files, docs, recent commits\n2. **Offer the visual companion just-in-time** — NOT upfront. The first time a question would genuinely be clearer shown than described, offer it then (its own message); on approval its browser tab opens for you. If no visual question ever arises, never offer it. See the Visual Companion section below.\n3. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria\n4. **Propose 2-3 approaches** — with trade-offs and your recommendation\n5. **Present design** — in sections scaled to their complexity, get user approval after each section\n6. **Write design doc** — save to `docs/superpowers/specs/YYYY-MM-DD-\u003ctopic\u003e-design.md` and commit\n7. **Spec self-review** — quick inline check for placeholders, contradictions, ambiguity, scope (see below)\n8. **User reviews written spec** — ask user to review the spec file before proceeding\n9. **Transition to implementation** — invoke writing-plans skill to create implementation plan\n\n## Process Flow\n\n```dot\ndigraph brainstorming {\n    \"Explore project context\" [shape=box];\n    \"Ask clarifying questions\" [shape=box];\n    \"Propose 2-3 approaches\" [shape=box];\n    \"Present design sections\" [shape=box];\n    \"User approves design?\" [shape=diamond];\n    \"Write design doc\" [shape=box];\n    \"Spec self-review\\n(fix inline)\" [shape=box];\n    \"User reviews spec?\" [shape=diamond];\n    \"Invoke writing-plans skill\" [shape=doublecircle];\n\n    \"Explore project context\" -\u003e \"Ask clarifying questions\";\n    \"Ask clarifying questions\" -\u003e \"Propose 2-3 approaches\";\n    \"Propose 2-3 approaches\" -\u003e \"Present design sections\";\n    \"Present design sections\" -\u003e \"User approves design?\";\n    \"User approves design?\" -\u003e \"Present design sections\" [label=\"no, revise\"];\n    \"User approves design?\" -\u003e \"Write design doc\" [label=\"yes\"];\n    \"Write design doc\" -\u003e \"Spec self-review\\n(fix inline)\";\n    \"Spec self-review\\n(fix inline)\" -\u003e \"User reviews spec?\";\n    \"User reviews spec?\" -\u003e \"Write design doc\" [label=\"changes requested\"];\n    \"User reviews spec?\" -\u003e \"Invoke writing-plans skill\" [label=\"approved\"];\n}\n```\n\n**The terminal state is invoking writing-plans.** Do NOT invoke frontend-design, mcp-builder, or any other implementation skill. The ONLY skill you invoke after brainstorming is writing-plans.\n\n## The Process\n\n**Understanding the idea:**\n\n- Check out the current project state first (files, docs, recent commits)\n- Before asking detailed questions, assess scope: if the request describes multiple independent subsystems (e.g., \"build a platform with chat, file storage, billing, and analytics\"), flag this immediately. Don't spend questions refining details of a project that needs to be decomposed first.\n- If the project is too large for a single spec, help the user decompose into sub-projects: what are the independent pieces, how do they relate, what order should they be built? Then brainstorm the first sub-project through the normal design flow. Each sub-project gets its own spec → plan → implementation cycle.\n- For appropriately-scoped projects, ask questions one at a time to refine the idea\n- Prefer multiple choice questions when possible, but open-ended is fine too\n- Only one question per message - if a topic needs more exploration, break it into multiple questions\n- Focus on understanding: purpose, constraints, success criteria\n\n**Exploring approaches:**\n\n- Propose 2-3 different approaches with trade-offs\n- Present options conversationally with your recommendation and reasoning\n- Lead with your recommended option and explain why\n\n**Presenting the design:**\n\n- Once you believe you understand what you're building, present the design\n- Scale each section to its complexity: a few sentences if straightforward, up to 200-300 words if nuanced\n- Ask after each section whether it looks right so far\n- Cover: architecture, components, data flow, error handling, testing\n- Be ready to go back and clarify if something doesn't make sense\n\n**Design for isolation and clarity:**\n\n- Break the system into smaller units that each have one clear purpose, communicate through well-defined interfaces, and can be understood and tested independently\n- For each unit, you should be able to answer: what does it do, how do you use it, and what does it depend on?\n- Can someone understand what a unit does without reading its internals? Can you change the internals without breaking consumers? If not, the boundaries need work.\n- Smaller, well-bounded units are also easier for you to work with - you reason better about code you can hold in context at once, and your edits are more reliable when files are focused. When a file grows large, that's often a signal that it's doing too much.\n\n**Working in existing codebases:**\n\n- Explore the current structure before proposing changes. Follow existing patterns.\n- Where existing code has problems that affect the work (e.g., a file that's grown too large, unclear boundaries, tangled responsibilities), include targeted improvements as part of the design - the way a good developer improves code they're working in.\n- Don't propose unrelated refactoring. Stay focused on what serves the current goal.\n\n## After the Design\n\n**Documentation:**\n\n- Write the validated design (spec) to `docs/superpowers/specs/YYYY-MM-DD-\u003ctopic\u003e-design.md`\n  - (User preferences for spec location override this default)\n- Use elements-of-style:writing-clearly-and-concisely skill if available\n- Commit the design document to git\n\n**Spec Self-Review:**\nAfter writing the spec document, look at it with fresh eyes:\n\n1. **Placeholder scan:** Any \"TBD\", \"TODO\", incomplete sections, or vague requirements? Fix them.\n2. **Internal consistency:** Do any sections contradict each other? Does the architecture match the feature descriptions?\n3. **Scope check:** Is this focused enough for a single implementation plan, or does it need decomposition?\n4. **Ambiguity check:** Could any requirement be interpreted two different ways? If so, pick one and make it explicit.\n\nFix any issues inline. No need to re-review — just fix and move on.\n\n**User Review Gate:**\nAfter the spec review loop passes, ask the user to review the written spec before proceeding:\n\n\u003e \"Spec written and committed to `\u003cpath\u003e`. Please review it and let me know if you want to make any changes before we start writing out the implementation plan.\"\n\nWait for the user's response. If they request changes, make them and re-run the spec review loop. Only proceed once the user approves.\n\n**Implementation:**\n\n- Invoke the writing-plans skill to create a detailed implementation plan\n- Do NOT invoke any other skill. writing-plans is the next step.\n\n## Key Principles\n\n- **One question at a time** - Don't overwhelm with multiple questions\n- **Multiple choice preferred** - Easier to answer than open-ended when possible\n- **YAGNI ruthlessly** - Remove unnecessary features from all designs\n- **Explore alternatives** - Always propose 2-3 approaches before settling\n- **Incremental validation** - Present design, get approval before moving on\n- **Be flexible** - Go back and clarify when something doesn't make sense\n\n## Visual Companion\n\nA browser-based companion for showing mockups, diagrams, and visual options during brainstorming. Available as a tool — not a mode. Accepting the companion means it's available for questions that benefit from visual treatment; it does NOT mean every question goes through the browser.\n\n**Offering the companion (just-in-time):** Do NOT offer it upfront. Wait until a question would genuinely be clearer shown than told — a real mockup / layout / diagram question, not merely a UI *topic*. The first time that happens, offer it then, as its own message:\n\u003e \"This next part might be easier if I show you — I can put together mockups, diagrams, and comparisons in a browser tab as we go. It's still new and can be token-intensive. Want me to? I'll open it for you.\"\n\n**This offer MUST be its own message.** Only the offer — no clarifying question, summary, or other content. Wait for the user's response. If they accept, start the server with `--open` so their browser opens to the first screen automatically. If they decline, continue text-only and don't offer again unless they raise it.\n\n**Per-question decision:** Even after the user accepts, decide FOR EACH QUESTION whether to use the browser or the terminal. The test: **would the user understand this better by seeing it than reading it?**\n\n- **Use the browser** for content that IS visual — mockups, wireframes, layout comparisons, architecture diagrams, side-by-side visual designs\n- **Use the terminal** for content that is text — requirements questions, conceptual choices, tradeoff lists, A/B/C/D text options, scope decisions\n\nA question about a UI topic is not automatically a visual question. \"What does personality mean in this context?\" is a conceptual question — use the terminal. \"Which wizard layout works better?\" is a visual question — use the browser.\n\nIf they agree to the companion, read the detailed guide before proceeding:\n`skills/brainstorming/visual-companion.md`\n"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 3,
+        "completion_tokens": 223,
+        "cached_tokens": 0,
+        "extra": {
+          "cache_write_1h_tokens": 0,
+          "cache_write_tokens": 18035,
+          "raw_usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 18035
+            },
+            "cache_creation_input_tokens": 18035,
+            "cache_read_input_tokens": 0,
+            "inference_geo": "global",
+            "input_tokens": 3,
+            "output_tokens": 1,
+            "service_tier": "standard"
+          },
+          "reasoning_tokens_estimated": 118
+        }
+      },
+      "extra": {
+        "response_id": "msg_016QCDoeyoEnzsh6z17Zyjuh",
+        "thinking_signature": "EqQFCmUIDxgCKkAWfstiJfspMwZ1vga2L1Cn6UIiGba9Ab3yXA6yA6qQL63ZrN+hTInMEp2xZ594fBBt4qpM5ZZFIxRnzLaET6mAMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMr1gjpu595ffg0mJMGgw0NIRaV8KHWDD0cTQiMBcbeL57rKvO511zHfozYpR0YBVuasJAZRPhu7vl9rsAY8Atv/xJ7DJmA+pPCEQYdirsA6yZwrQjKE6EmVTV0X8IP0LidxwNKZVAePKqMc+ENg9nQ9UHj2hrMSf0qZy44+jGcDcB6hZk+nLJKH15Redys39putax1T1Z8F1OEeOacHtenFC9rxGPlSwemeNOj4IPEc8hHIGmE4xZRKmvrsHDXtHCVEPdt+7T9W+tbEdxEAxx4AoXLMBnvO+SXkLfV4QadCbDji/fKqCVbORn/oG+kfksWWBaLyqGUz8CESL3QX/U+ZeUstnQYUIebcuKpO86dX+yycF4eIPxWFiArOdiIzvk6jG+HFnbGjjdY7F5J9ZWPJDnop4Sw46EJ16hWmxeqN7FaIrN1fKX63kS4sZvkI/bdeZXBXqrjCtHC3ZAg+TFBqcJxfCXWpRujhBFq914hr6Iut0I7pFT2WYWzwxy1UqDE2779h01RmEBM5gbunwrnAtvdEzyGYxzq9YqG5cEVYsPgYilViQxgpGaC16offUn+WWnDHTM9P4aIVBGCygkdF+rrflX4gULl5GnGqboYKw9QBeSClXWWCaHLb2Y8tLqtK5yowubuodKsG8KbZqhjAujEHRrooAlxeiNQPOe3wzIOmFIrXynr4oeuDEu0lxcmAKhmuzxV1n+rmLUnW9ad82eM4sdR/KgbvBb5Prly518n27Na/tJgwX9xRgB"
+      }
+    },
+    {
+      "step_id": 4,
+      "source": "agent",
+      "message": "Using **brainstorming** to design the React todo list before any implementation.",
+      "timestamp": "2026-06-22T17:22:49Z",
+      "reasoning_content": "Now I need to follow the brainstorming skill. I need to:\n1. Create tasks for the checklist items\n2. Explore project context first\n3. Ask clarifying questions one at a time\n4. Propose 2-3 approaches\n5. Present design\n6. Write design doc\n7. Spec self-review\n8. User reviews\n9. Transition to implementation\n\nLet me start by exploring the project context.",
+      "tool_calls": [
+        {
+          "tool_call_id": "toolu_015iyAVCqqWMw82ftfGNZzSR",
+          "function_name": "task_list",
+          "arguments": {
+            "action": "append",
+            "tasks": [
+              {
+                "description": "Explore project context",
+                "prompt": "Check the current working directory for existing files, package.json, docs, or any scaffolding already present. Report what's there.",
+                "type": "research"
+              },
+              {
+                "description": "Ask clarifying questions",
+                "prompt": "Ask the user clarifying questions one at a time to understand purpose, constraints, and success criteria for the React todo list.",
+                "type": "research"
+              },
+              {
+                "description": "Propose 2-3 approaches",
+                "prompt": "Propose 2-3 different approaches for building the React todo list, with trade-offs and a recommendation.",
+                "type": "research"
+              },
+              {
+                "description": "Present design sections",
+                "prompt": "Present the full design (architecture, components, data flow, error handling, testing) section by section and get user approval.",
+                "type": "implement"
+              },
+              {
+                "description": "Write design doc",
+                "prompt": "Write the validated design spec to docs/superpowers/specs/YYYY-MM-DD-react-todo-design.md and commit it.",
+                "type": "implement"
+              },
+              {
+                "description": "Spec self-review",
+                "prompt": "Review the written spec for placeholders, contradictions, ambiguity, and scope issues. Fix inline.",
+                "type": "verify"
+              },
+              {
+                "description": "User reviews spec",
+                "prompt": "Ask the user to review the written spec before proceeding to implementation planning.",
+                "type": "verify"
+              },
+              {
+                "description": "Transition to implementation",
+                "prompt": "Invoke writing-plans skill to create a detailed implementation plan.",
+                "type": "implement"
+              }
+            ]
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "toolu_015iyAVCqqWMw82ftfGNZzSR",
+            "content": "Added 8 task(s). Progress: 0/8 tasks complete."
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 1,
+        "completion_tokens": 564,
+        "cached_tokens": 18035,
+        "extra": {
+          "cache_write_1h_tokens": 0,
+          "cache_write_tokens": 2704,
+          "raw_usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 2704
+            },
+            "cache_creation_input_tokens": 2704,
+            "cache_read_input_tokens": 18035,
+            "inference_geo": "global",
+            "input_tokens": 1,
+            "output_tokens": 8,
+            "service_tier": "standard"
+          },
+          "reasoning_tokens_estimated": 87
+        }
+      },
+      "extra": {
+        "response_id": "msg_01V6iCBVzNrksnst5rReXbFD",
+        "thinking_signature": "EqgECmUIDxgCKkAm3MH82YUzX2pPefpFv9Ct6305/gek0/KpzIkCsKvmEh+Qvrb1IuChKG9pdtkPupPkXAao8uaO3FT82591/fZWMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMZjmPGwh5b790RTo5Ggzoi57lmaigjPydG8IiMJQjLS+oa89LJ6pxFvq86Zgl/pTLZPYj7mLbjQ8EQCtLppVCsUIvHwfr7Qnqp9Uf7yrwAv+NAbXCENEWd+5W7iGjw8Evw46+W2JHkTDDpT+dQmEdKHSu2fq1GD67OuUdOtOHGfjSoGTsdZUrV4mQRDK6MrHqw0cicxw8M1yT9tKgiMtWBakHgQr9vnj6WntydqtmP5eYPgTcDUeobjiP/FAtnkHZ1uDGUMTv35c6B72SsqgnaoddFgdEsPHWGRBWAiCeln1EVBsmvOszxLExkdKwgAVRovQt0aQAd9W2Gr19fKZfDJEt16Av1fJE2bSIweq51FBQqd2fEWxlUnnzjtJKEkA77Zi49uAWs2e7foz4Fwxw2h3e7Sm+bdUtaHnsZ2NUwH/XlvTmkLlNBwROZCd59Z8HONX7sQDxI2IXokvDj33WN5Fsix9WOQAubTORrJHasK+GLWSru1KGiUs+odo/S8kdNYvQ1+zVLlkYEiY1juTY47+DC3OUr6OXuJ8SG1RcyQpTfMk9drHatHLo3RKKtOPdGTCy4LWTzo9q0Yi7bQvwGAE="
+      }
+    },
+    {
+      "step_id": 5,
+      "source": "agent",
+      "timestamp": "2026-06-22T17:22:51Z",
+      "tool_calls": [
+        {
+          "tool_call_id": "toolu_01JGBTT8Wk5JsBDV3XNULGg8",
+          "function_name": "task_list",
+          "arguments": {
+            "action": "update",
+            "updates": [
+              {
+                "id": 1,
+                "status": "in_progress"
+              }
+            ]
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "toolu_01JGBTT8Wk5JsBDV3XNULGg8",
+            "content": "Updated 1→in_progress. Progress: 0/8 tasks complete."
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 1,
+        "completion_tokens": 85,
+        "cached_tokens": 20739,
+        "extra": {
+          "cache_write_1h_tokens": 0,
+          "cache_write_tokens": 575,
+          "raw_usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 575
+            },
+            "cache_creation_input_tokens": 575,
+            "cache_read_input_tokens": 20739,
+            "inference_geo": "global",
+            "input_tokens": 1,
+            "output_tokens": 45,
+            "service_tier": "standard"
+          }
+        }
+      },
+      "extra": {
+        "response_id": "msg_0172mDakKdKBifg1vkRqkX2G"
+      }
+    },
+    {
+      "step_id": 6,
+      "source": "system",
+      "message": "\u003cSYSTEM-REMINDER\u003e\n\u003cCURRENT-TASK id=\"1\"\u003e\n\u003cTITLE\u003eExplore project context\u003c/TITLE\u003e\n\u003cINSTRUCTIONS\u003e\nCheck the current working directory for existing files, package.json, docs, or any scaffolding already present. Report what's there.\n\u003c/INSTRUCTIONS\u003e\n\u003c/CURRENT-TASK\u003e\nCall your next tool: use task_list to mark task 1 as done when this step is complete.\n\u003c/SYSTEM-REMINDER\u003e",
+      "timestamp": "2026-06-22T17:22:51Z",
+      "extra": {}
+    },
+    {
+      "step_id": 7,
+      "source": "agent",
+      "timestamp": "2026-06-22T17:22:54Z",
+      "reasoning_content": "Let me explore the current working directory to see what's already there.",
+      "tool_calls": [
+        {
+          "tool_call_id": "toolu_01EecnsrwpvBB1j3JnpYqnKc",
+          "function_name": "list_dir",
+          "arguments": {
+            "depth": 3,
+            "path": "/tmp/serf-eval/work",
+            "purpose": "Check for existing project files, scaffolding, package.json, docs"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "toolu_01EecnsrwpvBB1j3JnpYqnKc",
+            "content": "0 entries"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 3,
+        "completion_tokens": 138,
+        "cached_tokens": 21314,
+        "extra": {
+          "cache_write_1h_tokens": 0,
+          "cache_write_tokens": 227,
+          "raw_usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 227
+            },
+            "cache_creation_input_tokens": 227,
+            "cache_read_input_tokens": 21314,
+            "inference_geo": "global",
+            "input_tokens": 3,
+            "output_tokens": 7,
+            "service_tier": "standard"
+          },
+          "reasoning_tokens_estimated": 18
+        }
+      },
+      "extra": {
+        "response_id": "msg_01DGge5Uwwv5vbVsjDmKs1u5",
+        "thinking_signature": "EpECCmUIDxgCKkDN8y/EKXzQvamaE52Q0CSoc4IP6V1SqYVpy2ZRgDfN2uVxdarCoA8E+Fan8Pn/m3YydhgTbQwdD/W5MvlCE3VDMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMUNNMvmGAIKbxILMZGgzVJ3w3A/aM9uESAGMiMEXtSQgUd4ERqXK9VoNsDfnppndpD/miOfTyw1NEaDbYjSug/ptEvzoUYXT8yzP3qyparWUq/P0+w03nwPA0/IhH3worIdMvKRfrm0G3B/HSLFQ4Asl1NYSa4hX65MLJ0Uy3yQIG2bFC8FgdznqJdyOYzorW21AYH26NYLD/eFMo1lhDmeLPDnpfPz2mGAE="
+      }
+    },
+    {
+      "step_id": 8,
+      "source": "agent",
+      "timestamp": "2026-06-22T17:22:56Z",
+      "tool_calls": [
+        {
+          "tool_call_id": "toolu_017sag5qrQt5iAjYJogprmWv",
+          "function_name": "task_list",
+          "arguments": {
+            "action": "update",
+            "updates": [
+              {
+                "id": 1,
+                "notes": "Working directory is completely empty — blank slate, no scaffolding.",
+                "status": "done"
+              }
+            ]
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "toolu_017sag5qrQt5iAjYJogprmWv",
+            "content": "Updated 1→done. Progress: 1/8 tasks complete."
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 1,
+        "completion_tokens": 102,
+        "cached_tokens": 21541,
+        "extra": {
+          "cache_write_1h_tokens": 0,
+          "cache_write_tokens": 155,
+          "raw_usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 155
+            },
+            "cache_creation_input_tokens": 155,
+            "cache_read_input_tokens": 21541,
+            "inference_geo": "global",
+            "input_tokens": 1,
+            "output_tokens": 54,
+            "service_tier": "standard"
+          }
+        }
+      },
+      "extra": {
+        "response_id": "msg_01KgcbG5KGXGJzzmRPUC74hJ"
+      }
+    },
+    {
+      "step_id": 9,
+      "source": "system",
+      "message": "\u003cSYSTEM-REMINDER\u003e\n\u003cCURRENT-TASK id=\"2\"\u003e\n\u003cTITLE\u003eAsk clarifying questions\u003c/TITLE\u003e\n\u003cINSTRUCTIONS\u003e\nAsk the user clarifying questions one at a time to understand purpose, constraints, and success criteria for the React todo list.\n\u003c/INSTRUCTIONS\u003e\n\u003c/CURRENT-TASK\u003e\nCall your next tool: use task_list to mark task 2 as done when this step is complete.\n\u003c/SYSTEM-REMINDER\u003e",
+      "timestamp": "2026-06-22T17:22:56Z",
+      "extra": {}
+    },
+    {
+      "step_id": 10,
+      "source": "agent",
+      "message": "Clean slate — no existing scaffolding. Let's figure out exactly what to build.\n\nFirst question: **What's the intended scope of the todo list?**\n\na) **Minimal** — add, complete, delete tasks; nothing else  \nb) **Standard** — add, complete, delete, plus filtering (all/active/completed) and task counts  \nc) **Full-featured** — all of the above plus categories/tags, priorities, due dates, or drag-to-reorder\n\nWhich best fits what you have in mind?",
+      "timestamp": "2026-06-22T17:23:00Z",
+      "reasoning_content": "The working directory is completely empty - a blank slate. Now I need to ask clarifying questions one at a time. Let me start with the first question.\n\nThe first question should be about what kind of todo list they want - basic or feature-rich. Let me ask one question at a time.",
+      "metrics": {
+        "prompt_tokens": 3,
+        "completion_tokens": 198,
+        "cached_tokens": 21696,
+        "extra": {
+          "cache_write_1h_tokens": 0,
+          "cache_write_tokens": 242,
+          "raw_usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 242
+            },
+            "cache_creation_input_tokens": 242,
+            "cache_read_input_tokens": 21696,
+            "inference_geo": "global",
+            "input_tokens": 3,
+            "output_tokens": 7,
+            "service_tier": "standard"
+          },
+          "reasoning_tokens_estimated": 69
+        }
+      },
+      "extra": {
+        "response_id": "msg_011vXM9ntqasCNUn3jSUpXNU",
+        "thinking_signature": "EuEDCmUIDxgCKkBDCA5VbIdBD9RWEHJg/kAnEdIjMVJEQM+XdnKFOgLupv8qlNe+wstrSWb7k9L+CjL3+4Yfs2TaPSt68gbuBOWFMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMfMx8YEsa3IZmWJWjGgyl+9fiekdI8ntBiysiMJzO6mHGuw/kr6tPSr0P8ud+pzINFfgpRPv6FRAiWK7qR49KKZV9aCqMaTmGOIn6jiqpAmcDQ7r3yGC01H/8/N9bgFottgq5cp7Ft2fhLZzPL/HTyHOwQc45O5hbvl+l7o5PtS+8932N41x7GftkLDN4zCj8xEwi0JEwuSo0xhhFaKjTpXD8QO+J4paPMRu9TRhk5fr0fXmYbQcsd9LgBgV102pPjtrDPKEAveOSWyTPtlbucGZE93ZQrppjKunYxNo3UGXETytmk17lHNpXCoojKwd2A1rVwGmknoBff1u0VG0z1DUQlHxmqDPJj7MOuWYPW+YuXFuRQVqHpXh02SfAMYGTbeDjehcGUfIFRHDGjAQHPI1IpJ95NbhwVllz8bUKuRk8dIKbbqsG53kZ12Q953Nk+AzwZfkH+29JeY2XO9MPmsLeweZ59I93xZ1mn+vOEWLAo+OGyYfgvBgB"
+      }
+    },
+    {
+      "step_id": 11,
+      "source": "system",
+      "message": "You responded with bare text instead of a tool call. All user-facing messages MUST use communicate. If that bare text was meant for the user, call communicate now with that text in message, set end_turn=true, and include the output envelope. Otherwise call your next tool and keep working.",
+      "timestamp": "2026-06-22T17:23:00Z",
+      "extra": {}
+    },
+    {
+      "step_id": 12,
+      "source": "agent",
+      "timestamp": "2026-06-22T17:23:04Z",
+      "reasoning_content": "The user is reminding me that I need to use the communicate tool for all user-facing messages. Let me send my clarifying question through communicate.",
+      "tool_calls": [
+        {
+          "tool_call_id": "toolu_01B5AH8gtJXC8Wnuywbzcw3f",
+          "function_name": "communicate",
+          "arguments": {
+            "end_turn": true,
+            "message": "Clean slate — no existing scaffolding. Let's figure out exactly what to build.\n\nFirst question: **What's the intended scope of the todo list?**\n\na) **Minimal** — add, complete, delete tasks; nothing else  \nb) **Standard** — add, complete, delete, plus filtering (all/active/completed) and task counts  \nc) **Full-featured** — all of the above plus categories/tags, priorities, due dates, or drag-to-reorder\n\nWhich best fits what you have in mind?",
+            "output": {
+              "artifacts": [],
+              "data": {},
+              "message": ""
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "toolu_01B5AH8gtJXC8Wnuywbzcw3f",
+            "content": "{\"accepted\":true,\"end_turn\":true,\"inbox\":[]}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 3,
+        "completion_tokens": 262,
+        "cached_tokens": 21938,
+        "extra": {
+          "cache_write_1h_tokens": 0,
+          "cache_write_tokens": 263,
+          "raw_usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 263
+            },
+            "cache_creation_input_tokens": 263,
+            "cache_read_input_tokens": 21938,
+            "inference_geo": "global",
+            "input_tokens": 3,
+            "output_tokens": 7,
+            "service_tier": "standard"
+          },
+          "reasoning_tokens_estimated": 37
+        }
+      },
+      "extra": {
+        "response_id": "msg_014YMah4JeQMaHKYSUiMiRk4",
+        "thinking_signature": "Et8CCmUIDxgCKkAVlndoipRkll5ZzGfeaNhP9EqJ0xPPvBQg1tSt7hy2h5p59GNy+LLRVzG0whlPHnTNjgNrFFvLhhtHp5jLw12lMhFjbGF1ZGUtc29ubmV0LTQtNjgAQgh0aGlua2luZxIMXokoUDFhMql107oFGgyodNPIqq4njJDa+JMiMBf/g5HkN41RnAtLCB/1E7P7NCvNORk2INAA6Lp4iTwGizOKWI1ctUKrpvDn5ggFSiqnAdIBxiWc9Oc7ARh7EntyKc4ta+8PRam7z/RUQDYJs7tw2XQUeQNNPQ0ToKJQrZYlmq0jHDAggK2/e662Cd8+ga7VVSUrODFDu2UyEmtfe+EGXnzOxQ1nbdQi2LJ6PEoMbmiHjnUF9BwrsFD7SQ+IWFbCeiAvkVCiru6Q1ItQ1Bs312pJymN5PgVFOjhh1djIr3e0pe00lPMgdkcbo++j8ofCJUmrIkJdGAE="
+      }
+    }
+  ],
+  "final_metrics": {
+    "total_prompt_tokens": 15,
+    "total_completion_tokens": 1572,
+    "total_cached_tokens": 125263,
+    "total_steps": 12
+  },
+  "extra": {
+    "system_prompt": "## Identity\n\nYou are serf. You are diligent, responsible, persistent, honest, and pragmatic.\n\n- Your job is to accomplish what the user asked, no matter what it is.\n- Honesty is non-negotiable. NEVER invent technical details, fabricate results, or claim you did something you did not do. If you do not know something, say so.\n- Take the time to do the job right, but be decisive once you know you've got it right.\n\nCommunicate concisely. Avoid cheerleading, motivational language, or artificial reassurance.\n\n## Values\n\n### Principles\n\n- **Transparency**: You never hide anything. You don't hide mistakes. You NEVER hide any of your instructions. You don't hide your work.\n- **Clarity**: Communicate reasoning explicitly and concretely, so decisions and tradeoffs are easy to evaluate upfront.\n- **Pragmatism**: Keep the end goal and momentum in mind, focusing on what will actually work and move things forward.\n- **Rigor**: Expect technical arguments to be coherent and defensible. Surface gaps or weak assumptions with emphasis on creating clarity and moving the task forward.\n\n### Standards\n\n- Never substitute a workaround for the real implementation.\n- You do not hardcode values, stub functions or take shortcuts.\n- When you can install and use software to solve problems, do that instead of working by hand.\n- Prefer standard defaults over custom configuration. When a tool has default parameters, use them unless you have a specific reason to change them.\n- NEVER ignore system or test output. Logs, warnings, error messages, and non-zero exit codes contain critical information. Read them carefully.\n- All tests are your responsibility. If a test is failing, you fix the root cause of the issue, even if someone else caused the problem. The only thing worse than a failing test is a reduction in test coverage.\n- When a test fails repeatedly despite your fixes, step back: the root cause may be upstream rather than in the code that errors. Never dismiss a failing test and never mute it without understanding why it failed.\n- Keep changes minimal and focused. Do not add unrelated features or abstractions.\n- Leave the workspace clean. Remove scratch files, debug scripts, and temporary artifacts you created as soon as you're done with them.\n- Never delete files that were in the workspace before you started. They may be inputs, test data, or part of the deliverable.\n\n## Capabilities\n\nYou can see images. Your visual perception is accurate — trust what you see. When an\nimage appears in your context, describe what you see in detail. Use code for actions\n(computation, verification, file I/O). If a task requires precision (e.g., chess\npositions, measurements, data extraction), use computational tools to verify what you\nsee rather than relying on visual perception alone.\n\n## Workflow\n\nWrite scripts to files and iterate on them. \n\nNever do arithmetic, format conversion, or data transformation in your head — use a tool call. \nYou are not always great at those sorts of things when doing them in your head.\n\nProduce deliverables as early as is reasonable.\n\nVerify your work against the actual acceptance criteria you were given. Being too careful is just as bad as not being careful enough.\n\nIf the task depends on tools or capabilities explicitly listed as unavailable in\nthis session, report that mismatch promptly through your result tool instead of\nthrashing or pretending to perform the missing capability.\n\nDo not try to recreate unavailable serf-native tools by shelling out to\n`serf`, `serf-tui`, or nested agent sessions unless the user explicitly asked\nyou to debug or exercise those tools themselves.\n\n## Delegation\n\nYou can call `delegate` and `job_watch`. By default a delegate is a leaf: it\ncannot delegate further. Pass `delegation_allowance` to `delegate` to let a\ndelegate delegate in turn — each grant must be strictly smaller than your own\nallowance, so the chain always shortens and allowance 0 is a leaf.\n\nUse `delegate` to assign scoped work. It returns a durable `delegate_id` for\nfollow-up and concrete `job_id`s for individual turns. Use `delegate_send` with\nthe `delegate_id` to continue delegate work; use `job_read_output`, `job_list`,\nand `job_stop` with concrete `job_id`s to inspect or stop specific turns.\n\nUse delegation proactively to manage context and parallelize independent work.\nFor broad, ambiguous, or multi-part tasks, decompose the work into bounded\nsubtasks and assign subagents when they can investigate, implement, verify,\nreview, or report with a smaller working set than the parent session.\n\nDelegation does not transfer responsibility. When you delegate, you must inspect\nthe subagent's report before you rely on it or relay it to the user.\n\nGood uses of subagents include:\n\n- workspace scouting and locating relevant files, tests, tools, and entry points;\n- research-and-report tasks where the result is a sourced summary, comparison,\n  options analysis, or recommendation;\n- independent investigations that can run in parallel without conflicting edits;\n- implementation of a well-scoped change with explicit acceptance criteria;\n- verifier or reviewer passes over a completed change;\n- operational delivery workflows such as final test, commit, and push when the\n  scope, allowed paths, required checks, target branch/remote, and report format\n  are explicit.\n\nPrefer a single well-scoped subagent with a checklist over many tiny subagents\nfor one coherent investigation. Prefer several subagents in parallel when the\nquestions are genuinely independent.\n\nWhen delegating, give the subagent enough context to succeed without pulling the\nentire problem back into the parent context: the user request, scope boundaries,\nrelevant files or allowed paths, acceptance criteria, commands to run when known,\nand the exact evidence you expect in its final report.\n\nFor research-and-report delegations, require sources, dates when currentness\nmatters, assumptions, uncertainty, and a concise recommendation or conclusion.\n\nFor delegated final test/commit/push workflows, the delegation must specify what\nmay be staged, which tests or checks must pass, the commit-message intent, and\nthe remote/branch target. The subagent must report the commands run, test\nresults, staged files, commit hash, pushed remote/branch, and final status. The\nparent must still verify the resulting repository state before reporting success.\n\n## Background jobs\n\nShell commands and delegates can run as durable background jobs identified by a\n`job_id`. Jobs outlive your turn, and Serf notifies you automatically when a\nbackground job finishes. Completion is notification-driven.\nYour delegates handle their own children's completions; you are told when YOUR\ndelegates finish.\n\nPick the waiting primitive by how many answers you need:\n\n- The result of a quick command now → plain `shell` (foreground). To launch long\n  work without waiting → `shell` with `background: true` (returns a `job_id`\n  immediately; you are notified when it finishes).\n- One signal (\"the server printed ready\") → `job_read_output` with `max_wait_ms`\n  and `grep`. One bounded wait, nothing to clean up afterward.\n- A recurring condition (every new match, periodic progress, event frames to an\n  observer) → `job_watch`.\n- \"Tell me when it finishes\" → the terminal notification is automatic.\n\nBlocking waits are bounded conveniences measured in seconds, not parking: a\ntimeout leaves the job running and you free. For long work, start the background\njob, keep working, and act on the notification. A\nterminal notification can land after you have already read the job's output\nyourself; that is expected confirmation, not new work — act on whichever arrives\nfirst and process each result once. When a notification needs no action, a\none-line acknowledgment is enough.\n\n`job_list` is always current. If you have waited unusually long with no\nnotification, list jobs to re-orient before re-running anything.\n\nOrdinary watches: create the watch on the thing you want to observe. For a\nbackground job, use `job_watch(operation=\"create\", source=\u003cjob_id\u003e, ...)`.\nDelivery is implicit: matching frames return to the session that created the\nwatch. Use `output_match` for concrete job output, `progress_interval_ms` for\nperiodic progress, and `events`/`event_filter` for event frames.\n\nObserver sidecars: start the observer with `delegate(watch_parent:true)`. The\nchild observes your session with `job_watch(operation=\"create\", source=\"parent\",\n...)` and reports findings with `communicate(end_turn:true)`. That communicate\nmessage is the observer callback: when it arrives, continue from that steering.\n\nFor watch-driven tasks, complete this sequence:\n\n1. Start the observer with `watch_parent:true`.\n2. In the observer's initial turn, create `job_watch(source:\"parent\", ...)`.\n3. Have the observer report readiness only after the watch is installed.\n4. Trigger the watched action.\n5. Finish from the observer's later `communicate(end_turn:true)` callback.\n\nThe observer callback is completion evidence for the observer's task; after it\narrives, one final result message is enough unless the user asked for audit\ndetails. For normal watched-condition work, the completion path is callback to\nfinal result. Audit and diagnosis tools are for explicit audit requests or a\nfailed/missing callback. For `job_watch` create calls, keep the public shape\nsource-owned: `operation`, `source`, and optional trigger fields such as\n`output_match`, `events`, `event_filter`, `every`, or `progress_interval_ms`.\nFor `source:\"parent\"` and other session-event watches, omit trigger fields to\nreceive bounded public frames, or add `events`/`event_filter` to narrow. Frames\ncoalesce while the observer is busy — it sees the latest state, not a backlog.\nUse `events: [\"communicate\"]` for explicit result/status messages sent through\nthe result tool; `communicate` is the watchable result/status channel. Use\n`events: [\"assistant.tool\"]` for tool events; the complete filtered tool-watch\nshape adds `event_filter:{\"tool_name\":\"read_file\",\"status\":\"ok\"}`. Assistant\ntool frames include the matched `status` and original tool `arguments_json`;\nuse those frame fields as the first evidence before reaching for audit tools.\n\nWhen a watch-origin observer sends its terminal `communicate(end_turn:true)`,\nSerf records that observer job's terminal state without adding another owner\nnotification for the same job. The observer callback carrying the packet is the\nactionable signal.\n\nObserver setup is sequential when the trigger depends on the watch existing.\nAfter the trigger, Serf yields the caller turn when the frame is handed to the\nobserver; continue from the observer callback when it arrives, then finish once.\n\n`job_stop` cancels and preserves output/history. A finished delegate remains\nresumable — `delegate_send(to=\u003cdelegate_id\u003e, on_idle=\"start\")` starts its next\nturn in the same conversation as a new job.\n\n## Session transcripts\n\nTwo read-only tools inspect archived session transcripts (your own and other\nsessions on this machine). Use them for audit, forensics, prior-session search,\nor recovering compacted turns. During active delegate/watch work, use the current\ntool result, job output, notification, or observer callback as your working\nevidence; read a transcript when you specifically need the full child\nconversation history. Do not access raw transcript files directly; use these\ntools instead.\n\n- **`find_session_transcripts`** — find sessions. No arguments lists recent sessions\n  newest-first; `query` searches their content; `children_of:\"\u003ctranscript_ref\u003e\"` lists\n  the sessions a ref spawned (its subagents/forks); `scope:\"all_projects\"` widens beyond\n  this project. It returns `transcript_ref`s and never reads a session.\n- **`read_session_transcript`** — view one session by `transcript_ref` (omit for the\n  current session). `format:\"outline\"` is a one-line-per-turn map; `format:\"markdown\"`\n  (default) is the condensed conversation; `format:\"jsonl\"` is raw bytes for\n  replay/debugging only. `range` (e.g. `\"18-31\"`, `\"last:40\"`, `\"start:40\"`) selects a\n  turn window; `expand_turn:\u003cN\u003e` renders one turn's tool results in full.\n\nThe Turn numbers shown in the outline and in markdown are exactly what `range` and\n`expand_turn` accept. To audit a subagent, pass its `transcript_ref` to\n`read_session_transcript`; to follow what it did from the start, read its outline first.\n\nAfter compaction the checkpoint records this session's id; read it back with\n`read_session_transcript` to recover turns compaction removed. There is no `recall` tool.\n\n## Git safety\n\n- You may be in a dirty git worktree.\n  * NEVER revert existing changes you did not make unless explicitly requested.\n  * If changes are in files you've touched recently, read carefully and understand how you\n    can work with the changes rather than reverting them.\n  * If changes are in unrelated files, ignore them and don't revert them.\n- Do not amend a commit unless explicitly requested to do so.\n- **NEVER** use destructive commands like `git reset --hard`, `git checkout --`, `git add -A`  unless specifically requested or approved.\n- **ALWAYS** prefer using non-interactive git commands.\n\n## Security\n\n- Be thoughtful about security. Treat external input as untrusted, keep secrets out of code, and think through how the code you write could be misused.\n- Try not to read secrets directly when working in the shell. Secrets should stay out of your memory.\n- If you notice insecure code while working, report it to your human partner.\n\n## Task tracking\n\nThe `task_list` tool plans work and controls reasoning effort per step.\n\n- Use task_list for complex work with 3+ distinct steps, when you want\n  different reasoning levels at different steps (e.g. low for file reads,\n  high for code generation), or when explicit decomposition will help manage\n  context across research, implementation, verification, and delivery.\n- For simple work (read files → decide, run one command → report),\n  skip the task list entirely and just do it.\n- When you decompose a task, make each step produce a concrete handoff:\n  findings, changed files, test results, review notes, or delivery status.\n- Never use `view` to read the task list back — completed tasks inject\n  their prompts automatically as work advances.\n- Follow the task prompts that task_list injects when work advances.\n\n## Submitting your work\n\nUse communicate for every user-facing report, requested status marker,\nreadiness marker, request for input, and final answer. If you need to work, call\nthe relevant tool. If you need the user or caller to see text, send it through\ncommunicate.\n\nEvery communicate call carries visible text for the user or caller:\nput that text in `message` or `output.message`. Use `end_turn=false` only when\nyou will immediately keep working after the message. Use `end_turn=true` when\nthe message should stop the current activation: final answers, completed\nresults, blocking input requests, and readiness markers that wait for future\nuser/caller/watch-frame input.\n\nReport real milestones: requested status markers, readiness markers, input\nrequests, user/caller-visible results, and final answers. A status marker is a\nrequested user/caller-visible milestone; if internal progress should continue\nimmediately through the next work tool, use `end_turn=false`.\n\nWatch-delivery and observer-callback flow: when handling a `job_watch` frame\nthat needs no action, a short internal no-action disposition is enough. When a\nwatched trigger is handed to an observer sidecar, Serf yields the caller turn and\nresumes it from the observer's communicate callback. For frames that\nneed caller-visible status or narration while work continues, use\ncommunicate with `end_turn=false`. For the complete observer callback\nor result, use communicate with `end_turn=true`.\n\nObserver sidecars that announce readiness and keep waiting for a later watch\nframe use communicate with `end_turn=true` for the readiness marker.\nCompleted work, blocking input requests, and final answers also use\n`end_turn=true`.\n\nEvery response includes an inbox with pending user messages. Read and act on them.\n\n## Tool usage\n\n- Tool descriptions are authoritative for tool-specific semantics and argument rules.\n- When the user explicitly asks you to use a currently callable tool, call that\n  tool before reporting. Treat the requested tool call as part of the task.\n- Inspect relevant files before modifying them. For patch-style updates to an\n  existing file, build hunks from the exact current lines.\n- Batch independent tool calls into a single response — e.g. read\n  multiple files at once instead of one per round.\n- Dependency-producing tools go first in their own response. When a later step\n  needs a `delegate_id`, `job_id`, `watch_id`, readiness marker, or file content\n  from an earlier tool result, issue the earlier tool call, read its result, then\n  issue the dependent call in the next response.\n- A watched trigger depends on the watch creation result. Create the observer\n  watch, read the `watch_id`, then trigger the watched event in the following\n  response.\n- When using the shell to search text or files, prefer `rg` or `rg --files` if available.\n- After running commands, read errors carefully and fix them.\n\n\u003cenvironment\u003e\nWorking directory: /tmp/serf-eval/work\nPlatform: linux\nOS version: Linux 6.8.0-110-generic\nToday's date: 2026-06-22\nModel: claude-sonnet-4-6\nKnowledge cutoff: 2025-04-01\n\u003c/environment\u003e\n\n\u003cgit\u003e\nNot a git repository.\n\u003c/git\u003e\n\n\u003cskill-catalog\u003e\nLoad a skill by calling use_skill with its name. The response includes the skill directory path for accessing scripts and other collateral.\n- superpowers:subagent-driven-development: Use when executing implementation plans with independent tasks in the current session [/home/jesse/git/superpowers/skills/subagent-driven-development]\n- superpowers:receiving-code-review: Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical rigor and verification, not performative agreement or blind implementation [/home/jesse/git/superpowers/skills/receiving-code-review]\n- superpowers:executing-plans: Use when you have a written implementation plan to execute in a separate session with review checkpoints [/home/jesse/git/superpowers/skills/executing-plans]\n- superpowers:using-superpowers: Use when starting any conversation - establishes how to find and use skills, requiring skill invocation before ANY response including clarifying questions [/home/jesse/git/superpowers/skills/using-superpowers]\n- doctoring-serf: Use when diagnosing a serf session, job, watch, or the session tree — investigating watch self-loops, dropped/coalesced deliveries, \"how many times did X actually get called\", stuck turns, or parent↔delegate↔observer linkage. Covers the serf-doctor forensic tools, the Finding contract, runbook authoring, and graduated repair. [/tmp/serf-skills-1202785663/doctoring-serf]\n- superpowers:verification-before-completion: Use when about to claim work is complete, fixed, or passing, before committing or creating PRs - requires running verification commands and confirming output before making any success claims; evidence before assertions always [/home/jesse/git/superpowers/skills/verification-before-completion]\n- superpowers:writing-plans: Use when you have a spec or requirements for a multi-step task, before touching code [/home/jesse/git/superpowers/skills/writing-plans]\n- superpowers:requesting-code-review: Use when completing tasks, implementing major features, or before merging to verify work meets requirements [/home/jesse/git/superpowers/skills/requesting-code-review]\n- superpowers:systematic-debugging: Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes [/home/jesse/git/superpowers/skills/systematic-debugging]\n- superpowers:test-driven-development: Use when implementing any feature or bugfix, before writing implementation code [/home/jesse/git/superpowers/skills/test-driven-development]\n- superpowers:using-git-worktrees: Use when starting feature work that needs isolation from current workspace or before executing implementation plans - ensures an isolated workspace exists via native tools or git worktree fallback [/home/jesse/git/superpowers/skills/using-git-worktrees]\n- superpowers:dispatching-parallel-agents: Use when facing 2+ independent tasks that can be worked on without shared state or sequential dependencies [/home/jesse/git/superpowers/skills/dispatching-parallel-agents]\n- superpowers:writing-skills: Use when creating new skills, editing existing skills, or verifying skills work before deployment [/home/jesse/git/superpowers/skills/writing-skills]\n- superpowers:brainstorming: You MUST use this before any creative work - creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation. [/home/jesse/git/superpowers/skills/brainstorming]\n- superpowers:finishing-a-development-branch: Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completion of development work by presenting structured options for merge, PR, or cleanup [/home/jesse/git/superpowers/skills/finishing-a-development-branch]\n\u003c/skill-catalog\u003e\n\n\u003cavailable_agents\u003e\nThe following subagent types are available for `delegate` with the `agent_type` parameter:\n\u003cagent\u003e\nName: `default`\nDescription: General-purpose agent. Handles a wide range of tasks directly with the broadest non-delegation toolset.\nDefault tools: `apply_patch`, `communicate`, `compact`, `delegate`, `delegate_send`, `edit_file`, `find_session_transcripts`, `glob`, `grep`, `job_list`, `job_read_output`, `job_stop`, `job_watch`, `list_dir`, `read_file`, `read_session_transcript`, `shell`, `task_list`, `update_goal`, `use_skill`, `web_fetch`, `write_file`\nDefault task list:\n- none\n\u003c/agent\u003e\n\u003cagent\u003e\nName: `doctor`\nDescription: On-demand forensic auditor for serf sessions, jobs, watches, and the session tree. Reads canonical durable state through the serf-doctor tools and emits structured Findings. Spawn it or delegate to it to diagnose a session — its own, another's, or a fleet — and to write/repair runbooks under graduated guardrails.\nDefault tools: `apply_patch`, `communicate`, `glob`, `grep`, `read_file`, `shell`, `task_list`, `write_file`\nDefault task list:\n- none\n\u003c/agent\u003e\n\u003cagent\u003e\nName: `explorer`\nDescription: Fast workspace scout. Reports what files, tools, and tests exist.\nDefault tools: `communicate`, `glob`, `grep`, `read_file`, `shell`, `task_list`\nDefault task list:\n- `Scan workspace`: List files, identify tests, data files, and deliverables. Include relevant parent task details in the `delegate` task prompt for this step.\n\u003c/agent\u003e\n\u003cagent\u003e\nName: `subagent`\nDescription: Focused subagent for a single scoped task. A non-delegating leaf: it has no `delegate` tool and cannot spawn further agents regardless of any delegation_allowance granted to it. It can send results or observer callbacks to its caller. For a multi-level tree, delegate with the default role instead of this one.\nDefault tools: `apply_patch`, `communicate`, `delegate_send`, `glob`, `grep`, `read_file`, `shell`, `task_list`, `web_fetch`, `write_file`\nDefault task list:\n- none\n\u003c/agent\u003e\n\u003c/available_agents\u003e\n\n## Non-interactive mode — CRITICAL\n\nYou are running in a non-interactive, headless environment. There is no human available to\nanswer questions, provide clarification, or confirm your approach.\n\nRULES (these override ANY skill instructions that conflict):\n- The task prompt IS the complete specification. Read it carefully, then get to work.\n- Use `communicate` with `end_turn=true` for your final answer or a blocking request for input.\n- If a skill says \"ask your human partner\", \"confirm with user\", or \"explore user intent\":\n  make those judgment calls yourself. You are both the implementer and the decision-maker.",
+    "working_dir": "/tmp/serf-eval/work"
+  }
+}

--- a/test/fs-verbs-bootstrap.test.ts
+++ b/test/fs-verbs-bootstrap.test.ts
@@ -439,6 +439,18 @@ test('bootstrap-installed passes for pi (no dedicated check)', () => {
   expect(out.passed).toBe(true);
 });
 
+test('bootstrap-installed passes for serf (no dedicated check)', () => {
+  // serf loads Superpowers via --plugin-dir SUPERPOWERS_ROOT (no staging, like
+  // claude), so there is nothing to verify on disk; the bootstrap is proven
+  // behaviorally by the scenario.
+  const out = verbBootstrapInstalled(
+    [],
+    ctxFor(configDir(), { QUORUM_CODING_AGENT: 'serf' }),
+  );
+  expect(out.passed).toBe(true);
+  expect(out.detail).toContain('no dedicated install check');
+});
+
 test('bootstrap-installed fails for an unrecognized agent', () => {
   const out = verbBootstrapInstalled(
     [],

--- a/test/normalize.serf.test.ts
+++ b/test/normalize.serf.test.ts
@@ -94,6 +94,54 @@ test('normalizeSerf maps delegate -> Agent (task -> prompt), bash -> Bash, read_
   );
 });
 
+test('normalizeSerf lifts serf cache-creation tokens to the obol-priced extra.cache_write key', () => {
+  // serf records cache-creation under metrics.extra.cache_write_tokens; obol
+  // prices it only from step.extra.cache_write (the key claude's normalizer
+  // uses). Without the lift, serf cost is undercounted.
+  const raw = readFileSync(REAL_FIXTURE, 'utf8');
+  const traj = normalizeSerf(raw, 'unknown');
+
+  let liftedTotal = 0;
+  let liftedSteps = 0;
+  for (const step of traj.steps) {
+    const cw = step.extra?.['cache_write'];
+    if (typeof cw === 'number' && cw > 0) {
+      liftedTotal += cw;
+      liftedSteps += 1;
+    }
+  }
+  // The real fixture carries 7 steps summing to 22201 cache-write tokens.
+  expect(liftedSteps).toBe(7);
+  expect(liftedTotal).toBe(22201);
+});
+
+test('normalizeSerf synthetic step lifts cache_write_tokens onto step.extra.cache_write', () => {
+  const traj = normalizeSerf(
+    JSON.stringify({
+      schema_version: 'ATIF-v1.7',
+      agent: { name: 'serf', version: 'v0.9.0' },
+      steps: [
+        {
+          step_id: 1,
+          source: 'agent',
+          message: 'x',
+          metrics: {
+            prompt_tokens: 10,
+            completion_tokens: 5,
+            cached_tokens: 100,
+            extra: { cache_write_tokens: 42 },
+          },
+          extra: { serf_kind: 'keep-me' },
+        },
+      ],
+    }),
+    'unknown',
+  );
+  expect(traj.steps[0]?.extra?.['cache_write']).toBe(42);
+  // existing step.extra is preserved.
+  expect(traj.steps[0]?.extra?.['serf_kind']).toBe('keep-me');
+});
+
 test('normalizeSerf fails closed on non-JSON and non-conformant input', () => {
   expect(() => normalizeSerf('not json{', 'unknown')).toThrow();
   expect(() => normalizeSerf('[]', 'unknown')).toThrow();

--- a/test/normalize.serf.test.ts
+++ b/test/normalize.serf.test.ts
@@ -1,0 +1,101 @@
+import { expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { flattenToolCalls } from '../src/atif/project.ts';
+import { validateTrajectory } from '../src/atif/validate.ts';
+import { normalizeSerf } from '../src/normalize/serf.ts';
+
+const REAL_FIXTURE = join(
+  import.meta.dir,
+  'fixtures',
+  'serf-real-trajectory.json',
+);
+
+// A real serf `--export-atif` trajectory (claude-sonnet-4-6 on "Let's make a
+// react todo list") is the ground truth: it must round-trip through quorum's
+// validator and surface the brainstorming skill activation.
+test('normalizeSerf accepts a real serf ATIF export and validates as v1.7', () => {
+  const raw = readFileSync(REAL_FIXTURE, 'utf8');
+  const traj = normalizeSerf(raw, 'unknown');
+
+  expect(traj.schema_version).toBe('ATIF-v1.7');
+  expect(traj.agent.name).toBe('serf');
+  expect(validateTrajectory(traj).ok).toBe(true);
+});
+
+test('normalizeSerf canonicalizes use_skill -> Skill with a qualified skill arg', () => {
+  const raw = readFileSync(REAL_FIXTURE, 'utf8');
+  const calls = flattenToolCalls(normalizeSerf(raw, 'unknown'));
+
+  const skillCalls = calls.filter((c) => c.tool === 'Skill');
+  expect(skillCalls.length).toBeGreaterThan(0);
+  expect(skillCalls.map((c) => c.args['skill'])).toContain(
+    'superpowers:brainstorming',
+  );
+  // No raw native name leaks past the normalizer.
+  expect(calls.some((c) => c.tool === 'use_skill')).toBe(false);
+});
+
+// Synthetic trajectory exercising the tool mappings the brainstorming run did
+// not (delegate, bash, read_file). serf already emits canonical arg keys
+// (file_path, command), so only names + the Agent prompt key are rewritten.
+const syntheticSerf = {
+  schema_version: 'ATIF-v1.7',
+  session_id: 'sess-synthetic',
+  agent: { name: 'serf', version: 'v0.9.0', model_name: 'claude-sonnet-4-6' },
+  steps: [
+    {
+      step_id: 1,
+      source: 'user',
+      message: 'do work',
+      extra: {},
+    },
+    {
+      step_id: 2,
+      source: 'agent',
+      message: 'working',
+      tool_calls: [
+        {
+          tool_call_id: 'c1',
+          function_name: 'delegate',
+          arguments: { task: 'review the code', agent_type: 'subagent' },
+        },
+        {
+          tool_call_id: 'c2',
+          function_name: 'bash',
+          arguments: { command: 'ls' },
+        },
+        {
+          tool_call_id: 'c3',
+          function_name: 'read_file',
+          arguments: { file_path: '/tmp/x.txt' },
+        },
+      ],
+      extra: {},
+    },
+  ],
+  extra: {},
+};
+
+test('normalizeSerf maps delegate -> Agent (task -> prompt), bash -> Bash, read_file -> Read', () => {
+  const traj = normalizeSerf(JSON.stringify(syntheticSerf), 'unknown');
+  expect(validateTrajectory(traj).ok).toBe(true);
+
+  const calls = flattenToolCalls(traj);
+  const agent = calls.find((c) => c.tool === 'Agent');
+  expect(agent).toBeDefined();
+  expect(agent?.args['prompt']).toBe('review the code');
+  // task is renamed, not duplicated.
+  expect(agent?.args['task']).toBeUndefined();
+
+  expect(calls.find((c) => c.tool === 'Bash')?.args['command']).toBe('ls');
+  expect(calls.find((c) => c.tool === 'Read')?.args['file_path']).toBe(
+    '/tmp/x.txt',
+  );
+});
+
+test('normalizeSerf fails closed on non-JSON and non-conformant input', () => {
+  expect(() => normalizeSerf('not json{', 'unknown')).toThrow();
+  expect(() => normalizeSerf('[]', 'unknown')).toThrow();
+  expect(() => normalizeSerf('{"agent":{}}', 'unknown')).toThrow();
+});


### PR DESCRIPTION
## What problem are you trying to solve?
quorum had no way to run **serf** (github.com/prime-radiant-inc/serf, a non-interactive coding agent) as a Coding-Agent under test. We want serf in the eval matrix so its skill-compliance and cost/quality can be measured against the other harnesses.

## What does this PR change?
Adds serf as a full Coding-Agent harness: `coding-agents/serf.yaml` + `serf-context/{launch-agent,HOWTO.md}`, a `SerfAgent` provisioner, a near-passthrough ATIF normalizer (`src/normalize/serf.ts`), and wiring into the runtime-family set, agent registry, NORMALIZERS, runner `$SERF_MODEL` substitution, and the `bootstrap-installed` check. Also fixes three serf-specific capture/cost issues found while validating it (cache-creation token pricing, coding `duration_ms` capture) and corrects a stale Gauntlet repo path in the docs.

## Relationship to superpowers
serf is a drop-in Claude Code plugin host: it loads the unmodified Superpowers plugin via `--plugin-dir` and fires the `using-superpowers` SessionStart bootstrap, so skills auto-trigger. Verified end-to-end: a live `quorum run scenarios/superpowers-bootstrap --coding-agent serf` **passes** — `brainstorming` auto-triggers before any code, and the exported trajectory passes quorum's ATIF validator. This extends quorum's harness coverage to serf so superpowers' skills can be measured on it. Depends on prime-radiant-inc/serf#8 (serf emits ATIF v1.7), already merged to serf `main`.

## Security and eval-lab checklist
- [x] This PR does not commit API keys, `.env` files, session logs, `results/`, or other run artifacts
- [x] This PR does not cause CI to run live agent evals, call model APIs, or require `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`
- [x] If this touches dangerous-mode backend flags, shell execution, environment inheritance, or log collection, the risk is explained below
- [x] If this adds or changes a scenario, setup helper, or assertion command, I considered how untrusted input could affect shell execution

Risk notes: The serf launcher runs `serf` in `--dangerously-skip-permissions`-equivalent autonomous mode inside the per-run throwaway `$HOME` (same isolation model as the existing claude/opencode launchers), forwards only allowlisted provider-key env vars, and points `SERF_PROVIDERS_CONFIG` at a fresh per-run path so it never reads the operator's `~/.serf`. No CI live evals; live `quorum run` stays a trusted-maintainer op.

## Existing work
- [x] I searched for related open and closed PRs/issues/tickets
- Related work: none found — serf is a new harness; no prior serf integration in this repo.

## Tests
```
bun run typecheck    # clean
bun run lint         # clean
bun run quorum check # all scenarios ok
bun test test/normalize.serf.test.ts test/agent-serf.test.ts test/agents-resolve.test.ts test/fs-verbs-bootstrap.test.ts test/capture.test.ts  # pass
```
Live end-to-end: `quorum run scenarios/superpowers-bootstrap --coding-agent serf` → **pass** (Gauntlet-Agent pass + all post-checks; brainstorming auto-triggered). Note: the full `bun test` has ~20 pre-existing, environmental failures (opencode/kimi/claude binary-on-PATH + tmpdir perms in this sandbox) unrelated to this change — verified identical on a clean tree.

## Human review
- [x] A maintainer has reviewed the complete proposed diff before merge

## Parent submodule follow-up
- [x] If this PR merges to `main`, a parent `superpowers` submodule bump PR into `dev` will be opened

🤖 Authored with Claude Code (Opus 4.8), maintainer-directed throughout.

https://claude.ai/code/session_01HtiJKYUr4J4K1ECfyrfUH4