### PR TITLE
fix(pi): coherent @earendil-works pi packages + drift-free eval-agent pins

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -96,7 +96,8 @@ RUN npm install -g \
     openclaw \
     @sourcegraph/amp \
     cline \
-    @mariozechner/pi-coding-agent \
+    @earendil-works/pi-coding-agent@0.80.1 \
+    pi-subagents@0.28.0 \
     @xai-official/grok \
   && if command -v kilocode >/dev/null 2>&1 && ! command -v kilo >/dev/null 2>&1; then ln -s "$(command -v kilocode)" /usr/local/bin/kilo; fi \
   && if command -v factory >/dev/null 2>&1 && ! command -v droid >/dev/null 2>&1; then ln -s "$(command -v factory)" /usr/local/bin/droid; fi \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -84,9 +84,9 @@ RUN curl -fsSL https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise sh \
   && mise --version
 
 RUN npm install -g \
-    @anthropic-ai/claude-code \
-    @openai/codex \
-    @google/gemini-cli \
+    @anthropic-ai/claude-code@2.1.181 \
+    @openai/codex@0.140.0 \
+    @google/gemini-cli@0.47.0 \
     opencode-ai \
     @github/copilot \
     @factory/cli \


### PR DESCRIPTION
## What
Fixes `pi` in the eval Docker image and pins the eval-agent CLIs for reproducible builds.

- **pi never launched.** `pi-subagents` was made a launcher prerequisite (61c58ce) but never added to the Dockerfile; meanwhile the image's `@mariozechner/pi-coding-agent` is deprecated (0.73.1) and modern `pi-subagents` peer-depends on the renamed `@earendil-works/*` → `Cannot find module '@earendil-works/pi-coding-agent'`. Replaced with the coherent `@earendil-works/pi-coding-agent@0.80.1` + `pi-subagents@0.28.0` pair (the host's working combo; both ship bin `pi`, so no adapter/launcher/`pi.yaml` change).
- **Pinned** `@anthropic-ai/claude-code@2.1.181`, `@openai/codex@0.140.0`, `@google/gemini-cli@0.47.0` so rebuilding the otherwise-unpinned `npm install -g` layer doesn't silently drift the verified eval agents.

## Verified
Rebuilt the image: `pi 0.80.1` + `pi-subagents` resolve; claude/codex/gemini pins intact; build succeeds.

## Known remaining blocker (separate follow-up — NOT fixed here)
pi launches but does not yet *run* evals: the adapter seeds pi's provider from the host `~/.pi` config, currently a custom `glm-lunaroute-test` GLM provider that isn't reproducible in the container → "Unknown provider". Resolving that needs pi's eval credential pinned to a reproducible provider (or the provider defined in the image) — a config decision, not a packaging one.

Authoring: agent-generated (Claude Code) under maintainer direction.

https://claude.ai/code/session_01Hz32pBE7kiqr78DY6PWmZN