### PR TITLE
feat(credential): add pinned claude-sonnet-5 credential for the claude harness

### DIFF
--- a/credentials.yaml
+++ b/credentials.yaml
@@ -21,6 +21,23 @@ haiku:
   api_key_env: ANTHROPIC_API_KEY
   harnesses: [claude]
 
+sonnet5:
+  # Claude Sonnet 5. Pinned to the stable generation id `claude-sonnet-5` (the
+  # bare id is canonical; Anthropic publishes no dated snapshot for it) rather
+  # than the floating `sonnet` alias, so the benchmarked model can't silently
+  # repoint to a later Sonnet and break longitudinal comparability.
+  # COST CAVEAT: obol's bundled rate table (as_of 2026-06-08) has no
+  # claude-sonnet-5 key, and Claude session logs embed no cost_usd, so runs
+  # report est_cost_usd: null / partial: true. Token counts are correct and the
+  # pass/fail verdict is unaffected; only the dollar figure is missing until
+  # obol learns the rate. Intro pricing is $2/$10 per MTok through 2026-08-31
+  # (standard $3/$15); obol has no time-windowed rates, so whoever prices it
+  # must pick which window applies.
+  model: claude-sonnet-5
+  api: anthropic
+  api_key_env: ANTHROPIC_API_KEY
+  harnesses: [claude]
+
 opencode_gpt5:
   # OpenAI gpt-5.5. base_url is OpenAI's first-party host (api.openai.com), which
   # the opencode translator routes to opencode's BUILT-IN `openai` provider (by


### PR DESCRIPTION
Adds an opt-in `sonnet5` credential pinning the stable `claude-sonnet-5` id for benchmarking the Claude coding-agent on Sonnet 5. The default claude credential is unchanged (still `opus`).

- Pinned id (not the floating `sonnet` alias) for longitudinal comparability — mirrors the pinned `haiku` precedent.
- Inline comment documents the obol pricing gap (no `claude-sonnet-5` rate as_of 2026-06-08 → `est_cost_usd: null` / `partial`) and the $2/$10 introductory window through 2026-08-31.
- `quorum check` passes; 25 credential tests pass.

Needed on `main` so the shared appliance (`evals_ref=main`) can run `--credentials sonnet5` for a Sonnet 5 × superpowers `v6.1.0` sentinel (context: obra/superpowers#1878).

🤖 Generated with [Claude Code](https://claude.com/claude-code)