### PR TITLE
feat(credential): add pinned claude-sonnet-4-6 credential for the claude harness

### DIFF
--- a/credentials.yaml
+++ b/credentials.yaml
@@ -38,6 +38,16 @@ sonnet5:
   api_key_env: ANTHROPIC_API_KEY
   harnesses: [claude]
 
+sonnet46:
+  # Claude Sonnet 4.6 — the previous-generation Sonnet, pinned as the control for
+  # `sonnet5` (Sonnet 5) comparisons so the benchmarked model can't drift with the
+  # floating `sonnet` alias. Unlike sonnet5, obol's bundled rate table includes
+  # claude-sonnet-4-6, so this column reports real coding cost.
+  model: claude-sonnet-4-6
+  api: anthropic
+  api_key_env: ANTHROPIC_API_KEY
+  harnesses: [claude]
+
 opencode_gpt5:
   # OpenAI gpt-5.5. base_url is OpenAI's first-party host (api.openai.com), which
   # the opencode translator routes to opencode's BUILT-IN `openai` provider (by


### PR DESCRIPTION
Adds an opt-in `sonnet46` credential pinning `claude-sonnet-4-6` (previous-generation Sonnet) as the control for `sonnet5` comparisons — the `sonnet` alias floats and can't anchor a benchmark. Default claude credential unchanged (still `opus`).

- `quorum check` passes.
- obol prices `claude-sonnet-4-6`, so this column reports real coding cost (unlike `sonnet5`, which is unpriced).
- Needed on `main` so the appliance (`evals_ref=main`) can run `--credentials sonnet46` for a Sonnet 4.6 vs Sonnet 5 comparison on superpowers `v6.1.0`.

Note: `main`'s `test` CI is pre-existing red (SUP-410, agent CLI binaries absent in the runner) — unrelated to this additive YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)