### PR TITLE
fix: make CI green — test hermeticity + container build fixes

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -112,7 +112,9 @@ RUN mkdir -p /opt/cursor-agent \
   && ln -sf /opt/cursor-agent/.local/bin/cursor-agent /usr/local/bin/cursor-agent \
   && agent --version
 
-RUN uv tool install mini-swe-agent \
+# Both tools pin Python 3.12: litellm builds a pyo3 extension whose maximum
+# supported interpreter is 3.13, and unpinned uv resolves to CPython 3.14.
+RUN uv tool install --python 3.12 mini-swe-agent \
   && uv tool install --python 3.12 "trae-agent[test,evaluation] @ git+https://github.com/bytedance/trae-agent.git" \
   && chmod -R a+rX "$UV_TOOL_DIR" "$UV_PYTHON_INSTALL_DIR" \
   && mini-swe-agent --help >/dev/null \

--- a/src/agents/kimi.ts
+++ b/src/agents/kimi.ts
@@ -826,28 +826,48 @@ function validateSuperpowersKimiRoot(rootArg: string): string {
   return resolved;
 }
 
-// Compute a temp-dir parent that is NOT inside the run artifact root, so the
-// capture snapshot never sweeps up the mode-0600 secret env file. The artifact
-// root is run_dir's parent. If the OS tmpdir (or override) resolves inside the
-// artifact root, walk one level above the artifact root. As a last-line guard,
-// RAISE if the chosen parent still resolves inside the artifact root.
-function kimiRuntimeEnvTempParent(
-  runDir: string,
-  tmpDirOverride?: string,
-): string {
-  const runDirResolved = realpathSync(resolve(runDir));
+// Make the run-scoped secret dir under a temp parent that is NOT inside the
+// run artifact root, so the capture snapshot never sweeps up the mode-0600
+// secret env file. The artifact root is run_dir's parent. Candidates, in
+// order: the OS tmpdir (or override); one level above the artifact root (for
+// when tmpdir resolves inside it); a ~/.quorum-tmp fallback (the level-above
+// walk can land on an unwritable dir — '/' when the artifact root sits
+// directly under /tmp, e.g. --out-root /tmp). A candidate that resolves
+// inside the artifact root or refuses the mkdtemp is skipped; exhausting all
+// candidates raises.
+function makeKimiRuntimeEnvSecretDir(opts: {
+  readonly runDir: string;
+  readonly tmpDirOverride?: string;
+}): string {
+  const runDirResolved = realpathSync(resolve(opts.runDir));
   const artifactRootResolved = dirname(runDirResolved);
-  let tempParent = realpathSync(resolve(tmpDirOverride ?? tmpdir()));
-  if (isInsideOrEqual(tempParent, artifactRootResolved)) {
-    tempParent = dirname(artifactRootResolved);
+  const candidates = [
+    resolve(opts.tmpDirOverride ?? tmpdir()),
+    dirname(artifactRootResolved),
+    join(homedir(), '.quorum-tmp'),
+  ];
+  for (const candidate of candidates) {
+    let parent: string;
+    try {
+      mkdirSync(candidate, { recursive: true });
+      parent = realpathSync(candidate);
+    } catch {
+      continue;
+    }
+    if (isInsideOrEqual(parent, artifactRootResolved)) {
+      continue;
+    }
+    try {
+      return mkdtempSync(
+        join(parent, `quorum-kimi-env-${basename(opts.runDir)}-`),
+      );
+    } catch {
+      continue;
+    }
   }
-  mkdirSync(tempParent, { recursive: true });
-  if (isInsideOrEqual(realpathSync(tempParent), artifactRootResolved)) {
-    throw new ProvisionError(
-      'Kimi runtime env temp directory resolved inside artifact root',
-    );
-  }
-  return tempParent;
+  throw new ProvisionError(
+    'no writable Kimi runtime env temp directory outside the artifact root',
+  );
 }
 
 // Is `candidate` the same as or nested under `ancestor`?
@@ -864,10 +884,7 @@ export function writeKimiRuntimeEnvFile(
   env: Readonly<Record<string, string>>,
   opts: { readonly runDir: string; readonly tmpDirOverride?: string },
 ): string {
-  const tempParent = kimiRuntimeEnvTempParent(opts.runDir, opts.tmpDirOverride);
-  const secretDir = mkdtempSync(
-    join(tempParent, `quorum-kimi-env-${basename(opts.runDir)}-`),
-  );
+  const secretDir = makeKimiRuntimeEnvSecretDir(opts);
   const path = join(secretDir, KIMI_RUNTIME_ENV_FILE_NAME);
   const keys = Object.keys(env).sort();
   const body = keys

--- a/test/agent-kimi.test.ts
+++ b/test/agent-kimi.test.ts
@@ -954,6 +954,33 @@ test('writeKimiRuntimeEnvFile walks the temp parent out when tmpdir is inside th
   }
 });
 
+test('writeKimiRuntimeEnvFile falls back when the walked-out temp parent is unwritable', () => {
+  // When the artifact root sits directly under the OS tmpdir (e.g.
+  // --out-root /tmp), walking one level above it lands on '/', which is not
+  // writable. The secret dir must fall back to a writable parent that is
+  // still outside the artifact root, not crash with EACCES.
+  const base = mkdtempSync(join(tmpdir(), 'kimi-locked-'));
+  const locked = join(base, 'locked');
+  const artifactRoot = join(locked, 'artifacts');
+  const runDir = join(artifactRoot, 'run-x');
+  const insideTmp = join(artifactRoot, 'tmp-inside');
+  mkdirSync(runDir, { recursive: true });
+  mkdirSync(insideTmp, { recursive: true });
+  // The walk target (parent of the artifact root) refuses new entries.
+  chmodSync(locked, 0o555);
+  try {
+    const path = writeKimiRuntimeEnvFile(
+      { KIMI_MODEL_API_KEY: API_KEY },
+      { runDir, tmpDirOverride: insideTmp },
+    );
+    expect(existsSync(path)).toBe(true);
+    expect(path.startsWith(`${realpathSync(artifactRoot)}/`)).toBe(false);
+  } finally {
+    chmodSync(locked, 0o755);
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Live preflight session_index / workDir / sessionDir / wire.jsonl attribution
 // ---------------------------------------------------------------------------

--- a/test/agent-opencode.test.ts
+++ b/test/agent-opencode.test.ts
@@ -1,15 +1,18 @@
-import { expect, test } from 'bun:test';
+import { afterAll, beforeAll, expect, test } from 'bun:test';
 import {
   chmodSync,
   existsSync,
   lstatSync,
   mkdirSync,
+  mkdtempSync,
   readFileSync,
   readlinkSync,
+  rmSync,
   statSync,
   symlinkSync,
   writeFileSync,
 } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { CommandResult } from '../src/agents/command-runner.ts';
 import { ProvisionError } from '../src/agents/index.ts';
@@ -23,6 +26,24 @@ import type { AgentConfig } from '../src/contracts/agent-config.ts';
 import type { Credential } from '../src/contracts/credential.ts';
 import { FakeCommandRunner } from './fake-command-runner.ts';
 import { makeTempHome } from './provision-helpers.ts';
+
+// The provision preflight probes PATH for the real `opencode` binary
+// (Bun.which); dev machines have it, a bare CI runner does not. Every test in
+// this file runs with a shim dir prepended so the probe resolves
+// hermetically. Tests that need a different PATH (the node-absent B2 case)
+// still override it themselves inside the test body.
+const SHIM_BIN = mkdtempSync(join(tmpdir(), 'opencode-shim-'));
+writeFileSync(join(SHIM_BIN, 'opencode'), '#!/bin/sh\nexit 0\n');
+chmodSync(join(SHIM_BIN, 'opencode'), 0o755);
+const PREV_PATH = process.env['PATH'];
+beforeAll(() => {
+  process.env['PATH'] = `${SHIM_BIN}:${PREV_PATH ?? ''}`;
+});
+afterAll(() => {
+  if (PREV_PATH === undefined) delete process.env['PATH'];
+  else process.env['PATH'] = PREV_PATH;
+  rmSync(SHIM_BIN, { recursive: true, force: true });
+});
 
 // An opencode.yaml-shaped config (mirrors coding-agents/opencode.yaml). The
 // fields the adapter reads are home_config_subdir and required_env

--- a/test/mock-gauntlet/claude
+++ b/test/mock-gauntlet/claude
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# PATH-presence shim: satisfies the runner's Bun.which('claude') preflight and
+# the best-effort provenance `--version` probe on hosts without Claude Code
+# (CI). The mock gauntlet never launches the coding agent, so nothing else
+# executes this.
+if [ "${1:-}" = "--version" ]; then
+  echo "0.0.0 (mock-claude)"
+fi
+exit 0


### PR DESCRIPTION
## Problem

The required `test` check has failed **100/100 recent runs back to June 15** — it has plausibly never been green, and merges have been happening via admin bypass. Separately, the container image stopped being buildable at all.

Four independent root causes, one commit each:

## 1. `fix(container): pin mini-swe-agent to Python 3.12`

`litellm` 1.92.0 (via unpinned `mini-swe-agent`) now ships a pyo3 extension capped at Python ≤3.13; unpinned uv picks CPython 3.14 as the build interpreter → maturin aborts → **no image can be rebuilt**. Pin `--python 3.12` like the adjacent trae-agent line.

## 2. `fix(kimi): fall back when the secret-dir temp parent is unwritable`

Real bug, not test debt: when the artifact root sits directly under the OS tmpdir (`--out-root /tmp`, or any run dir mkdtemp'd into `/tmp` — which is exactly what the tests do), the walk-one-level-up logic lands on `/` and mkdtemp dies with EACCES. macOS masks it (deeply nested tmpdir); Linux exposes it — all ~11 agent-kimi CI failures. Fix: ordered candidate chain (tmpdir/override → one level above artifact root → `~/.quorum-tmp`), first writable parent outside the artifact root wins. TDD: new red test simulates the unwritable walk target.

## 3. `test(cli): add a claude PATH shim next to the mock gauntlet`

The runner's setup preflight requires `claude` on PATH (`Bun.which`). cli-run / cli-run-sigint / runner-e2e only passed on hosts with Claude Code installed; on a bare runner every run exits 2 at setup, and the SIGINT pair burns its full 30s timeout. The shim sits in the `test/mock-gauntlet` dir all three files already prepend to PATH.

## 4. `test(opencode): shim the opencode binary onto PATH for the whole file`

provision's fail-fast probes PATH for real `opencode`. The tests fake every subprocess but the presence probe escapes the seam → all ~17 provision tests fail on a bare runner. File-scoped shim dir, mirroring the file's own B2 node-absent technique.

## Verification

- Full suite under a CI-like sanitized env (no agent CLIs on PATH, no git identity): **1877 pass / 0 fail** (was 35 fail)
- Full suite under normal dev env: pass (two pre-existing load flakes in `runner-guards` / `runner-credential` surface only under full-suite contention, 3/3 green in isolation — not touched by this PR, tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)