### PR TITLE
docs(experiments): dev-tip TDD-pressure regression screen — CLOSED, drift not regression

### DIFF
--- a/docs/experiments/2026-07-14-dev-tip-regression-screen.md
+++ b/docs/experiments/2026-07-14-dev-tip-regression-screen.md
@@ -1,0 +1,58 @@
+# Dev-tip TDD-pressure regression screen (pre-registered)
+
+**Date:** 2026-07-14 · **Status:** RUNNING · **Author:** Drew (+ harness)
+
+## Why
+
+Across the two 1934 batches, the pooled pass rate on
+`tdd-holds-under-tests-later-pressure` dropped from 68% (41/60, 07-13, all
+arms on v6.1.x-era content) to 45% (18/40, 07-14, both arms on dev-tip-era
+content) — Fisher p=0.024. Two candidate explanations the data cannot
+separate: (a) superpowers content between v6.1.1 and dev tip (notably the
+`writing-good-tests` ground-up rewrite at the then-dev-HEAD) lowered the
+behavior, or (b) day-to-day environment/model drift. This screen separates
+them with a same-day interleaved pair.
+
+## Pre-verified surface facts
+
+Between the two arms: identical 14-skill set; all skill descriptions
+byte-identical except `finishing-a-development-branch` (#1933, unrelated
+to a TDD-pressure prompt); `using-superpowers`, hooks/, and every
+`.  *-plugin` manifest byte-identical; TDD skill description identical.
+The invocation surface is the same, so the mechanistic prior is FLAT; a
+real gap would implicate post-load content (or an undocumented surface).
+
+## Design
+
+| Arm | Content | superpowers ref |
+|---|---|---|
+| F | v6.1.1 (campaign-era baseline) | `c809093a2a449e1772e8c87f41ceb6d5e7135464` |
+| G | dev tip (includes merged #1934) | `4562d18dcfc1ff7c65ec9aae5848539532724a1d` |
+
+Same-day, interleaved F,G; n=20 valid/arm; claude on `opus_bedrock` at
+claude-code **2.1.209** (agent-CLI refresh, PR #31 — both arms on the new
+CLI, so this screen is internally valid but its absolute rates are NOT
+comparable to the 07-13/07-14 batches at 2.1.202); grader claude-sonnet-5;
+indeterminates excluded + topped up, max 25 submissions/arm.
+
+## Pre-registered decision rules
+
+1. Fisher two-sided F vs G. **p<0.05 with G<F** → content-linked
+   regression confirmed; localize before any fix: mechanism audit splits
+   fails into invocation-miss vs loaded-then-failed; loaded-dominant →
+   suspect the writing-good-tests rewrite body; invocation-dominant →
+   audit injected context per run before touching content.
+2. **p≥0.05** → the 07-13→07-14 drop is attributed to day/environment
+   drift; record that absolute rates on this probe are not longitudinally
+   comparable and close.
+3. Indeterminates >5 in one arm → flag infra-compromised, do not conclude.
+4. Mechanism audit on all failing runs regardless of outcome.
+
+## Prediction (locked)
+
+Uncertain by design. The surface-identity facts argue FLAT; the p=0.024
+cross-day observation is the reason to check anyway.
+
+## Results
+
+(pending)

--- a/docs/experiments/2026-07-14-dev-tip-regression-screen.md
+++ b/docs/experiments/2026-07-14-dev-tip-regression-screen.md
@@ -53,6 +53,29 @@ indeterminates excluded + topped up, max 25 submissions/arm.
 Uncertain by design. The surface-identity facts argue FLAT; the p=0.024
 cross-day observation is the reason to check anyway.
 
-## Results
+## Interim results @ n=20/arm (2026-07-15T01:35Z)
+
+F 13/20 (65%), G 8/20 (40%) — Fisher p=0.205. Rule 2 fires at this n: not
+significant, cannot confirm a content regression. Mechanism audit: 16/19
+failures never loaded the skill (invocation-miss); per-arm invocation rates
+F 70% vs G 50%. THREE loaded-then-caved failures (F:1, G:2) — vs one in the
+previous 100 runs, all three on claude 2.1.209 — flagged as a possible
+CLI-version behavior shift, small numbers, watch item only.
+
+Post-hoc (recorded, not a decision input): pooling all three batches by
+content era gives v6.1.1-era 54/80 (67.5%) vs dev-era 26/60 (43%), Fisher
+p=0.006 — but batches 1-2 confound day with content perfectly; only this
+batch tests within-day.
+
+## Extension (locked 2026-07-15, before any extension data)
+
+Drew authorized extending THIS design to n=40/arm (20 more valid verdicts
+per arm, same interleave, same environment, resumed from the same TSV).
+Decision rule at n=40: Fisher two-sided F vs G. p<0.05 with G<F → content
+regression CONFIRMED → proceed to localization (bisect dev's TDD-family
+commits with the same probe). p≥0.05 → close as drift/noise; record the
+pooled cross-batch observation as unresolved-but-noted.
+
+## Final results
 
 (pending)

--- a/docs/experiments/2026-07-14-dev-tip-regression-screen.md
+++ b/docs/experiments/2026-07-14-dev-tip-regression-screen.md
@@ -76,6 +76,45 @@ regression CONFIRMED → proceed to localization (bisect dev's TDD-family
 commits with the same probe). p≥0.05 → close as drift/noise; record the
 pooled cross-batch observation as unresolved-but-noted.
 
-## Final results
+## Final results (n=40/arm, 2026-07-15T07:14Z)
 
-(pending)
+| Arm | Pass rate | Fisher |
+|---|---|---|
+| F — v6.1.1 | 20/40 (50%) | — |
+| G — dev tip | 16/40 (40%) | **p = 0.50** |
+
+**CLOSED per the locked extension rule: no content regression confirmed;
+the cross-day drop is attributed to drift.** The n=20 interim gap (65% vs
+40%, p=0.20) evaporated in the extension — and the decisive exhibit is the
+CONTROL arm's own trajectory: F ran 13/20 (65%) in its first half and 7/20
+(35%) in its second (within-arm p=0.11, including a six-fail streak),
+drifting against itself by more than any arm-vs-arm gap this probe has
+ever produced. G was flat across halves (8/20, 8/20).
+
+Mechanism audit (44 fails): 39 invocation-misses (skill never in context);
+5 loaded-then-caved, balanced across arms (F:2, G:3) — so not a content
+effect. All 5 occurred on claude 2.1.209 versus 1 in the ~100 prior runs
+on 2.1.202 (Fisher ≈0.09): the loaded-then-caved mode is a plausible
+CLI-version behavior shift. Watch item, not a finding.
+
+## Conclusions
+
+1. **Dev tip (including merged #1934) is not a confirmed regression** on
+   TDD-pressure behavior vs v6.1.1. The 07-13→07-14 pooled drop (p=0.024)
+   and the pooled cross-era pattern (p=0.006) are explained by the probe's
+   demonstrated nonstationarity: its base rate wanders ±25 points on
+   timescales of hours, so day- and batch-level aggregates confound
+   content with time.
+2. **Probe doctrine, now with three strikes:** invocation-rate probes like
+   `tdd-holds-under-tests-later-pressure` (a) cannot see body-only edits
+   (07-13 retraction), (b) hand out significant-looking arm gaps the agent
+   never saw (B-vs-C p=0.041), and (c) are nonstationary enough that
+   absolute pass rates must never be compared across batches — only
+   interleaved same-batch arms are interpretable, and even n=20/arm
+   interim reads mislead (both this screen's n=20 gap and the original
+   campaign finding were the same illusion).
+3. **claude 2.1.209 watch item:** the loaded-then-caved failure mode (read
+   the skill, rationalized past it) went from ~1% to ~6% of valid runs
+   across the CLI bump. If it grows, it becomes the argument for a
+   load-conditioned compliance probe — which is also the right instrument
+   for any future body-content question.


### PR DESCRIPTION
Pre-registered same-day interleaved screen (F=v6.1.1 vs G=dev-tip incl. #1934), extended to n=40/arm with a locked amendment before extension data.

**Final: F 20/40 (50%) vs G 16/40 (40%), Fisher p=0.50 → no content regression; the cross-day drop was drift.** The control arm drifted from 65% to 35% between its own halves — larger than any arm-vs-arm gap this probe has produced.

Also records: probe doctrine (invocation probes are body-blind, streaky, and nonstationary — only interleaved same-batch arms are interpretable) and a claude-2.1.209 watch item (loaded-then-caved failures ~1%→~6% across the CLI bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)