### PR TITLE
Import locally-run eval results onto the appliance

### DIFF
--- a/docs/appliance-runbook.md
+++ b/docs/appliance-runbook.md
@@ -146,6 +146,91 @@ The helper sends SIGINT to the tracked process group and waits for stopped
 verdicts or a batch footer. If cancellation returns `lost`, do not retry a new
 live job until `doctor --json` explains the lock and process state.
 
+## Importing Locally-Run Results
+
+Runs produced on a workstation before the appliance existed are moved in two
+steps: a local export that scrubs them, and an appliance-side import that
+ingests the result. Never copy a raw local `results/` tree to the shared box —
+run homes contain live agent credentials.
+
+Design:
+[`docs/superpowers/specs/2026-08-09-appliance-results-import-design.md`](superpowers/specs/2026-08-09-appliance-results-import-design.md).
+
+### Step 1: Export locally
+
+On the workstation that holds the runs:
+
+```bash
+bun run quorum export-runs <results-dir> \
+  --out <bundle-dir> \
+  --superpowers-repo <path-to-superpowers-checkout>
+```
+
+This copies an allowlist — `verdict.json`, `trajectory.json`,
+`coding-agent-token-usage.json`, `phase.json`, `gauntlet-agent/`,
+`coding-agent-workdir/`, and the raw session logs lifted to `raw-sessions/` —
+and drops each run's throwaway `$HOME` wholesale. `auth.json`,
+`credentials.snapshot.yaml`, and agent config files never enter the bundle.
+
+`--superpowers-repo` lets the export resolve the skill tree a run archived back
+to an exact commit. Without it, runs whose verdict lacks a rev degrade to
+`tree_only`: the tree hash is still recorded, but no commit is named. It
+defaults to `$SUPERPOWERS_ROOT`.
+
+The summary line reports how each run's superpowers rev was established:
+
+```
+bundle written to /tmp/lane-b-bundle
+  exported 346, skipped 0
+  superpowers rev: recorded=196 recovered=128 inferred=22
+```
+
+`recorded` came from the verdict, `recovered` was matched exactly from the
+archived tree, `tree_only` means the run used a modified tree that matches no
+commit, `inferred` was borrowed from the nearest co-temporal run in the same
+experiment directory and is stored in its own field, and `unknown` means no
+evidence survived.
+
+### Step 2: Verify before transfer
+
+The bundle is meant to be audited before it crosses to a shared host. Confirm
+it carries no credentials:
+
+```bash
+find <bundle-dir> \( -name auth.json -o -name 'credentials.snapshot.yaml' \
+  -o -name 'config.toml' -o -name '.env*' -o -name '*.pem' -o -name '*.key' \) | head
+```
+
+Expect no output. Then transfer the bundle over the approved private access
+path documented in the private ops runbook.
+
+### Step 3: Import on the appliance
+
+```bash
+evals-appliance import --json <bundle-dir>
+```
+
+Import verifies every checksum in the manifest and re-runs the credential
+denylist against what is actually on disk before anything lands, so a tampered
+or mis-built bundle is rejected whole rather than partially applied. It holds
+`run.lock` for the duration; if a live job holds it, import returns `lock_busy`
+and does nothing. Re-running is safe: runs already present are skipped, and
+`--force` replaces them.
+
+Imported runs are visible to the normal read commands:
+
+```bash
+evals-appliance status --json <run-id>
+evals-appliance show <run-id>
+evals-appliance costs <run-id>
+```
+
+An imported job reports `kind: "import"` and carries an `origin` block instead
+of `refs` and a credential bundle, because it was neither built from an
+appliance-resolved ref nor run against the blessed bundle. Treat
+`origin.rev_recovery` as the confidence marker: `inferred_superpowers_sha` is a
+neighbour's sha, not evidence about the run itself.
+
 ## Dashboard
 
 The dashboard is read-only and must not submit or stop jobs:

--- a/docs/superpowers/specs/2026-08-09-appliance-results-import-design.md
+++ b/docs/superpowers/specs/2026-08-09-appliance-results-import-design.md
@@ -1,0 +1,256 @@
+# Importing Locally-Run Results Into The Appliance
+
+Status: approved 2026-08-09. Supersedes nothing.
+
+Two corpora of quorum runs were produced on Jesse's laptop before the shared
+appliance existed. They hold the only copy of several experiment campaigns.
+This design moves them onto the appliance as first-class artifacts that
+`evals-appliance status/show/costs` can read, without moving the credentials
+they accumulated along the way.
+
+## The Corpora
+
+| corpus | runs | size | `auth.json` files |
+|---|---|---|---|
+| `evals-lane-b/results` | 346 | 23 GB | 245 |
+| `superpowers/evals/results` | 280 | 39 GB | 261 |
+| **total** | **626** | **62 GB** | **506** |
+
+Three properties of this data drive the whole design.
+
+**They are runs, not batches.** Zero of the 617 top-level directories contain a
+`batch.json`. In `evals-lane-b`, 327 of 344 hold exactly one run directory and
+17 hold two; `superpowers/evals` has the same shape. They are single
+`quorum run` invocations grouped under experiment labels. The import
+unit is therefore the run, and `results_root/batches/<id>` is not where they
+land.
+
+**They carry live credentials.** Every run kept its throwaway `$HOME`. 506 of
+those homes contain `.codex/auth.json` with a usable `access_token` and
+`refresh_token`; 370 run directories also carry a `credentials.snapshot.yaml`
+naming the whole credential registry. None of this may reach a shared host.
+
+**The bulk is disposable.** Of 62 GB, the analytically meaningful payload is
+about 2.2 GB per the table in "Payload" below. The rest is npm and bun caches,
+sqlite logs, and archived plugin trees.
+
+## Recovering The Superpowers Rev
+
+`verdict.json` carries a best-effort `provenance.superpowers_rev`, but it is
+null for 332 of 626 runs — entirely codex, gemini, and claude runs, because
+those harnesses installed superpowers by mount or link rather than by a probe
+that recorded a sha.
+
+For codex the rev is nonetheless recoverable, exactly. Codex archives a full
+content copy of the superpowers tree into
+`home/.codex/plugins/cache/debug/superpowers/local/`. Hashing that tree's
+`skills/` directory into the superpowers object store yields a tree sha, and
+searching history for commits whose `skills` subtree matches that sha
+identifies the commit. Where several commits share an identical `skills` tree —
+a docs-only commit stacked on a real one — the run's `started_at` selects the
+newest match that precedes it.
+
+Gemini and claude archive nothing. Gemini's extension is installed as
+`{"source": "/workspace/superpowers", "type": "link"}` and claude's
+`plugins/data/superpowers-inline` is empty. For those the rev is genuinely
+unrecoverable from the artifacts.
+
+This yields a five-state recovery ladder, recorded per run:
+
+| status | meaning | count |
+|---|---|---|
+| `recorded` | the verdict already had it | 294 |
+| `recovered` | tree hash matched exactly one commit (after timestamp disambiguation) | 285 (expected) |
+| `tree_only` | tree hash computed, no commit matches — the run used a modified tree | part of the 285 |
+| `inferred` | copied from the nearest co-temporal run in the same experiment directory | 47 (expected) |
+| `unknown` | no evidence at all | 0 (expected) |
+
+`recovered` and `tree_only` are both derived from the archived tree; the split
+between them is not knowable until the export runs, so the 285 covers both. An
+`inferred` sha is stored in a distinct field and never presented as recovered.
+
+Recovery reads `home/`, which is also what gets discarded. Export therefore
+mines the sha before scrubbing, and the appliance never needs the 60 GB.
+
+## Architecture
+
+Two commands with a bundle between them.
+
+```
+laptop                                    appliance
+------                                    ---------
+quorum export-runs <results-dir>
+  scan runs
+  recover superpowers rev  <- reads home/
+  scrub to allowlist       -> drops home/
+  write manifest+checksums
+        |
+        v
+  <bundle>  --------- transfer ---------> evals-appliance import <bundle>
+                                            verify checksums
+                                            reject credential-shaped paths
+                                            write job records + provenance
+                                            land payload in results_root
+```
+
+The split follows the boundary the codebase already draws: `quorum` owns
+`results/`, `src/appliance/` owns job records. It also means the secrets are
+removed on the machine that already has them, and the bundle is an inspectable
+artifact that can be audited before it crosses to a shared host.
+
+### Export: `quorum export-runs`
+
+```
+quorum export-runs <results-dir> --out <bundle-dir> [--superpowers-repo <path>]
+                   [--limit N] [--only <glob>]
+```
+
+Lives in `src/export-runs/`. For each `<results-dir>/*/*/verdict.json`:
+
+1. Parse the verdict with `FinalVerdictSchema`. An unparseable verdict is
+   skipped and recorded in the manifest as `skipped` with its reason; it never
+   aborts the export.
+2. Resolve the superpowers rev via the ladder above. Commit matching uses
+   `git cat-file --batch-check` over `rev-list --all` in one pass, with the
+   commit-to-tree map cached across runs so 626 runs cost one traversal.
+3. Copy the payload allowlist into `<bundle>/runs/<run-id>/`.
+4. Append a manifest entry.
+
+`--superpowers-repo` defaults to a sibling `superpowers` checkout and is
+required only when some run needs `recovered` status; without it those runs
+degrade to `tree_only` with the tree sha still recorded.
+
+### Payload
+
+An allowlist, not a denylist. Only these are copied:
+
+| path | source | size (both corpora) |
+|---|---|---|
+| `verdict.json`, `trajectory.json`, `coding-agent-token-usage.json`, `phase.json` | run root | 237 MB |
+| `gauntlet-agent/` | run root | 0.5 GB |
+| `coding-agent-workdir/` | run root | 1.1 GB |
+| `raw-sessions/` | lifted from `home/<agent-cfg>/sessions/` | 0.4 GB |
+
+Everything else under `home/` is dropped, including `auth.json`, the npm and
+bun caches, sqlite logs, and the archived plugin trees.
+`credentials.snapshot.yaml` is dropped: it is a registry listing, and the
+credential actually used is already named in `verdict.credential`.
+
+Raw sessions are kept because `trajectory.json` is a normalized projection of
+them; keeping the source means a future normalizer fix can be replayed.
+
+### Bundle Format
+
+```
+<bundle>/
+  manifest.json            # schema_version, source host, created_at, entries[]
+  runs/<run-id>/           # the payload above, one dir per run
+```
+
+Each manifest entry records: `run_id`, source path, scenario, coding agent,
+credential name, `started_at`/`finished_at`, final verdict, the recovery status
+plus `superpowers_sha` / `superpowers_tree_sha` / `inferred_superpowers_sha`,
+`harness_rev`, and a sha-256 for every copied file.
+
+The credential *name* travels (it is already in the verdict and is not a
+secret); no credential *material* does.
+
+### Import: `evals-appliance import`
+
+```
+evals-appliance import --json <bundle-dir> [--force]
+```
+
+Lives in `src/appliance/import.ts`, wired into the appliance CLI alongside
+`doctor`/`prepare`/`run`. It:
+
+1. Acquires `run.lock`, so an import cannot interleave with a live batch
+   writing `results_root`. A busy lock returns `lock_busy` and imports nothing.
+2. Parses `manifest.json` and verifies every recorded sha-256. A mismatch fails
+   the whole import before anything lands.
+3. Rejects the bundle if any path matches the credential denylist —
+   `auth.json`, `credentials.snapshot.yaml`, `*.pem`, `*.key`, `.env*`,
+   `config.toml`. The export allowlist should make this unreachable; it is the
+   backstop that makes the guarantee checkable at the boundary rather than
+   trusted from the sender.
+4. For each entry, writes a job record and provenance, then moves the payload
+   to `<results_root>/<run-id>/`.
+5. Is idempotent on `run_id`: an already-present run is skipped unless
+   `--force`, which replaces it. Interrupted imports resume by re-running.
+
+### Schema Changes
+
+`ApplianceCommandKindSchema` gains `'import'`.
+
+`JobRecordSchema` gains an optional `origin` block, absent on live jobs:
+
+```ts
+origin: z.object({
+  kind: z.literal('imported'),
+  imported_at: z.string(),
+  source_host: z.string(),
+  source_path: z.string(),
+  superpowers_sha: z.string().nullable(),
+  superpowers_tree_sha: z.string().nullable(),
+  inferred_superpowers_sha: z.string().nullable(),
+  rev_recovery: z.enum(['recorded','recovered','tree_only','inferred','unknown']),
+  harness_rev: z.string().nullable(),
+}).optional()
+```
+
+An imported job sets `kind: 'import'`, `refs: null`, `credential_bundle: null`,
+`container: null`, `process: null`, `status: 'done'`, `artifacts.run_id` to the
+run id, and `result.exit_code` mirroring the verdict (0 for pass, 1 otherwise).
+
+`refs` stays strict and null rather than being loosened to accept partial data.
+Loosening `RefSnapshotSchema` would weaken the guarantee for live jobs, which
+is the opposite of what it exists for. Everything an imported run knows about
+its provenance lives in `origin`, where its uncertainty is explicit.
+
+`ProvenanceRecordSchema` gains a parallel imported variant with the same
+reasoning: `refs` and `credential_bundle` are required for live provenance and
+absent for imported provenance, discriminated on a `kind` field.
+
+`summary.ts` renders an imported job by showing `origin` in place of the refs
+and bundle block. `status` reports `done` with an `imported` marker so an
+imported run is never mistaken for something this appliance executed.
+
+## Errors
+
+Export is per-run fault-tolerant: an unreadable verdict, a missing payload
+directory, or a failed tree hash marks that run `skipped` with a reason and
+continues. The manifest is the report; the summary line prints the counts by
+status. An unwritable bundle directory or a missing results directory is fatal
+before any work starts.
+
+Import is all-or-nothing on validation and per-run on landing. Checksum
+mismatch, denylist hit, or malformed manifest aborts before the first run lands.
+After validation, a per-run failure is recorded and the remaining runs proceed,
+because a partial import is resumable and a half-validated one is not.
+
+## Testing
+
+Unit tests over a fixture bundle, following the existing `appliance-*.test.ts`
+pattern with a tmpdir config:
+
+- rev recovery: each of the five ladder states, including the two-commit tie
+  broken by `started_at`, and a modified tree yielding `tree_only`
+- scrub: a fixture run containing `auth.json` and `credentials.snapshot.yaml`
+  produces a bundle containing neither, asserted by walking the output
+- manifest: checksums match; a corrupted payload byte fails import
+- denylist: a hand-built malicious bundle with `auth.json` is rejected
+- idempotency: importing twice lands one copy; `--force` replaces
+- schema: an imported job round-trips `JobRecordSchema`; `summary.ts` renders it
+- lock: import refuses when `run.lock` is held
+
+The end-to-end check is the real export: 626 runs, then a walk of both bundles
+asserting zero credential-shaped files and recovery-status counts matching the
+294 / 285 / 47 prediction.
+
+## Out Of Scope
+
+Deleting the local corpora. Export copies; the originals stay until Jesse
+decides otherwise.
+
+Backfilling the harness so future codex/gemini/claude runs record their rev.
+That is a real gap this work surfaced, and it belongs in its own change.

--- a/docs/superpowers/specs/2026-08-09-appliance-results-import-design.md
+++ b/docs/superpowers/specs/2026-08-09-appliance-results-import-design.md
@@ -55,19 +55,30 @@ Gemini and claude archive nothing. Gemini's extension is installed as
 `plugins/data/superpowers-inline` is empty. For those the rev is genuinely
 unrecoverable from the artifacts.
 
-This yields a five-state recovery ladder, recorded per run:
+This yields a five-state recovery ladder, recorded per run. Counts are the
+measured result of exporting both corpora:
 
 | status | meaning | count |
 |---|---|---|
 | `recorded` | the verdict already had it | 294 |
-| `recovered` | tree hash matched exactly one commit (after timestamp disambiguation) | 285 (expected) |
-| `tree_only` | tree hash computed, no commit matches — the run used a modified tree | part of the 285 |
-| `inferred` | copied from the nearest co-temporal run in the same experiment directory | 47 (expected) |
-| `unknown` | no evidence at all | 0 (expected) |
+| `recovered` | tree hash matched history (timestamp breaks ties) | 217 |
+| `tree_only` | tree hash computed, no commit matches — the run used a modified tree | 68 |
+| `inferred` | borrowed from the nearest co-temporal run in the same campaign | 47 |
+| `unknown` | no evidence at all | 0 |
 
-`recovered` and `tree_only` are both derived from the archived tree; the split
-between them is not knowable until the export runs, so the 285 covers both. An
-`inferred` sha is stored in a distinct field and never presented as recovered.
+511 runs carry an exact sha. The 68 `tree_only` runs are the experiment arms
+that ran a modified superpowers tree — a real finding, and their tree hash still
+identifies which arm uniquely. The 47 `inferred` are exactly the gemini and
+claude runs predicted above; an inferred sha is stored in a distinct field and
+never presented as recovered.
+
+Inference is scoped to the campaign (the first two segments of an experiment
+label, so `cx-eff-cc-ceremony-arch-dev-rep1` is `cx-eff`) rather than the
+experiment directory, because arms are agent-specific: a gemini-only arm has no
+sibling to learn from, but its campaign does. A 24-hour window bounds it —
+superpowers moves several times a day mid-campaign, so a run with no closer
+neighbour stays `unknown` rather than borrowing a probably-wrong sha. Every one
+of the 47 had a same-campaign neighbour within 1.1 to 15.6 hours (median 3).
 
 Recovery reads `home/`, which is also what gets discarded. Export therefore
 mines the sha before scrubbing, and the appliance never needs the 60 GB.
@@ -135,6 +146,14 @@ Everything else under `home/` is dropped, including `auth.json`, the npm and
 bun caches, sqlite logs, and the archived plugin trees.
 `credentials.snapshot.yaml` is dropped: it is a registry listing, and the
 credential actually used is already named in `verdict.credential`.
+
+Vendored dependency trees inside `coding-agent-workdir/` — `.venv`,
+`node_modules`, `__pycache__`, and the mypy/pytest/ruff caches — are excluded.
+They are reproducible bulk the agent's toolchain materialized rather than
+authored, and they vendor CA trust stores (certifi's `cacert.pem`) that are not
+credentials but match the denylist exactly; the first real export run aborted on
+one. The agent's own `.git` is kept: its commits are genuine output that the
+campaign reports cite.
 
 Raw sessions are kept because `trajectory.json` is a normalized projection of
 them; keeping the source means a future normalizer fix can be replayed.
@@ -246,6 +265,15 @@ pattern with a tmpdir config:
 The end-to-end check is the real export: 626 runs, then a walk of both bundles
 asserting zero credential-shaped files and recovery-status counts matching the
 294 / 285 / 47 prediction.
+
+Measured result, 2026-08-09:
+
+- 626 runs exported, 0 skipped, 62 GB in, 2.4 GB out
+- 0 credential-shaped paths in either bundle; grepping both for the actual
+  token values taken from 9 source `auth.json` files finds nothing
+- recovery: 294 recorded, 217 recovered, 68 tree_only, 47 inferred, 0 unknown
+- both bundles import cleanly into a throwaway appliance state dir (346 in
+  8.8s, 280 in 8.0s), and a second import of each is a no-op
 
 ## Out Of Scope
 

--- a/src/appliance/cli.ts
+++ b/src/appliance/cli.ts
@@ -11,6 +11,7 @@ import { getEnv } from '../env.ts';
 import { loadConfig as loadApplianceConfig } from './config.ts';
 import { doctorPayload } from './doctor.ts';
 import { ApplianceError, toErrorJson } from './errors.ts';
+import { importBundle } from './import.ts';
 import { createJob, readJob } from './jobs.ts';
 import { prepare } from './preflight.ts';
 import { cancelJob, runWorker, spawnDetachedWorker } from './process.ts';
@@ -42,6 +43,11 @@ export interface IdCommandArgs extends BaseCommandArgs {
   readonly id: string;
 }
 
+export interface ImportCommandArgs extends BaseCommandArgs {
+  readonly bundleDir: string;
+  readonly force: boolean;
+}
+
 export type ApplianceActionResult = unknown;
 
 export interface ApplianceActions {
@@ -68,6 +74,9 @@ export interface ApplianceActions {
   ) => ApplianceActionResult | Promise<ApplianceActionResult>;
   readonly costs: (
     args: IdCommandArgs,
+  ) => ApplianceActionResult | Promise<ApplianceActionResult>;
+  readonly import: (
+    args: ImportCommandArgs,
   ) => ApplianceActionResult | Promise<ApplianceActionResult>;
 }
 
@@ -370,6 +379,13 @@ function defaultActions(): ApplianceActions {
       const loaded = loadApplianceConfig();
       return costsPayload(loaded, args.id, args.json);
     },
+    import: async (args) => {
+      const loaded = loadApplianceConfig(undefined, { ensureState: true });
+      return importBundle(loaded, {
+        bundleDir: args.bundleDir,
+        force: args.force,
+      });
+    },
   };
 }
 
@@ -567,6 +583,21 @@ export function createApplianceProgram(deps: ApplianceCliDeps = {}): Command {
     .action((id: string, options: JsonOption) => {
       const args = { ...commandOptions(options), id };
       return handleAction(args, resolvedDeps, () => actions.costs(args));
+    });
+
+  program
+    .command('import')
+    .description('ingest a scrubbed bundle built by quorum export-runs')
+    .option('--json', 'emit JSON')
+    .option('--force', 'replace runs that are already imported')
+    .argument('<bundle-dir>')
+    .action((bundleDir: string, options: JsonOption & { force?: boolean }) => {
+      const args = {
+        ...commandOptions(options),
+        bundleDir,
+        force: options.force ?? false,
+      };
+      return handleAction(args, resolvedDeps, () => actions.import(args));
     });
 
   return program;

--- a/src/appliance/import.ts
+++ b/src/appliance/import.ts
@@ -1,0 +1,261 @@
+import {
+  cpSync,
+  existsSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { join, relative } from 'node:path';
+import type { BundleManifest } from '../export-runs/manifest.ts';
+import { BundleManifestSchema, denylistHit } from '../export-runs/manifest.ts';
+import { ApplianceError } from './errors.ts';
+import { atomicWriteJson } from './fs.ts';
+import { createJob, readJob, updateJob } from './jobs.ts';
+import { acquireLock } from './locks.ts';
+import { provenancePath } from './provenance.ts';
+import {
+  ImportedProvenanceRecordSchema,
+  type JobRecord,
+  type LoadedApplianceConfig,
+  type Origin,
+} from './types.ts';
+
+export interface ImportArgs {
+  readonly bundleDir: string;
+  readonly force: boolean;
+}
+
+export interface ImportResult {
+  readonly imported: number;
+  readonly skipped: number;
+  readonly failed: number;
+  readonly run_ids: readonly string[];
+}
+
+function readManifest(bundleDir: string): BundleManifest {
+  const path = join(bundleDir, 'manifest.json');
+  if (!existsSync(path)) {
+    throw new ApplianceError(
+      'config_invalid',
+      'import',
+      `bundle has no manifest.json: ${bundleDir}`,
+    );
+  }
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    throw new ApplianceError(
+      'config_invalid',
+      'import',
+      `bundle manifest is not JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  const parsed = BundleManifestSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new ApplianceError(
+      'config_invalid',
+      'import',
+      `bundle manifest is malformed: ${parsed.error.issues[0]?.message ?? 'unknown'}`,
+    );
+  }
+  return parsed.data;
+}
+
+// Walk what is actually on disk, not just what the manifest lists: a bundle
+// that smuggles an unlisted secret must be caught too.
+function allBundleFiles(runDir: string): string[] {
+  const out: string[] = [];
+  const visit = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        visit(path);
+      } else if (entry.isFile()) {
+        out.push(relative(runDir, path));
+      }
+    }
+  };
+  if (existsSync(runDir)) {
+    visit(runDir);
+  }
+  return out;
+}
+
+// Validation runs over the whole bundle before a single run lands, so a bad
+// bundle leaves the results root untouched rather than half-populated.
+function validateBundle(bundleDir: string, manifest: BundleManifest): void {
+  for (const entry of manifest.entries) {
+    const runDir = join(bundleDir, 'runs', entry.run_id);
+    if (!existsSync(runDir) || !statSync(runDir).isDirectory()) {
+      throw new ApplianceError(
+        'artifact_missing',
+        'import',
+        `manifest lists ${entry.run_id} but the bundle has no payload for it`,
+      );
+    }
+
+    for (const rel of allBundleFiles(runDir)) {
+      const hit = denylistHit(rel);
+      if (hit !== null) {
+        throw new ApplianceError(
+          'config_invalid',
+          'import',
+          `refusing bundle: ${entry.run_id}/${rel} matches credential pattern ${hit}`,
+        );
+      }
+    }
+
+    for (const [rel, expected] of Object.entries(entry.files)) {
+      const path = join(runDir, rel);
+      if (!existsSync(path)) {
+        throw new ApplianceError(
+          'artifact_missing',
+          'import',
+          `${entry.run_id}: manifest lists ${rel} but it is not in the bundle`,
+        );
+      }
+      const actual = Bun.SHA256.hash(readFileSync(path), 'hex');
+      if (actual !== expected) {
+        throw new ApplianceError(
+          'artifact_missing',
+          'import',
+          `${entry.run_id}: checksum mismatch for ${rel}`,
+        );
+      }
+    }
+  }
+}
+
+// An imported run already has a job when a previous import landed it; readJob
+// resolves by run_id, so absence is the only signal we need.
+function alreadyImported(
+  loaded: LoadedApplianceConfig,
+  runId: string,
+): boolean {
+  try {
+    readJob(loaded, runId);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function writeImportedProvenance(
+  loaded: LoadedApplianceConfig,
+  job: JobRecord,
+  origin: Origin,
+  runDir: string,
+): string {
+  const record = ImportedProvenanceRecordSchema.parse({
+    schema_version: 1,
+    kind: 'imported',
+    job_id: job.job_id,
+    created_at: origin.imported_at,
+    origin,
+    requester: job.requester,
+    command_argv: [...job.command.argv],
+  });
+  const path = provenancePath(loaded, job.job_id);
+  atomicWriteJson(path, record);
+  atomicWriteJson(join(runDir, 'appliance-provenance.json'), record);
+  return path;
+}
+
+export function importBundle(
+  loaded: LoadedApplianceConfig,
+  args: ImportArgs,
+): ImportResult {
+  // Import writes into the results root, so it must not interleave with a live
+  // batch writing there. Held for the whole import, including validation, so a
+  // job cannot start against a half-landed corpus.
+  const lock = acquireLock({
+    loaded,
+    name: 'run.lock',
+    jobId: `import-${Date.now().toString(36)}`,
+    command: 'import',
+  });
+  try {
+    return importLocked(loaded, args);
+  } finally {
+    lock.release();
+  }
+}
+
+function importLocked(
+  loaded: LoadedApplianceConfig,
+  args: ImportArgs,
+): ImportResult {
+  const manifest = readManifest(args.bundleDir);
+  validateBundle(args.bundleDir, manifest);
+
+  const resultsRoot = loaded.config.container.results_root;
+  const importedAt = new Date().toISOString();
+  const runIds: string[] = [];
+  let imported = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const entry of manifest.entries) {
+    const destRun = join(resultsRoot, entry.run_id);
+    if (alreadyImported(loaded, entry.run_id) && !args.force) {
+      skipped += 1;
+      continue;
+    }
+
+    try {
+      // Land the payload first: a job record pointing at a missing run dir is
+      // worse than a run dir with no job, which the next import repairs.
+      rmSync(destRun, { recursive: true, force: true });
+      cpSync(join(args.bundleDir, 'runs', entry.run_id), destRun, {
+        recursive: true,
+      });
+
+      const origin: Origin = {
+        kind: 'imported',
+        imported_at: importedAt,
+        source_host: manifest.source_host,
+        source_path: entry.source_path,
+        superpowers_sha: entry.superpowers_sha,
+        superpowers_tree_sha: entry.superpowers_tree_sha,
+        inferred_superpowers_sha: entry.inferred_superpowers_sha,
+        rev_recovery: entry.rev_recovery,
+        harness_rev: entry.harness_rev,
+        scenario: entry.scenario,
+        coding_agent: entry.coding_agent,
+        credential: entry.credential,
+      };
+
+      const created = createJob(loaded, {
+        kind: 'import',
+        // An imported run's ref is whatever we could establish about it, which
+        // origin carries; the request field records the same for readability.
+        superpowersRef: entry.superpowers_sha ?? 'unknown',
+        argv: ['evals-appliance', 'import', entry.run_id],
+        requester: { agent: null, thread: null, task: null },
+      });
+
+      const job = updateJob(loaded, created.job_id, (current) => ({
+        ...current,
+        status: 'done' as const,
+        started_at: entry.started_at,
+        finished_at: entry.finished_at,
+        origin,
+        artifacts: { ...current.artifacts, run_id: entry.run_id },
+        result: {
+          exit_code: entry.final === 'pass' ? 0 : 1,
+          summary: `imported ${entry.final} run ${entry.run_id}`,
+        },
+      }));
+
+      writeImportedProvenance(loaded, job, origin, destRun);
+      runIds.push(entry.run_id);
+      imported += 1;
+    } catch {
+      failed += 1;
+    }
+  }
+
+  return { imported, skipped, failed, run_ids: runIds };
+}

--- a/src/appliance/summary.ts
+++ b/src/appliance/summary.ts
@@ -14,7 +14,12 @@ import { type FinalStatus, FinalVerdictSchema } from '../contracts/verdict.ts';
 import { ApplianceError } from './errors.ts';
 import { readJob } from './jobs.ts';
 import { inspectLock } from './locks.ts';
-import type { JobRecord, JobStatus, LoadedApplianceConfig } from './types.ts';
+import type {
+  JobRecord,
+  JobStatus,
+  LoadedApplianceConfig,
+  Origin,
+} from './types.ts';
 
 const STARTUP_GRACE_MS = 30_000;
 
@@ -51,6 +56,9 @@ export interface JobStatusPayload {
   readonly status: JobStatus;
   readonly run_id: string | null;
   readonly batch_id: string | null;
+  // Present only for imported runs, so a reader can never mistake one for
+  // something this appliance executed.
+  readonly origin?: Origin;
 }
 
 export interface ArtifactPayload {
@@ -176,6 +184,7 @@ function jobPayload(job: JobRecord | null): JobStatusPayload | null {
     status: job.status,
     run_id: job.artifacts.run_id,
     batch_id: job.artifacts.batch_id,
+    ...(job.origin === undefined ? {} : { origin: job.origin }),
   };
 }
 

--- a/src/appliance/types.ts
+++ b/src/appliance/types.ts
@@ -51,8 +51,43 @@ export const JobStatusSchema = z.enum([
 ]);
 export type JobStatus = z.infer<typeof JobStatusSchema>;
 
-export const ApplianceCommandKindSchema = z.enum(['prepare', 'run', 'run-all']);
+export const ApplianceCommandKindSchema = z.enum([
+  'prepare',
+  'run',
+  'run-all',
+  'import',
+]);
 export type ApplianceCommandKind = z.infer<typeof ApplianceCommandKindSchema>;
+
+export const REV_RECOVERY_STATUSES = [
+  'recorded',
+  'recovered',
+  'tree_only',
+  'inferred',
+  'unknown',
+] as const;
+
+// What an imported run knows about its own provenance. This block exists
+// because an imported run cannot honestly fill in RefSnapshot: it predates the
+// appliance, ran on local credentials, and in many cases had no rev recorded at
+// all. Loosening RefSnapshotSchema to hold partial data would weaken the
+// guarantee it exists to give live jobs, so the uncertainty lives here instead,
+// named explicitly.
+export const OriginSchema = z.object({
+  kind: z.literal('imported'),
+  imported_at: z.string(),
+  source_host: z.string(),
+  source_path: z.string(),
+  superpowers_sha: z.string().nullable(),
+  superpowers_tree_sha: z.string().nullable(),
+  inferred_superpowers_sha: z.string().nullable(),
+  rev_recovery: z.enum(REV_RECOVERY_STATUSES),
+  harness_rev: z.string().nullable(),
+  scenario: z.string().nullable(),
+  coding_agent: z.string().nullable(),
+  credential: z.string().nullable(),
+});
+export type Origin = z.infer<typeof OriginSchema>;
 
 export const RefSnapshotSchema = z.object({
   superpowers_requested_ref: z.string(),
@@ -125,6 +160,8 @@ export const JobRecordSchema = z.object({
     provenance: z.string(),
   }),
   progress: JobProgressSchema.nullable(),
+  // Present only on imported jobs; absent on anything this appliance ran.
+  origin: OriginSchema.optional(),
   result: z.object({
     exit_code: z.number().int().nullable(),
     summary: z.string().nullable(),
@@ -185,6 +222,33 @@ export const ProvenanceRecordSchema = z
     },
   );
 export type ProvenanceRecord = z.infer<typeof ProvenanceRecordSchema>;
+
+// Provenance for an imported run. `kind` discriminates it from a live record,
+// which has no such field, so provenance written before this existed still
+// parses unchanged.
+export const ImportedProvenanceRecordSchema = z.object({
+  schema_version: z.literal(1),
+  kind: z.literal('imported'),
+  job_id: z.string(),
+  created_at: z.string(),
+  origin: OriginSchema,
+  requester: z.object({
+    agent: z.string().nullable().optional(),
+    thread: z.string().nullable().optional(),
+    task: z.string().nullable().optional(),
+    host_user: z.string(),
+    remote_identity: z.string(),
+  }),
+  command_argv: z.array(z.string()),
+});
+export type ImportedProvenanceRecord = z.infer<
+  typeof ImportedProvenanceRecordSchema
+>;
+
+export const AnyProvenanceRecordSchema = z.union([
+  ImportedProvenanceRecordSchema,
+  ProvenanceRecordSchema,
+]);
 
 export interface LoadedApplianceConfig {
   readonly config: ApplianceConfig;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,11 +6,15 @@ import {
   readFileSync,
   statSync,
 } from 'node:fs';
+import { hostname } from 'node:os';
 import { join, resolve } from 'node:path';
 import { Command } from 'commander';
+import { SpawnCommandRunner } from '../agents/command-runner.ts';
 import type { FinalVerdict } from '../contracts/verdict.ts';
 import { FinalVerdictSchema } from '../contracts/verdict.ts';
 import { checkCredentials } from '../credentials/check.ts';
+import { getEnv } from '../env.ts';
+import { exportRuns } from '../export-runs/index.ts';
 import { runBatch } from '../run-all/index.ts';
 import { writeGridManifest } from '../run-all/write-grid-manifest.ts';
 import {
@@ -373,6 +377,63 @@ program
       now: new Date().toISOString(),
     });
     process.stdout.write(`grid-manifest written to ${outPath}\n`);
+    process.exit(0);
+  });
+
+interface ExportRunsOptions {
+  readonly out: string;
+  readonly superpowersRepo: string | undefined;
+}
+
+program
+  .command('export-runs')
+  .description(
+    'build a scrubbed bundle of local runs for evals-appliance import',
+  )
+  .argument('<results-dir>', 'local results dir to export')
+  .requiredOption('--out <dir>', 'bundle output dir')
+  .option(
+    '--superpowers-repo <path>',
+    'superpowers checkout used to resolve archived skill trees to commits',
+  )
+  .action((resultsDir: string, opts: ExportRunsOptions) => {
+    const source = resolve(resultsDir);
+    if (!existsSync(source) || !statSync(source).isDirectory()) {
+      process.stderr.write(`error: results dir does not exist: ${source}\n`);
+      process.exit(1);
+    }
+    // Without a repo the tree hash is still recorded, so runs degrade to
+    // tree_only rather than failing the export.
+    const superpowersRepo = resolve(
+      opts.superpowersRepo ?? getEnv('SUPERPOWERS_ROOT') ?? '.',
+    );
+
+    let last = 0;
+    const summary = exportRuns({
+      resultsDir: source,
+      outDir: resolve(opts.out),
+      superpowersRepo,
+      runner: new SpawnCommandRunner(),
+      sourceHost: hostname(),
+      now: new Date().toISOString(),
+      onProgress: (done, total) => {
+        // One line per 25 runs keeps a 626-run export legible.
+        if (done === total || done - last >= 25) {
+          last = done;
+          process.stderr.write(`  exported ${done}/${total}\n`);
+        }
+      },
+    });
+
+    const recovery = Object.entries(summary.byRecovery)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([status, count]) => `${status}=${count}`)
+      .join(' ');
+    process.stdout.write(
+      `bundle written to ${summary.bundleDir}\n` +
+        `  exported ${summary.exported}, skipped ${summary.skipped}\n` +
+        `  superpowers rev: ${recovery}\n`,
+    );
     process.exit(0);
   });
 

--- a/src/export-runs/index.ts
+++ b/src/export-runs/index.ts
@@ -27,6 +27,20 @@ const PAYLOAD_FILES = [
 
 const PAYLOAD_DIRS = ['gauntlet-agent', 'coding-agent-workdir'] as const;
 
+// Dependency trees the agent's toolchain materialized rather than authored.
+// They are reproducible bulk, and they vendor trust stores (certifi's
+// cacert.pem) that are not credentials but look exactly like one. The agent's
+// own .git is deliberately absent from this list: its commits are real output.
+const VENDOR_DIRS = new Set([
+  '.venv',
+  'venv',
+  'node_modules',
+  '__pycache__',
+  '.mypy_cache',
+  '.pytest_cache',
+  '.ruff_cache',
+]);
+
 // Raw coding-agent session logs, lifted out of the throwaway home into
 // raw-sessions/ so the rest of home/ can be dropped wholesale.
 const SESSION_DIRS = [
@@ -90,12 +104,16 @@ function copyTree(
   src: string,
   dest: string,
   record: (destPath: string) => void,
+  skipVendor = false,
 ): void {
   for (const entry of readdirSync(src, { withFileTypes: true })) {
     const from = join(src, entry.name);
     const to = join(dest, entry.name);
     if (entry.isDirectory()) {
-      copyTree(from, to, record);
+      if (skipVendor && VENDOR_DIRS.has(entry.name)) {
+        continue;
+      }
+      copyTree(from, to, record, skipVendor);
       continue;
     }
     if (!entry.isFile()) {
@@ -128,7 +146,12 @@ function copyPayload(runDir: string, destRun: string): Record<string, string> {
   for (const name of PAYLOAD_DIRS) {
     const from = join(runDir, name);
     if (existsSync(from) && statSync(from).isDirectory()) {
-      copyTree(from, join(destRun, name), record);
+      copyTree(
+        from,
+        join(destRun, name),
+        record,
+        name === 'coding-agent-workdir',
+      );
     }
   }
   for (const name of SESSION_DIRS) {
@@ -140,9 +163,24 @@ function copyPayload(runDir: string, destRun: string): Record<string, string> {
   return files;
 }
 
+// A campaign groups the experiment directories run against one superpowers
+// build — `cx-eff-cc-ceremony-arch-dev-rep1` and `cx-eff-cx-sdd-small-fix-rep3`
+// are both `cx-eff`. Arms are agent-specific, so a gemini-only arm has no
+// sibling to learn from; the campaign does.
+function campaignOf(sourcePath: string): string {
+  const label = basename(join(sourcePath, '..'));
+  const parts = label.split('-');
+  return parts.slice(0, 2).join('-');
+}
+
+// Beyond this, "co-temporal" stops meaning anything: superpowers moves several
+// times a day during a campaign. A run with no closer neighbour stays unknown
+// rather than borrowing a sha that is probably wrong.
+const INFERENCE_WINDOW_MS = 24 * 60 * 60 * 1000;
+
 // Runs whose rev could not be recovered borrow the sha from the nearest
-// co-temporal run in the same experiment directory, recorded in a field that
-// never masquerades as a recovered sha.
+// co-temporal run in the same campaign, recorded in a field that never
+// masquerades as a recovered sha.
 function applyInference(entries: BundleEntry[]): BundleEntry[] {
   const known = entries.filter(
     (e) => e.superpowers_sha !== null && e.started_at !== null,
@@ -151,11 +189,11 @@ function applyInference(entries: BundleEntry[]): BundleEntry[] {
     if (entry.rev_recovery !== 'unknown' || entry.started_at === null) {
       return entry;
     }
-    const label = basename(join(entry.source_path, '..'));
+    const campaign = campaignOf(entry.source_path);
     const startedMs = Date.parse(entry.started_at);
     let best: { sha: string; delta: number } | null = null;
     for (const candidate of known) {
-      if (basename(join(candidate.source_path, '..')) !== label) {
+      if (campaignOf(candidate.source_path) !== campaign) {
         continue;
       }
       const sha = candidate.superpowers_sha;
@@ -164,7 +202,10 @@ function applyInference(entries: BundleEntry[]): BundleEntry[] {
         continue;
       }
       const delta = Math.abs(Date.parse(startedAt) - startedMs);
-      if (best === null || delta < best.delta) {
+      if (
+        delta <= INFERENCE_WINDOW_MS &&
+        (best === null || delta < best.delta)
+      ) {
         best = { sha, delta };
       }
     }

--- a/src/export-runs/index.ts
+++ b/src/export-runs/index.ts
@@ -1,0 +1,297 @@
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, join, relative } from 'node:path';
+import type { CommandRunner } from '../agents/command-runner.ts';
+import { FinalVerdictSchema } from '../contracts/verdict.ts';
+import type { BundleEntry, BundleSkip } from './manifest.ts';
+import { BundleManifestSchema, denylistHit } from './manifest.ts';
+import type { RevRecovery, SkillsTreeIndex } from './rev-recovery.ts';
+import { buildSkillsTreeIndex, recoverSuperpowersRev } from './rev-recovery.ts';
+
+// Run-root artifacts carried verbatim. Everything not named here is dropped,
+// so a new secret-bearing file added by some future harness cannot leak by
+// default.
+const PAYLOAD_FILES = [
+  'verdict.json',
+  'trajectory.json',
+  'coding-agent-token-usage.json',
+  'phase.json',
+] as const;
+
+const PAYLOAD_DIRS = ['gauntlet-agent', 'coding-agent-workdir'] as const;
+
+// Raw coding-agent session logs, lifted out of the throwaway home into
+// raw-sessions/ so the rest of home/ can be dropped wholesale.
+const SESSION_DIRS = [
+  'home/.codex/sessions',
+  'home/.claude/sessions',
+  'home/.gemini/sessions',
+  'home/.kimi/sessions',
+] as const;
+
+export interface ExportArgs {
+  readonly resultsDir: string;
+  readonly outDir: string;
+  readonly superpowersRepo: string;
+  readonly runner: CommandRunner;
+  readonly sourceHost: string;
+  readonly now: string;
+  readonly onProgress?: (done: number, total: number) => void;
+}
+
+export interface ExportSummary {
+  readonly exported: number;
+  readonly skipped: number;
+  readonly byRecovery: Record<string, number>;
+  readonly bundleDir: string;
+}
+
+function writePrivate(path: string, body: string | Buffer): void {
+  mkdirSync(join(path, '..'), { recursive: true });
+  writeFileSync(path, body, { mode: 0o600 });
+}
+
+function sha256(path: string): string {
+  return Bun.SHA256.hash(readFileSync(path), 'hex');
+}
+
+// Every run directory under results/<label>/<run-id>/ that has a verdict.
+function discoverRunDirs(resultsDir: string): string[] {
+  const runs: string[] = [];
+  if (!existsSync(resultsDir)) {
+    return runs;
+  }
+  for (const label of readdirSync(resultsDir, { withFileTypes: true })) {
+    if (!label.isDirectory()) {
+      continue;
+    }
+    const labelDir = join(resultsDir, label.name);
+    for (const run of readdirSync(labelDir, { withFileTypes: true })) {
+      if (!run.isDirectory()) {
+        continue;
+      }
+      const runDir = join(labelDir, run.name);
+      if (existsSync(join(runDir, 'verdict.json'))) {
+        runs.push(runDir);
+      }
+    }
+  }
+  return runs.sort();
+}
+
+function copyTree(
+  src: string,
+  dest: string,
+  record: (destPath: string) => void,
+): void {
+  for (const entry of readdirSync(src, { withFileTypes: true })) {
+    const from = join(src, entry.name);
+    const to = join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyTree(from, to, record);
+      continue;
+    }
+    if (!entry.isFile()) {
+      continue;
+    }
+    mkdirSync(dest, { recursive: true });
+    copyFileSync(from, to);
+    record(to);
+  }
+}
+
+// Copy the allowlisted payload out of a run dir. Returns bundle-relative path
+// -> sha-256 for everything written.
+function copyPayload(runDir: string, destRun: string): Record<string, string> {
+  const files: Record<string, string> = {};
+  const record = (destPath: string): void => {
+    const rel = relative(destRun, destPath);
+    files[rel] = sha256(destPath);
+  };
+
+  mkdirSync(destRun, { recursive: true });
+  for (const name of PAYLOAD_FILES) {
+    const from = join(runDir, name);
+    if (existsSync(from) && statSync(from).isFile()) {
+      const to = join(destRun, name);
+      copyFileSync(from, to);
+      record(to);
+    }
+  }
+  for (const name of PAYLOAD_DIRS) {
+    const from = join(runDir, name);
+    if (existsSync(from) && statSync(from).isDirectory()) {
+      copyTree(from, join(destRun, name), record);
+    }
+  }
+  for (const name of SESSION_DIRS) {
+    const from = join(runDir, name);
+    if (existsSync(from) && statSync(from).isDirectory()) {
+      copyTree(from, join(destRun, 'raw-sessions'), record);
+    }
+  }
+  return files;
+}
+
+// Runs whose rev could not be recovered borrow the sha from the nearest
+// co-temporal run in the same experiment directory, recorded in a field that
+// never masquerades as a recovered sha.
+function applyInference(entries: BundleEntry[]): BundleEntry[] {
+  const known = entries.filter(
+    (e) => e.superpowers_sha !== null && e.started_at !== null,
+  );
+  return entries.map((entry) => {
+    if (entry.rev_recovery !== 'unknown' || entry.started_at === null) {
+      return entry;
+    }
+    const label = basename(join(entry.source_path, '..'));
+    const startedMs = Date.parse(entry.started_at);
+    let best: { sha: string; delta: number } | null = null;
+    for (const candidate of known) {
+      if (basename(join(candidate.source_path, '..')) !== label) {
+        continue;
+      }
+      const sha = candidate.superpowers_sha;
+      const startedAt = candidate.started_at;
+      if (sha === null || startedAt === null) {
+        continue;
+      }
+      const delta = Math.abs(Date.parse(startedAt) - startedMs);
+      if (best === null || delta < best.delta) {
+        best = { sha, delta };
+      }
+    }
+    if (best === null) {
+      return entry;
+    }
+    return {
+      ...entry,
+      rev_recovery: 'inferred' as const,
+      inferred_superpowers_sha: best.sha,
+    };
+  });
+}
+
+export function exportRuns(args: ExportArgs): ExportSummary {
+  const runDirs = discoverRunDirs(args.resultsDir);
+  mkdirSync(args.outDir, { recursive: true });
+
+  let index: SkillsTreeIndex = { byTree: new Map() };
+  if (existsSync(join(args.superpowersRepo, '.git'))) {
+    index = buildSkillsTreeIndex(args.superpowersRepo, args.runner);
+  }
+
+  let entries: BundleEntry[] = [];
+  const skipped: BundleSkip[] = [];
+
+  let done = 0;
+  for (const runDir of runDirs) {
+    done += 1;
+    args.onProgress?.(done, runDirs.length);
+
+    let parsed: ReturnType<typeof FinalVerdictSchema.parse>;
+    try {
+      parsed = FinalVerdictSchema.parse(
+        JSON.parse(readFileSync(join(runDir, 'verdict.json'), 'utf8')),
+      );
+    } catch (error) {
+      skipped.push({
+        source_path: runDir,
+        reason: `unreadable verdict: ${error instanceof Error ? error.message.split('\n')[0] : String(error)}`,
+      });
+      continue;
+    }
+
+    let recovery: RevRecovery;
+    try {
+      recovery = recoverSuperpowersRev({
+        runDir,
+        recordedRev: parsed.provenance?.superpowers_rev ?? null,
+        startedAt: parsed.started_at,
+        superpowersRepo: args.superpowersRepo,
+        index,
+        runner: args.runner,
+      });
+    } catch {
+      recovery = {
+        status: 'unknown',
+        superpowersSha: null,
+        superpowersTreeSha: null,
+      };
+    }
+
+    const runId = basename(runDir);
+    const destRun = join(args.outDir, 'runs', runId);
+    let files: Record<string, string>;
+    try {
+      files = copyPayload(runDir, destRun);
+    } catch (error) {
+      skipped.push({
+        source_path: runDir,
+        reason: `payload copy failed: ${error instanceof Error ? error.message : String(error)}`,
+      });
+      continue;
+    }
+
+    const leaked = Object.keys(files).find((rel) => denylistHit(rel) !== null);
+    if (leaked !== undefined) {
+      // Unreachable via the allowlist; a hard stop rather than a skip, because
+      // it means the allowlist itself is wrong and every other run is suspect.
+      throw new Error(
+        `export allowlist leaked a credential-shaped file: ${runId}/${leaked}`,
+      );
+    }
+
+    entries.push({
+      run_id: runId,
+      source_path: runDir,
+      scenario: parsed.scenario ?? null,
+      coding_agent: parsed.coding_agent ?? null,
+      credential: parsed.credential ?? null,
+      os: parsed.os ?? null,
+      started_at: parsed.started_at ?? null,
+      finished_at: parsed.finished_at ?? null,
+      final: parsed.final,
+      harness_rev: parsed.provenance?.harness_rev ?? null,
+      rev_recovery: recovery.status,
+      superpowers_sha: recovery.superpowersSha,
+      superpowers_tree_sha: recovery.superpowersTreeSha,
+      inferred_superpowers_sha: null,
+      files,
+    });
+  }
+
+  entries = applyInference(entries);
+
+  const manifest = BundleManifestSchema.parse({
+    schema_version: 1,
+    created_at: args.now,
+    source_host: args.sourceHost,
+    source_results_dir: args.resultsDir,
+    entries,
+    skipped,
+  });
+  writePrivate(
+    join(args.outDir, 'manifest.json'),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+
+  const byRecovery: Record<string, number> = {};
+  for (const entry of entries) {
+    byRecovery[entry.rev_recovery] = (byRecovery[entry.rev_recovery] ?? 0) + 1;
+  }
+
+  return {
+    exported: entries.length,
+    skipped: skipped.length,
+    byRecovery,
+    bundleDir: args.outDir,
+  };
+}

--- a/src/export-runs/manifest.ts
+++ b/src/export-runs/manifest.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+import { REV_RECOVERY_STATUSES } from './rev-recovery.ts';
+
+// One exported run. Identity fields mirror the verdict's self-identity block so
+// the appliance never has to parse a run-dir name. `files` maps a bundle-
+// relative path to its sha-256, which import verifies before anything lands.
+export const BundleEntrySchema = z.object({
+  run_id: z.string(),
+  source_path: z.string(),
+  scenario: z.string().nullable(),
+  coding_agent: z.string().nullable(),
+  credential: z.string().nullable(),
+  os: z.string().nullable(),
+  started_at: z.string().nullable(),
+  finished_at: z.string().nullable(),
+  final: z.string(),
+  harness_rev: z.string().nullable(),
+  rev_recovery: z.enum(REV_RECOVERY_STATUSES),
+  superpowers_sha: z.string().nullable(),
+  superpowers_tree_sha: z.string().nullable(),
+  inferred_superpowers_sha: z.string().nullable(),
+  files: z.record(z.string()),
+});
+export type BundleEntry = z.infer<typeof BundleEntrySchema>;
+
+export const BundleSkipSchema = z.object({
+  source_path: z.string(),
+  reason: z.string(),
+});
+export type BundleSkip = z.infer<typeof BundleSkipSchema>;
+
+export const BundleManifestSchema = z.object({
+  schema_version: z.literal(1),
+  created_at: z.string(),
+  source_host: z.string(),
+  source_results_dir: z.string(),
+  entries: z.array(BundleEntrySchema),
+  skipped: z.array(BundleSkipSchema),
+});
+export type BundleManifest = z.infer<typeof BundleManifestSchema>;
+
+// Paths that must never appear in a bundle. The export allowlist should make
+// these unreachable; import re-checks so the guarantee is verified at the
+// boundary rather than trusted from whoever built the bundle.
+export const CREDENTIAL_DENYLIST: readonly RegExp[] = [
+  /(^|\/)auth\.json$/,
+  /(^|\/)credentials\.snapshot\.yaml$/,
+  /(^|\/)config\.toml$/,
+  /(^|\/)\.env(\.|$)/,
+  /\.pem$/,
+  /\.key$/,
+  /(^|\/)\.netrc$/,
+  /(^|\/)id_(rsa|ed25519)$/,
+];
+
+export function denylistHit(relPath: string): string | null {
+  for (const pattern of CREDENTIAL_DENYLIST) {
+    if (pattern.test(relPath)) {
+      return pattern.source;
+    }
+  }
+  return null;
+}

--- a/src/export-runs/rev-recovery.ts
+++ b/src/export-runs/rev-recovery.ts
@@ -1,0 +1,225 @@
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { CommandRunner } from '../agents/command-runner.ts';
+
+// How a run's superpowers rev was established. `recorded` came from the
+// verdict; `recovered` and `tree_only` are derived from the tree the harness
+// archived into the run's throwaway home; `inferred` is copied from a
+// co-temporal sibling run and is never presented as recovered.
+export const REV_RECOVERY_STATUSES = [
+  'recorded',
+  'recovered',
+  'tree_only',
+  'inferred',
+  'unknown',
+] as const;
+export type RevRecoveryStatus = (typeof REV_RECOVERY_STATUSES)[number];
+
+export interface RevRecovery {
+  readonly status: RevRecoveryStatus;
+  readonly superpowersSha: string | null;
+  readonly superpowersTreeSha: string | null;
+}
+
+// Where each coding agent archives a full content copy of the superpowers tree
+// inside a run's throwaway home. Agents absent from this list install by mount
+// or symlink and archive nothing, so their rev is unrecoverable.
+const ARCHIVED_SKILLS_DIRS = [
+  'home/.codex/plugins/cache/debug/superpowers/local/skills',
+] as const;
+
+function gitOrThrow(
+  gitRepo: string,
+  args: readonly string[],
+  runner: CommandRunner,
+  env?: Record<string, string | undefined>,
+): string {
+  const result = runner.run('git', args, {
+    cwd: gitRepo,
+    ...(env === undefined ? {} : { env }),
+  });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed: ${result.stderr.trim()}`);
+  }
+  return result.stdout.trim();
+}
+
+// Hash an on-disk skills directory into `gitRepo`'s object store and return the
+// resulting tree sha, without touching that repo's real index or worktree.
+export function skillsTreeSha(
+  skillsDir: string,
+  gitRepo: string,
+  runner: CommandRunner,
+): string {
+  const indexDir = mkdtempSync(join(tmpdir(), 'sp-index-'));
+  const env = { GIT_INDEX_FILE: join(indexDir, 'index') };
+  try {
+    // --work-tree points git at the archived copy; `add -f` bypasses any
+    // ignore rules that would otherwise skip files the copy legitimately has.
+    gitOrThrow(
+      gitRepo,
+      ['--work-tree', skillsDir, 'add', '-f', '.'],
+      runner,
+      env,
+    );
+    return gitOrThrow(gitRepo, ['write-tree'], runner, env);
+  } finally {
+    rmSync(indexDir, { recursive: true, force: true });
+  }
+}
+
+export interface SkillsTreeIndex {
+  // skills-tree sha -> commits carrying it, newest commit date first
+  readonly byTree: ReadonlyMap<
+    string,
+    ReadonlyArray<{ readonly sha: string; readonly committedAt: number }>
+  >;
+}
+
+// One traversal of superpowers history, mapping every commit's `skills` subtree
+// sha to that commit. Built once and shared across all runs in an export.
+export function buildSkillsTreeIndex(
+  gitRepo: string,
+  runner: CommandRunner,
+): SkillsTreeIndex {
+  const log = gitOrThrow(gitRepo, ['log', '--all', '--format=%H %ct'], runner);
+  const commits = log
+    .split('\n')
+    .filter((line) => line.trim() !== '')
+    .map((line) => {
+      const [sha, ct] = line.split(' ');
+      return { sha: sha ?? '', committedAt: Number(ct ?? '0') * 1000 };
+    })
+    .filter((commit) => commit.sha !== '');
+
+  // cat-file --batch-check resolves every <commit>:skills in a single process;
+  // %(rest) echoes the commit sha back so the output can be zipped to input.
+  const input = commits.map((c) => `${c.sha}:skills ${c.sha}\n`).join('');
+  const result = runner.run(
+    'git',
+    ['cat-file', '--batch-check=%(objectname) %(rest)'],
+    { cwd: gitRepo, input },
+  );
+
+  const byTree = new Map<string, Array<{ sha: string; committedAt: number }>>();
+  const dateBySha = new Map(commits.map((c) => [c.sha, c.committedAt]));
+  for (const line of result.stdout.split('\n')) {
+    const [tree, sha] = line.trim().split(' ');
+    // Commits without a skills/ dir resolve to "missing"; skip them.
+    if (
+      tree === undefined ||
+      sha === undefined ||
+      !/^[0-9a-f]{40}$/.test(tree)
+    ) {
+      continue;
+    }
+    const committedAt = dateBySha.get(sha);
+    if (committedAt === undefined) {
+      continue;
+    }
+    const bucket = byTree.get(tree);
+    if (bucket === undefined) {
+      byTree.set(tree, [{ sha, committedAt }]);
+    } else {
+      bucket.push({ sha, committedAt });
+    }
+  }
+  for (const bucket of byTree.values()) {
+    bucket.sort((a, b) => b.committedAt - a.committedAt);
+  }
+  return { byTree };
+}
+
+export interface RecoverArgs {
+  readonly runDir: string;
+  readonly recordedRev: string | null;
+  readonly startedAt: string | undefined;
+  readonly superpowersRepo: string;
+  readonly index: SkillsTreeIndex;
+  readonly runner: CommandRunner;
+}
+
+function archivedSkillsDir(runDir: string): string | null {
+  for (const candidate of ARCHIVED_SKILLS_DIRS) {
+    const path = join(runDir, candidate);
+    if (existsSync(path)) {
+      return path;
+    }
+  }
+  return null;
+}
+
+// Several commits can share an identical skills tree — a docs-only commit
+// stacked on a real one. The run was driven by the newest such commit that
+// already existed when it started.
+function pickCommit(
+  candidates: ReadonlyArray<{
+    readonly sha: string;
+    readonly committedAt: number;
+  }>,
+  startedAt: string | undefined,
+): string | null {
+  if (candidates.length === 0) {
+    return null;
+  }
+  const first = candidates[0];
+  if (first === undefined) {
+    return null;
+  }
+  if (candidates.length === 1 || startedAt === undefined) {
+    return first.sha;
+  }
+  const startedMs = Date.parse(startedAt);
+  if (Number.isNaN(startedMs)) {
+    return first.sha;
+  }
+  const preceding = candidates.find((c) => c.committedAt <= startedMs);
+  // Candidates are newest-first, so falling back to the last entry picks the
+  // oldest when every candidate somehow post-dates the run.
+  return (preceding ?? candidates.at(-1) ?? first).sha;
+}
+
+export function recoverSuperpowersRev(args: RecoverArgs): RevRecovery {
+  if (args.recordedRev !== null && args.recordedRev !== '') {
+    return {
+      status: 'recorded',
+      superpowersSha: args.recordedRev,
+      superpowersTreeSha: null,
+    };
+  }
+
+  const skillsDir = archivedSkillsDir(args.runDir);
+  if (skillsDir === null) {
+    return {
+      status: 'unknown',
+      superpowersSha: null,
+      superpowersTreeSha: null,
+    };
+  }
+
+  let treeSha: string;
+  try {
+    treeSha = skillsTreeSha(skillsDir, args.superpowersRepo, args.runner);
+  } catch {
+    return {
+      status: 'unknown',
+      superpowersSha: null,
+      superpowersTreeSha: null,
+    };
+  }
+
+  const sha = pickCommit(args.index.byTree.get(treeSha) ?? [], args.startedAt);
+  if (sha === null) {
+    return {
+      status: 'tree_only',
+      superpowersSha: null,
+      superpowersTreeSha: treeSha,
+    };
+  }
+  return {
+    status: 'recovered',
+    superpowersSha: sha,
+    superpowersTreeSha: treeSha,
+  };
+}

--- a/test/appliance-cli.test.ts
+++ b/test/appliance-cli.test.ts
@@ -28,6 +28,7 @@ function noopActions(
     cancel: async () => ({ ok: true }),
     show: async () => ({ ok: true }),
     costs: async () => ({ ok: true }),
+    import: async () => ({ ok: true }),
     ...overrides,
   };
 }
@@ -178,6 +179,40 @@ test('status accepts --json before the id', async () => {
     'job-1',
   ]);
   expect(ids).toEqual(['job-1']);
+});
+
+test('import forwards the bundle dir and defaults force to false', async () => {
+  const calls: Array<{ bundleDir: string; force: boolean }> = [];
+  const program = createApplianceProgram({
+    stdout: () => undefined,
+    stderr: () => undefined,
+    actions: noopActions({
+      import: async ({ bundleDir, force }) => {
+        calls.push({ bundleDir, force });
+        return { ok: true };
+      },
+    }),
+  });
+
+  await program.parseAsync([
+    'node',
+    'evals-appliance',
+    'import',
+    '--json',
+    '/srv/bundles/lane-b',
+  ]);
+  await program.parseAsync([
+    'node',
+    'evals-appliance',
+    'import',
+    '--force',
+    '/srv/bundles/lane-b',
+  ]);
+
+  expect(calls).toEqual([
+    { bundleDir: '/srv/bundles/lane-b', force: false },
+    { bundleDir: '/srv/bundles/lane-b', force: true },
+  ]);
 });
 
 test('run forwards scenario and coding agent with appliance options', async () => {

--- a/test/appliance-import.test.ts
+++ b/test/appliance-import.test.ts
@@ -1,0 +1,301 @@
+import { expect, test } from 'bun:test';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  ApplianceError,
+  type ApplianceErrorCode,
+} from '../src/appliance/errors.ts';
+import { importBundle } from '../src/appliance/import.ts';
+import { readJob } from '../src/appliance/jobs.ts';
+import { acquireLock } from '../src/appliance/locks.ts';
+import {
+  ImportedProvenanceRecordSchema,
+  type LoadedApplianceConfig,
+} from '../src/appliance/types.ts';
+
+function loaded(): LoadedApplianceConfig {
+  const root = mkdtempSync(join(tmpdir(), 'appliance-import-'));
+  mkdirSync(join(root, 'state/jobs'), { recursive: true });
+  mkdirSync(join(root, 'state/locks'), { recursive: true });
+  mkdirSync(join(root, 'state/provenance'), { recursive: true });
+  mkdirSync(join(root, 'evals/results'), { recursive: true });
+  return {
+    configPath: join(root, 'appliance.json'),
+    config: {
+      root,
+      evals: { path: join(root, 'evals'), remote: 'origin', ref: 'main' },
+      superpowers: { path: join(root, 'superpowers'), remote: 'origin' },
+      gauntlet: { path: join(root, 'gauntlet'), remote: 'origin', ref: 'main' },
+      credential_bundle: {
+        name: 'blessed',
+        path: join(root, 'credentials/blessed'),
+      },
+      container: {
+        name: 'quorum-appliance',
+        results_root: join(root, 'evals/results'),
+      },
+    },
+    bundle: {
+      bundle_id: 'blessed-2026-06-18-a',
+      rotated_at: '2026-06-18T00:00:00Z',
+      providers: [],
+      note: 'test',
+    },
+    paths: {
+      jobs: join(root, 'state/jobs'),
+      locks: join(root, 'state/locks'),
+      provenance: join(root, 'state/provenance'),
+    },
+  };
+}
+
+const RUN_ID = 'demo-codex-codex_sub-linux-20260730T201515Z-a325';
+
+function sha256(body: string): string {
+  return Bun.SHA256.hash(Buffer.from(body), 'hex');
+}
+
+interface BundleOverrides {
+  readonly extraFile?: { readonly path: string; readonly body: string };
+  readonly corruptChecksum?: boolean;
+  readonly revRecovery?: string;
+}
+
+function makeBundle(overrides: BundleOverrides = {}): string {
+  const dir = mkdtempSync(join(tmpdir(), 'bundle-'));
+  const runDir = join(dir, 'runs', RUN_ID);
+  mkdirSync(runDir, { recursive: true });
+
+  const verdictBody = JSON.stringify({ schema: 1, final: 'pass' });
+  writeFileSync(join(runDir, 'verdict.json'), verdictBody);
+  const files: Record<string, string> = {
+    'verdict.json': overrides.corruptChecksum
+      ? sha256('something else entirely')
+      : sha256(verdictBody),
+  };
+
+  if (overrides.extraFile !== undefined) {
+    const path = join(runDir, overrides.extraFile.path);
+    mkdirSync(join(path, '..'), { recursive: true });
+    writeFileSync(path, overrides.extraFile.body);
+    files[overrides.extraFile.path] = sha256(overrides.extraFile.body);
+  }
+
+  writeFileSync(
+    join(dir, 'manifest.json'),
+    JSON.stringify({
+      schema_version: 1,
+      created_at: '2026-08-09T00:00:00.000Z',
+      source_host: 'laptop',
+      source_results_dir: '/Users/jesse/git/evals/results',
+      entries: [
+        {
+          run_id: RUN_ID,
+          source_path: `/Users/jesse/git/evals/results/cx-demo-rep1/${RUN_ID}`,
+          scenario: 'demo-scenario',
+          coding_agent: 'codex',
+          credential: 'codex_sub',
+          os: 'linux',
+          started_at: '2026-07-30T20:15:15.000Z',
+          finished_at: '2026-07-30T20:35:15.000Z',
+          final: 'pass',
+          harness_rev: 'abc123harness',
+          rev_recovery: overrides.revRecovery ?? 'recovered',
+          superpowers_sha: '3da65fb0da716305934940f0760376496defc4e7',
+          superpowers_tree_sha: '0df4d01f92fd50730641366288d54ee59561a30c',
+          inferred_superpowers_sha: null,
+          files,
+        },
+      ],
+      skipped: [],
+    }),
+  );
+  return dir;
+}
+
+function expectCode(fn: () => void, code: ApplianceErrorCode): void {
+  try {
+    fn();
+  } catch (error) {
+    expect(error).toBeInstanceOf(ApplianceError);
+    expect((error as ApplianceError).code).toBe(code);
+    return;
+  }
+  throw new Error(`expected ApplianceError ${code}`);
+}
+
+test('import lands the payload and writes an imported job record', () => {
+  const cfg = loaded();
+  const result = importBundle(cfg, { bundleDir: makeBundle(), force: false });
+
+  expect(result.imported).toBe(1);
+  expect(result.skipped).toBe(0);
+  expect(
+    existsSync(join(cfg.config.container.results_root, RUN_ID, 'verdict.json')),
+  ).toBe(true);
+
+  const job = readJob(cfg, RUN_ID);
+  expect(job.kind).toBe('import');
+  expect(job.status).toBe('done');
+  expect(job.artifacts.run_id).toBe(RUN_ID);
+  expect(job.result.exit_code).toBe(0);
+  // An imported job must never claim refs or a blessed bundle it never had.
+  expect(job.refs).toBeNull();
+  expect(job.credential_bundle).toBeNull();
+  expect(job.container).toBeNull();
+  expect(job.origin?.kind).toBe('imported');
+  expect(job.origin?.rev_recovery).toBe('recovered');
+  expect(job.origin?.superpowers_sha).toBe(
+    '3da65fb0da716305934940f0760376496defc4e7',
+  );
+  expect(job.origin?.source_host).toBe('laptop');
+});
+
+test('imported provenance is written next to the run and in the state dir', () => {
+  const cfg = loaded();
+  importBundle(cfg, { bundleDir: makeBundle(), force: false });
+  const job = readJob(cfg, RUN_ID);
+
+  const stateRecord = ImportedProvenanceRecordSchema.parse(
+    JSON.parse(readFileSync(job.artifacts.provenance, 'utf8')),
+  );
+  expect(stateRecord.job_id).toBe(job.job_id);
+  expect(stateRecord.origin.superpowers_sha).toBe(
+    '3da65fb0da716305934940f0760376496defc4e7',
+  );
+
+  const beside = join(
+    cfg.config.container.results_root,
+    RUN_ID,
+    'appliance-provenance.json',
+  );
+  expect(existsSync(beside)).toBe(true);
+});
+
+test('a checksum mismatch aborts before anything lands', () => {
+  const cfg = loaded();
+  expectCode(
+    () =>
+      importBundle(cfg, {
+        bundleDir: makeBundle({ corruptChecksum: true }),
+        force: false,
+      }),
+    'artifact_missing',
+  );
+  expect(existsSync(join(cfg.config.container.results_root, RUN_ID))).toBe(
+    false,
+  );
+});
+
+test('a credential-shaped path in the bundle is rejected outright', () => {
+  const cfg = loaded();
+  expectCode(
+    () =>
+      importBundle(cfg, {
+        bundleDir: makeBundle({
+          extraFile: { path: 'raw-sessions/auth.json', body: '{"t":"secret"}' },
+        }),
+        force: false,
+      }),
+    'config_invalid',
+  );
+  expect(existsSync(join(cfg.config.container.results_root, RUN_ID))).toBe(
+    false,
+  );
+});
+
+test('importing the same bundle twice lands one copy', () => {
+  const cfg = loaded();
+  const bundle = makeBundle();
+  importBundle(cfg, { bundleDir: bundle, force: false });
+  const second = importBundle(cfg, { bundleDir: bundle, force: false });
+
+  expect(second.imported).toBe(0);
+  expect(second.skipped).toBe(1);
+  // One job record, not two.
+  const job = readJob(cfg, RUN_ID);
+  expect(job.artifacts.run_id).toBe(RUN_ID);
+});
+
+test('--force replaces an already-imported run', () => {
+  const cfg = loaded();
+  const bundle = makeBundle();
+  importBundle(cfg, { bundleDir: bundle, force: false });
+  const landed = join(
+    cfg.config.container.results_root,
+    RUN_ID,
+    'verdict.json',
+  );
+  writeFileSync(landed, 'STALE');
+
+  const second = importBundle(cfg, { bundleDir: bundle, force: true });
+  expect(second.imported).toBe(1);
+  expect(readFileSync(landed, 'utf8')).not.toBe('STALE');
+});
+
+test('a failing verdict imports with a non-zero exit code', () => {
+  const cfg = loaded();
+  const dir = makeBundle();
+  const manifestPath = join(dir, 'manifest.json');
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  manifest.entries[0].final = 'fail';
+  writeFileSync(manifestPath, JSON.stringify(manifest));
+
+  importBundle(cfg, { bundleDir: dir, force: false });
+  expect(readJob(cfg, RUN_ID).result.exit_code).toBe(1);
+});
+
+test('import refuses while a live job holds run.lock', () => {
+  const cfg = loaded();
+  const held = acquireLock({
+    loaded: cfg,
+    name: 'run.lock',
+    jobId: 'job-live',
+    command: 'run-all',
+  });
+
+  try {
+    expectCode(
+      () => importBundle(cfg, { bundleDir: makeBundle(), force: false }),
+      'lock_busy',
+    );
+    expect(existsSync(join(cfg.config.container.results_root, RUN_ID))).toBe(
+      false,
+    );
+  } finally {
+    held.release();
+  }
+});
+
+test('import releases run.lock when a bundle is rejected', () => {
+  const cfg = loaded();
+  expectCode(
+    () =>
+      importBundle(cfg, {
+        bundleDir: makeBundle({ corruptChecksum: true }),
+        force: false,
+      }),
+    'artifact_missing',
+  );
+
+  // A rejected import must not strand the lock; the next one has to work.
+  const result = importBundle(cfg, { bundleDir: makeBundle(), force: false });
+  expect(result.imported).toBe(1);
+});
+
+test('a malformed manifest is a config error, not a crash', () => {
+  const cfg = loaded();
+  const dir = mkdtempSync(join(tmpdir(), 'bundle-bad-'));
+  writeFileSync(join(dir, 'manifest.json'), '{"schema_version": 99}');
+  expectCode(
+    () => importBundle(cfg, { bundleDir: dir, force: false }),
+    'config_invalid',
+  );
+});

--- a/test/export-rev-recovery.test.ts
+++ b/test/export-rev-recovery.test.ts
@@ -1,0 +1,206 @@
+import { expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SpawnCommandRunner } from '../src/agents/command-runner.ts';
+import { envSnapshot } from '../src/env.ts';
+import {
+  buildSkillsTreeIndex,
+  recoverSuperpowersRev,
+  skillsTreeSha,
+} from '../src/export-runs/rev-recovery.ts';
+
+const runner = new SpawnCommandRunner();
+
+function git(cwd: string, args: string[], date?: string): string {
+  const proc = spawnSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    env:
+      date === undefined
+        ? envSnapshot()
+        : {
+            ...envSnapshot(),
+            GIT_AUTHOR_DATE: date,
+            GIT_COMMITTER_DATE: date,
+          },
+  });
+  if (proc.status !== 0) {
+    throw new Error(`git ${args.join(' ')}: ${proc.stderr}`);
+  }
+  return proc.stdout.trim();
+}
+
+function writeSkill(root: string, name: string, body: string): void {
+  mkdirSync(join(root, 'skills', name), { recursive: true });
+  writeFileSync(join(root, 'skills', name, 'SKILL.md'), body);
+}
+
+// Commit dates are pinned so the tie-break test has a real time gap to work
+// with; back-to-back test commits would otherwise share a second.
+const C1_DATE = '2026-07-30T10:00:00-07:00';
+const C2_DATE = '2026-07-30T12:51:00-07:00';
+const C3_DATE = '2026-07-30T15:56:00-07:00';
+
+// A superpowers-like repo with three commits:
+//   c1 -> skills A          (tree T1)
+//   c2 -> skills A + B      (tree T2)
+//   c3 -> docs only         (tree T2 again, identical skills)
+interface Fixture {
+  readonly repo: string;
+  readonly c1: string;
+  readonly c2: string;
+  readonly c3: string;
+}
+
+function superpowersRepo(): Fixture {
+  const repo = mkdtempSync(join(tmpdir(), 'sp-repo-'));
+  git(repo, ['init', '-q', '-b', 'main']);
+  git(repo, ['config', 'user.email', 'test@example.com']);
+  git(repo, ['config', 'user.name', 'Test']);
+
+  writeSkill(repo, 'brainstorming', 'first version\n');
+  git(repo, ['add', '-A']);
+  git(repo, ['commit', '-q', '-m', 'add brainstorming'], C1_DATE);
+  const c1 = git(repo, ['rev-parse', 'HEAD']);
+
+  writeSkill(repo, 'debugging', 'debugging skill\n');
+  git(repo, ['add', '-A']);
+  git(repo, ['commit', '-q', '-m', 'add debugging'], C2_DATE);
+  const c2 = git(repo, ['rev-parse', 'HEAD']);
+
+  writeFileSync(join(repo, 'README.md'), 'docs only\n');
+  git(repo, ['add', '-A']);
+  git(repo, ['commit', '-q', '-m', 'docs: readme'], C3_DATE);
+  const c3 = git(repo, ['rev-parse', 'HEAD']);
+
+  return { repo, c1, c2, c3 };
+}
+
+// A run dir whose archived plugin cache holds a copy of the given skills tree.
+function runWithArchivedTree(
+  skills: ReadonlyArray<readonly [string, string]>,
+): string {
+  const run = mkdtempSync(join(tmpdir(), 'run-'));
+  const local = join(run, 'home/.codex/plugins/cache/debug/superpowers/local');
+  for (const [name, body] of skills) {
+    writeSkill(local, name, body);
+  }
+  return run;
+}
+
+test('skillsTreeSha hashes an archived skills dir to a git tree sha', () => {
+  const fixture = superpowersRepo();
+  const run = runWithArchivedTree([['brainstorming', 'first version\n']]);
+
+  const sha = skillsTreeSha(
+    join(run, 'home/.codex/plugins/cache/debug/superpowers/local/skills'),
+    fixture.repo,
+    runner,
+  );
+
+  expect(sha).toBe(git(fixture.repo, ['rev-parse', `${fixture.c1}:skills`]));
+});
+
+test('recoverSuperpowersRev returns recorded when the verdict already has it', () => {
+  const fixture = superpowersRepo();
+  const index = buildSkillsTreeIndex(fixture.repo, runner);
+
+  const result = recoverSuperpowersRev({
+    runDir: runWithArchivedTree([['brainstorming', 'first version\n']]),
+    recordedRev: 'abc123',
+    startedAt: '2026-07-30T20:15:15Z',
+    superpowersRepo: fixture.repo,
+    index,
+    runner,
+  });
+
+  expect(result.status).toBe('recorded');
+  expect(result.superpowersSha).toBe('abc123');
+});
+
+test('recoverSuperpowersRev recovers an exact sha from the archived tree', () => {
+  const fixture = superpowersRepo();
+  const index = buildSkillsTreeIndex(fixture.repo, runner);
+
+  const result = recoverSuperpowersRev({
+    runDir: runWithArchivedTree([['brainstorming', 'first version\n']]),
+    recordedRev: null,
+    startedAt: '2026-07-30T20:15:15Z',
+    superpowersRepo: fixture.repo,
+    index,
+    runner,
+  });
+
+  expect(result.status).toBe('recovered');
+  expect(result.superpowersSha).toBe(fixture.c1);
+  expect(result.superpowersTreeSha).toBe(
+    git(fixture.repo, ['rev-parse', `${fixture.c1}:skills`]),
+  );
+});
+
+test('a skills-tree tie is broken by the newest commit preceding started_at', () => {
+  const fixture = superpowersRepo();
+  const index = buildSkillsTreeIndex(fixture.repo, runner);
+  // c2 and c3 share a skills tree; c3 is the docs-only commit stacked on c2.
+  const archived: ReadonlyArray<readonly [string, string]> = [
+    ['brainstorming', 'first version\n'],
+    ['debugging', 'debugging skill\n'],
+  ];
+
+  // 13:15 PDT: after c2 (12:51), before c3 (15:56).
+  const startedAt = '2026-07-30T20:15:15Z';
+
+  const result = recoverSuperpowersRev({
+    runDir: runWithArchivedTree(archived),
+    recordedRev: null,
+    startedAt,
+    superpowersRepo: fixture.repo,
+    index,
+    runner,
+  });
+
+  expect(result.status).toBe('recovered');
+  expect(result.superpowersSha).toBe(fixture.c2);
+});
+
+test('a modified tree that matches no commit is tree_only, keeping the tree sha', () => {
+  const fixture = superpowersRepo();
+  const index = buildSkillsTreeIndex(fixture.repo, runner);
+
+  const result = recoverSuperpowersRev({
+    runDir: runWithArchivedTree([['brainstorming', 'LOCALLY MODIFIED\n']]),
+    recordedRev: null,
+    startedAt: '2026-07-30T20:15:15Z',
+    superpowersRepo: fixture.repo,
+    index,
+    runner,
+  });
+
+  expect(result.status).toBe('tree_only');
+  expect(result.superpowersSha).toBeNull();
+  expect(result.superpowersTreeSha).not.toBeNull();
+});
+
+test('a run with no archived tree is unknown', () => {
+  const fixture = superpowersRepo();
+  const index = buildSkillsTreeIndex(fixture.repo, runner);
+  const run = mkdtempSync(join(tmpdir(), 'run-bare-'));
+  mkdirSync(join(run, 'home/.gemini/extensions/superpowers'), {
+    recursive: true,
+  });
+
+  const result = recoverSuperpowersRev({
+    runDir: run,
+    recordedRev: null,
+    startedAt: '2026-07-30T20:15:15Z',
+    superpowersRepo: fixture.repo,
+    index,
+    runner,
+  });
+
+  expect(result.status).toBe('unknown');
+  expect(result.superpowersSha).toBeNull();
+  expect(result.superpowersTreeSha).toBeNull();
+});

--- a/test/export-runs.test.ts
+++ b/test/export-runs.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from 'node:os';
 import { join, relative } from 'node:path';
 import { SpawnCommandRunner } from '../src/agents/command-runner.ts';
 import { exportRuns } from '../src/export-runs/index.ts';
+import type { BundleEntry } from '../src/export-runs/manifest.ts';
 import { BundleManifestSchema } from '../src/export-runs/manifest.ts';
 
 const runner = new SpawnCommandRunner();
@@ -58,7 +59,8 @@ function verdict(overrides: Record<string, unknown> = {}): string {
 function resultsTree(): { root: string; runId: string } {
   const root = mkdtempSync(join(tmpdir(), 'results-'));
   const runId = 'demo-codex-codex_sub-linux-20260730T201515Z-a325';
-  const run = join(root, 'cx-demo-rep1', runId);
+  // Label shape mirrors the real corpora: <campaign>-<arm>-rep<n>.
+  const run = join(root, 'cx-eff-demo-rep1', runId);
 
   write(join(run, 'verdict.json'), verdict());
   write(join(run, 'trajectory.json'), '{"steps":[]}');
@@ -67,6 +69,26 @@ function resultsTree(): { root: string; runId: string } {
   write(join(run, 'credentials.snapshot.yaml'), 'codex_sub:\n  api: openai\n');
   write(join(run, 'gauntlet-agent/results/g-1/run.jsonl'), '{"e":1}\n');
   write(join(run, 'coding-agent-workdir/src/main.go'), 'package main\n');
+  // The agent's own git history is real output and must survive.
+  write(join(run, 'coding-agent-workdir/.git/HEAD'), 'ref: refs/heads/main\n');
+  // Vendored dependency bulk the agent's toolchain created. Reproducible, and
+  // it drags in trust stores that trip the credential denylist.
+  write(
+    join(
+      run,
+      'coding-agent-workdir/.venv/lib/python3.12/site-packages/certifi/cacert.pem',
+    ),
+    '-----BEGIN CERTIFICATE-----\n',
+  );
+  write(
+    join(run, 'coding-agent-workdir/.venv/lib/python3.12/site-packages/x.py'),
+    'x = 1\n',
+  );
+  write(
+    join(run, 'coding-agent-workdir/__pycache__/main.cpython-312.pyc'),
+    'x',
+  );
+  write(join(run, 'coding-agent-workdir/node_modules/left-pad/index.js'), 'x');
 
   // Secrets and bulk that must be dropped.
   write(
@@ -170,6 +192,21 @@ test('export keeps the analytical payload and lifts raw sessions', () => {
   expect(existsSync(join(run, 'raw-sessions/2026/rollout.jsonl'))).toBe(true);
   // The npm cache is bulk, not payload.
   expect(existsSync(join(run, 'raw-sessions/_cacache'))).toBe(false);
+  // The agent's commits are output worth keeping.
+  expect(existsSync(join(run, 'coding-agent-workdir/.git/HEAD'))).toBe(true);
+});
+
+test('vendored dependency dirs are excluded from the workdir', () => {
+  const { bundle, runId } = runExport();
+  const workdir = join(bundle, 'runs', runId, 'coding-agent-workdir');
+
+  expect(existsSync(join(workdir, '.venv'))).toBe(false);
+  expect(existsSync(join(workdir, 'node_modules'))).toBe(false);
+  expect(existsSync(join(workdir, '__pycache__'))).toBe(false);
+  // Excluding them is what keeps a vendored CA trust store from tripping the
+  // credential denylist and aborting a 600-run export.
+  expect(walk(workdir).some((f) => f.endsWith('.pem'))).toBe(false);
+  expect(existsSync(join(workdir, 'src/main.go'))).toBe(true);
 });
 
 test('the manifest records identity, recovery status, and checksums', () => {
@@ -203,6 +240,58 @@ test('the manifest records identity, recovery status, and checksums', () => {
     expect(actual).toBe(sha);
   }
   expect(Object.keys(entry.files).length).toBeGreaterThan(0);
+});
+
+// A run with no archived tree (gemini/claude install superpowers by link)
+// alongside a codex run from the same campaign whose sha is recoverable.
+function corpusWithUnrecoverableRun(startedAt: string): string {
+  const { root } = resultsTree();
+  const run = join(root, 'cx-eff-cc-ceremony-arch-dev-rep1', 'gem-run');
+  write(
+    join(run, 'verdict.json'),
+    verdict({ coding_agent: 'gemini', started_at: startedAt }),
+  );
+  write(join(run, 'trajectory.json'), '{"steps":[]}');
+  return root;
+}
+
+function exportCorpus(root: string): BundleEntry[] {
+  const bundle = join(mkdtempSync(join(tmpdir(), 'bundle-')), 'out');
+  exportRuns({
+    resultsDir: root,
+    outDir: bundle,
+    superpowersRepo: superpowersRepo(),
+    runner,
+    sourceHost: 'test-host',
+    now: '2026-08-09T00:00:00.000Z',
+  });
+  return BundleManifestSchema.parse(
+    JSON.parse(readFileSync(join(bundle, 'manifest.json'), 'utf8')),
+  ).entries;
+}
+
+test('an unrecoverable run borrows a co-temporal sha from its campaign', () => {
+  // The seeded codex run started 2026-07-30T20:15:15Z; three hours later is
+  // well inside the window.
+  const entries = exportCorpus(
+    corpusWithUnrecoverableRun('2026-07-30T23:15:15.000Z'),
+  );
+  const gem = entries.find((e) => e.run_id === 'gem-run');
+
+  expect(gem?.rev_recovery).toBe('inferred');
+  expect(gem?.inferred_superpowers_sha).toMatch(/^[0-9a-f]{40}$/);
+  // The borrowed sha must never occupy the field meaning "this run's sha".
+  expect(gem?.superpowers_sha).toBeNull();
+});
+
+test('a run with no neighbour inside the window stays unknown', () => {
+  const entries = exportCorpus(
+    corpusWithUnrecoverableRun('2026-08-15T00:00:00.000Z'),
+  );
+  const gem = entries.find((e) => e.run_id === 'gem-run');
+
+  expect(gem?.rev_recovery).toBe('unknown');
+  expect(gem?.inferred_superpowers_sha).toBeNull();
 });
 
 test('a run whose verdict will not parse is skipped, not fatal', () => {

--- a/test/export-runs.test.ts
+++ b/test/export-runs.test.ts
@@ -1,0 +1,235 @@
+import { expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { SpawnCommandRunner } from '../src/agents/command-runner.ts';
+import { exportRuns } from '../src/export-runs/index.ts';
+import { BundleManifestSchema } from '../src/export-runs/manifest.ts';
+
+const runner = new SpawnCommandRunner();
+
+function write(path: string, body: string): void {
+  mkdirSync(join(path, '..'), { recursive: true });
+  writeFileSync(path, body);
+}
+
+function verdict(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    schema: 1,
+    final: 'pass',
+    final_reason: 'Gauntlet-Agent passed',
+    gauntlet: {
+      status: 'pass',
+      summary: 's',
+      reasoning: 'r',
+      run_id: 'g-1',
+    },
+    checks: [],
+    error: null,
+    economics: null,
+    scenario: 'demo-scenario',
+    coding_agent: 'codex',
+    started_at: '2026-07-30T20:15:15.000Z',
+    finished_at: '2026-07-30T20:35:15.000Z',
+    credential: 'codex_sub',
+    os: 'linux',
+    provenance: {
+      superpowers_rev: null,
+      superpowers_dirty: null,
+      harness_rev: 'abc123harness',
+      agent_cli_version: 'codex-cli 0.146.0',
+      gauntlet_version: null,
+    },
+    ...overrides,
+  });
+}
+
+// A results tree shaped like the real corpora: results/<label>/<run-id>/...
+// with a throwaway home holding credentials the export must not carry.
+function resultsTree(): { root: string; runId: string } {
+  const root = mkdtempSync(join(tmpdir(), 'results-'));
+  const runId = 'demo-codex-codex_sub-linux-20260730T201515Z-a325';
+  const run = join(root, 'cx-demo-rep1', runId);
+
+  write(join(run, 'verdict.json'), verdict());
+  write(join(run, 'trajectory.json'), '{"steps":[]}');
+  write(join(run, 'coding-agent-token-usage.json'), '{"total":1}');
+  write(join(run, 'phase.json'), '{"phase":"done"}');
+  write(join(run, 'credentials.snapshot.yaml'), 'codex_sub:\n  api: openai\n');
+  write(join(run, 'gauntlet-agent/results/g-1/run.jsonl'), '{"e":1}\n');
+  write(join(run, 'coding-agent-workdir/src/main.go'), 'package main\n');
+
+  // Secrets and bulk that must be dropped.
+  write(
+    join(run, 'home/.codex/auth.json'),
+    JSON.stringify({ tokens: { access_token: 'SECRET-ACCESS-TOKEN' } }),
+  );
+  write(join(run, 'home/.codex/config.toml'), 'model = "gpt"\n');
+  write(join(run, 'home/.npm/_cacache/big.bin'), 'x'.repeat(1024));
+  // Raw session logs must survive, lifted out of home/.
+  write(join(run, 'home/.codex/sessions/2026/rollout.jsonl'), '{"m":"hi"}\n');
+  // The archived tree the rev recovery reads.
+  write(
+    join(
+      run,
+      'home/.codex/plugins/cache/debug/superpowers/local/skills/brainstorming/SKILL.md',
+    ),
+    'first version\n',
+  );
+
+  return { root, runId };
+}
+
+function superpowersRepo(): string {
+  const repo = mkdtempSync(join(tmpdir(), 'sp-'));
+  const git = (args: string[]): void => {
+    const proc = spawnSync('git', args, { cwd: repo, encoding: 'utf8' });
+    if (proc.status !== 0) {
+      throw new Error(proc.stderr);
+    }
+  };
+  git(['init', '-q', '-b', 'main']);
+  git(['config', 'user.email', 'test@example.com']);
+  git(['config', 'user.name', 'Test']);
+  mkdirSync(join(repo, 'skills/brainstorming'), { recursive: true });
+  writeFileSync(join(repo, 'skills/brainstorming/SKILL.md'), 'first version\n');
+  git(['add', '-A']);
+  git(['commit', '-q', '-m', 'add brainstorming']);
+  return repo;
+}
+
+function walk(root: string): string[] {
+  const out: string[] = [];
+  const visit = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        visit(path);
+      } else {
+        out.push(relative(root, path));
+      }
+    }
+  };
+  visit(root);
+  return out;
+}
+
+function runExport(): { bundle: string; runId: string } {
+  const { root, runId } = resultsTree();
+  const bundle = join(mkdtempSync(join(tmpdir(), 'bundle-')), 'out');
+  exportRuns({
+    resultsDir: root,
+    outDir: bundle,
+    superpowersRepo: superpowersRepo(),
+    runner,
+    sourceHost: 'test-host',
+    now: '2026-08-09T00:00:00.000Z',
+  });
+  return { bundle, runId };
+}
+
+test('export drops every credential-bearing file', () => {
+  const { bundle } = runExport();
+  const files = walk(bundle);
+
+  expect(files.some((f) => f.endsWith('auth.json'))).toBe(false);
+  expect(files.some((f) => f.endsWith('credentials.snapshot.yaml'))).toBe(
+    false,
+  );
+  expect(files.some((f) => f.endsWith('config.toml'))).toBe(false);
+  // Nothing at all survives from home/ except the lifted sessions.
+  expect(files.some((f) => f.includes('/home/'))).toBe(false);
+
+  const dumped = files
+    .map((f) => readFileSync(join(bundle, f), 'utf8'))
+    .join('');
+  expect(dumped).not.toContain('SECRET-ACCESS-TOKEN');
+});
+
+test('export keeps the analytical payload and lifts raw sessions', () => {
+  const { bundle, runId } = runExport();
+  const run = join(bundle, 'runs', runId);
+
+  expect(existsSync(join(run, 'verdict.json'))).toBe(true);
+  expect(existsSync(join(run, 'trajectory.json'))).toBe(true);
+  expect(existsSync(join(run, 'coding-agent-token-usage.json'))).toBe(true);
+  expect(existsSync(join(run, 'phase.json'))).toBe(true);
+  expect(existsSync(join(run, 'gauntlet-agent/results/g-1/run.jsonl'))).toBe(
+    true,
+  );
+  expect(existsSync(join(run, 'coding-agent-workdir/src/main.go'))).toBe(true);
+  expect(existsSync(join(run, 'raw-sessions/2026/rollout.jsonl'))).toBe(true);
+  // The npm cache is bulk, not payload.
+  expect(existsSync(join(run, 'raw-sessions/_cacache'))).toBe(false);
+});
+
+test('the manifest records identity, recovery status, and checksums', () => {
+  const { bundle, runId } = runExport();
+  const manifest = BundleManifestSchema.parse(
+    JSON.parse(readFileSync(join(bundle, 'manifest.json'), 'utf8')),
+  );
+
+  expect(manifest.source_host).toBe('test-host');
+  expect(manifest.entries).toHaveLength(1);
+  const entry = manifest.entries[0];
+  if (entry === undefined) {
+    throw new Error('missing entry');
+  }
+  expect(entry.run_id).toBe(runId);
+  expect(entry.scenario).toBe('demo-scenario');
+  expect(entry.coding_agent).toBe('codex');
+  expect(entry.credential).toBe('codex_sub');
+  expect(entry.final).toBe('pass');
+  expect(entry.harness_rev).toBe('abc123harness');
+  // The verdict had no rev; the archived tree supplies it exactly.
+  expect(entry.rev_recovery).toBe('recovered');
+  expect(entry.superpowers_sha).toMatch(/^[0-9a-f]{40}$/);
+
+  // Every checksum must describe the file actually written.
+  for (const [relPath, sha] of Object.entries(entry.files)) {
+    const actual = Bun.SHA256.hash(
+      readFileSync(join(bundle, 'runs', runId, relPath)),
+      'hex',
+    );
+    expect(actual).toBe(sha);
+  }
+  expect(Object.keys(entry.files).length).toBeGreaterThan(0);
+});
+
+test('a run whose verdict will not parse is skipped, not fatal', () => {
+  const { root } = resultsTree();
+  write(join(root, 'broken-rep1/run-x/verdict.json'), '{not json');
+  const bundle = join(mkdtempSync(join(tmpdir(), 'bundle-')), 'out');
+
+  const summary = exportRuns({
+    resultsDir: root,
+    outDir: bundle,
+    superpowersRepo: superpowersRepo(),
+    runner,
+    sourceHost: 'test-host',
+    now: '2026-08-09T00:00:00.000Z',
+  });
+
+  expect(summary.exported).toBe(1);
+  expect(summary.skipped).toBe(1);
+  const manifest = BundleManifestSchema.parse(
+    JSON.parse(readFileSync(join(bundle, 'manifest.json'), 'utf8')),
+  );
+  expect(manifest.skipped).toHaveLength(1);
+  expect(manifest.skipped[0]?.reason).toContain('verdict');
+});
+
+test('bundle files are written private', () => {
+  const { bundle } = runExport();
+  const mode = statSync(join(bundle, 'manifest.json')).mode & 0o777;
+  expect(mode).toBe(0o600);
+});


### PR DESCRIPTION
Two laptop corpora of quorum runs predate the shared appliance and hold the only
copy of several experiment campaigns. This adds the path to move them.

**`quorum export-runs`** (local) copies an allowlist out of each run — verdict,
trajectory, token usage, phase, `gauntlet-agent/`, `coding-agent-workdir/`, and
the raw session logs — and drops the throwaway `$HOME` wholesale. The 506 live
`auth.json` files and 370 `credentials.snapshot.yaml` never enter a bundle.

**`evals-appliance import`** verifies every manifest checksum and re-checks a
credential denylist against what is actually on disk before a single run lands,
holds `run.lock` for the duration, and is idempotent on `run_id`.

### Recovering the superpowers rev

`provenance.superpowers_rev` is null in 332 of 626 verdicts. Codex archives a
full copy of the superpowers tree into the run home, so hashing its `skills/`
tree and matching that against superpowers history recovers the commit exactly,
with `started_at` breaking ties between commits that share a tree. Gemini and
claude install by link and archive nothing.

Measured over both corpora: 294 recorded, 217 recovered, 68 `tree_only`
(experiment arms that ran a modified tree), 47 inferred from a same-campaign
neighbour, 0 unknown. 626 runs, 0 skipped, 62 GB in, 2.4 GB out.

An imported job carries `kind: "import"`, null `refs`/`credential_bundle`, and a
new `origin` block. `RefSnapshotSchema` stays strict rather than being loosened
to hold partial data, which would weaken it for live jobs.

Design: `docs/superpowers/specs/2026-08-09-appliance-results-import-design.md`.
Runbook: new "Importing Locally-Run Results" section.

### Verification

- 67 tests across the affected files, all green; full suite 2089 pass
- both bundles grep-clean against the real token values from 9 source `auth.json`
- both import end-to-end into a throwaway appliance state dir; re-import is a no-op

Two pre-existing failures on this tree (`scenario-pinning`, `scaffold` verb lint)
come from 30 untracked locally-excluded scenario dirs and are unrelated.