### PR TITLE
tooling: thin-run-homes deletes exported run homes safely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 results/
+# Quarantine sweeps park run trees beside results/ under their own name. They
+# carry the same credential-bearing run homes, so they need the same fence.
+results-quarantine*/
 # Committed dashboard-scan test fixture (a results/ tree the unit tests read).
 !packages/dashboard/test/fixtures/scan/results/
 !packages/dashboard/test/fixtures/scan/results/**
@@ -10,6 +13,7 @@ dist/
 build/
 .venv/
 .env
+.env.*
 .claude/
 .superpowers/
 .clearance-rendered-preview-*/

--- a/docs/appliance-runbook.md
+++ b/docs/appliance-runbook.md
@@ -177,6 +177,21 @@ to an exact commit. Without it, runs whose verdict lacks a rev degrade to
 `tree_only`: the tree hash is still recorded, but no commit is named. It
 defaults to `$SUPERPOWERS_ROOT`.
 
+Export finds a run by its `verdict.json` at any depth, so quarantine sweeps that
+move a whole label tree under a holding directory are picked up along with the
+canonical `results/<label>/<run-id>/` layout.
+
+To export only what a previous bundle missed, exclude that bundle's runs:
+
+```bash
+bun run quorum export-runs <results-dir> --out <new-bundle> \
+  --exclude-manifest <old-bundle>/manifest.json
+```
+
+Prefer this over re-exporting everything. Thinning deletes the `home/` the rev
+recovery reads, so a second pass over an already-exported run produces a
+strictly weaker provenance record than the bundle already holds.
+
 The summary line reports how each run's superpowers rev was established:
 
 ```

--- a/docs/superpowers/specs/2026-08-09-appliance-results-import-design.md
+++ b/docs/superpowers/specs/2026-08-09-appliance-results-import-design.md
@@ -116,7 +116,17 @@ quorum export-runs <results-dir> --out <bundle-dir> [--superpowers-repo <path>]
                    [--limit N] [--only <glob>]
 ```
 
-Lives in `src/export-runs/`. For each `<results-dir>/*/*/verdict.json`:
+Lives in `src/export-runs/`. A run is any directory holding a `verdict.json`,
+found at any depth: the canonical layout is `results/<label>/<run-id>/`, but
+quarantine sweeps move a whole label tree under a holding directory and put its
+runs one level deeper. The first export scanned exactly two levels and silently
+missed 55 such runs across the three corpora — they were only noticed because
+the thinning pass refused to delete homes it could not find in a manifest.
+Descent stops at the first marker found, and never enters `home/`,
+`coding-agent-workdir/`, or `gauntlet-agent/`, so a scenario that exercises
+quorum itself cannot have its nested fixture verdicts mistaken for runs.
+
+For each run directory:
 
 1. Parse the verdict with `FinalVerdictSchema`. An unparseable verdict is
    skipped and recorded in the manifest as `skipped` with its reason; it never
@@ -274,6 +284,18 @@ Measured result, 2026-08-09:
 - recovery: 294 recorded, 217 recovered, 68 tree_only, 47 inferred, 0 unknown
 - both bundles import cleanly into a throwaway appliance state dir (346 in
   8.8s, 280 in 8.0s), and a second import of each is a no-op
+
+Second pass, 2026-08-10, after the discovery depth was fixed:
+
+- 55 further runs exported incrementally (22 lane-b, 25 corpus B, 8 from a third
+  tree, `results-quarantine-setupstubs/`, found during the same sweep), each
+  bundle excluding the prior manifest so no already-thinned run was re-exported
+- recovery: 46 recorded, 9 unknown — the unknown are setup-stub and pre-check
+  failures that never installed superpowers, so no evidence exists to recover
+- 0 credential-shaped paths; grepping the three bundles for the 10 real token
+  values in the source `auth.json` files finds nothing
+- all 55 imported, 0 failed; `status`, `show`, and `costs` read them
+- appliance now holds 681 imported runs
 
 ## Out Of Scope
 

--- a/scripts/thin-run-homes.ts
+++ b/scripts/thin-run-homes.ts
@@ -1,0 +1,310 @@
+#!/usr/bin/env bun
+/**
+ * Thin exported run dirs by deleting their throwaway $HOME.
+ *
+ * Usage:
+ *   bun scripts/thin-run-homes.ts --results <dir> --bundle <bundle-dir> [options]
+ *
+ * Required:
+ *   --results <dir>   local results tree (results/<label>/<run-id>/...)
+ *   --bundle <dir>    the bundle built from it by `quorum export-runs`
+ *
+ * Options:
+ *   --yes             actually delete; without it this is a dry run
+ *   --skip-verify     skip re-hashing bundle payloads (faster, weaker guarantee)
+ *   --json            machine-readable summary on stdout
+ *   -h, --help        this text
+ *
+ * Why this exists:
+ *   A finished run keeps the whole disposable $HOME the coding agent ran in —
+ *   npm/bun caches, sqlite logs, archived plugin trees, and a live `auth.json`
+ *   holding OAuth tokens. Across two corpora that was 54.9 GB of the 62 GB on
+ *   disk. Once `quorum export-runs` has captured the analytical payload, the
+ *   home is dead weight and a standing credential exposure.
+ *
+ * What it will not delete (each is reported, not silently skipped):
+ *   - a run with no verdict.json — it crashed mid-flight, and its home is the
+ *     only record of why
+ *   - a run absent from the bundle manifest
+ *   - a run whose bundle payload is missing or fails checksum verification
+ *   - anything resolving outside --results, or not named exactly `home`
+ *
+ * Exit codes:
+ *   0  clean (dry run, or deletion finished with nothing skipped unexpectedly)
+ *   1  bad arguments or unusable inputs
+ *   2  finished, but some runs were skipped — read the report
+ */
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { basename, join, relative, resolve } from 'node:path';
+import { BundleManifestSchema } from '../src/export-runs/manifest.ts';
+
+interface Options {
+  readonly results: string;
+  readonly bundle: string;
+  readonly yes: boolean;
+  readonly skipVerify: boolean;
+  readonly json: boolean;
+}
+
+interface Candidate {
+  readonly runId: string;
+  readonly homePath: string;
+  readonly bytes: number;
+}
+
+interface Skip {
+  readonly runId: string;
+  readonly reason: string;
+}
+
+function usage(): never {
+  const text = readFileSync(new URL(import.meta.url), 'utf8');
+  const doc = text.slice(text.indexOf('/**'), text.indexOf('*/') + 2);
+  process.stdout.write(`${doc}\n`);
+  process.exit(0);
+}
+
+function fail(message: string): never {
+  process.stderr.write(`error: ${message}\n`);
+  process.exit(1);
+}
+
+function parseArgs(argv: readonly string[]): Options {
+  let results: string | null = null;
+  let bundle: string | null = null;
+  let yes = false;
+  let skipVerify = false;
+  let json = false;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      usage();
+    } else if (arg === '--results') {
+      results = argv[++i] ?? null;
+    } else if (arg === '--bundle') {
+      bundle = argv[++i] ?? null;
+    } else if (arg === '--yes') {
+      yes = true;
+    } else if (arg === '--skip-verify') {
+      skipVerify = true;
+    } else if (arg === '--json') {
+      json = true;
+    } else {
+      fail(`unknown argument: ${arg}`);
+    }
+  }
+
+  if (results === null || bundle === null) {
+    fail('--results and --bundle are both required (--help for usage)');
+  }
+  const resolvedResults = resolve(results);
+  const resolvedBundle = resolve(bundle);
+  if (!existsSync(resolvedResults) || !statSync(resolvedResults).isDirectory()) {
+    fail(`results dir does not exist: ${resolvedResults}`);
+  }
+  if (!existsSync(join(resolvedBundle, 'manifest.json'))) {
+    fail(`bundle has no manifest.json: ${resolvedBundle}`);
+  }
+
+  return {
+    results: resolvedResults,
+    bundle: resolvedBundle,
+    yes,
+    skipVerify,
+    json,
+  };
+}
+
+function dirBytes(path: string): number {
+  let total = 0;
+  const visit = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const child = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        visit(child);
+      } else if (entry.isFile()) {
+        try {
+          total += statSync(child).size;
+        } catch {
+          // A file that vanished mid-walk contributes nothing; keep going.
+        }
+      }
+    }
+  };
+  visit(path);
+  return total;
+}
+
+function gb(bytes: number): string {
+  return `${(bytes / 1024 ** 3).toFixed(2)} GB`;
+}
+
+// The bundle is the only copy of the payload once a home is gone, so verify it
+// still hashes to what the manifest recorded before trusting it.
+function payloadIntact(
+  bundleDir: string,
+  runId: string,
+  files: Record<string, string>,
+): string | null {
+  const runDir = join(bundleDir, 'runs', runId);
+  if (!existsSync(runDir)) {
+    return 'bundle payload dir is missing';
+  }
+  for (const [rel, expected] of Object.entries(files)) {
+    const path = join(runDir, rel);
+    if (!existsSync(path)) {
+      return `bundle is missing ${rel}`;
+    }
+    if (Bun.SHA256.hash(readFileSync(path), 'hex') !== expected) {
+      return `bundle checksum mismatch for ${rel}`;
+    }
+  }
+  return null;
+}
+
+// A home qualifies only if the run it belongs to is provably captured. The
+// path checks are belt-and-braces against a manifest naming something odd.
+function classify(
+  options: Options,
+  runDir: string,
+  manifestFiles: Map<string, Record<string, string>>,
+): { candidate: Candidate } | { skip: Skip } {
+  const runId = basename(runDir);
+  const homePath = join(runDir, 'home');
+
+  if (!existsSync(homePath) || !statSync(homePath).isDirectory()) {
+    return { skip: { runId, reason: 'no home/ dir' } };
+  }
+  if (basename(homePath) !== 'home') {
+    return { skip: { runId, reason: 'refusing: path is not named home' } };
+  }
+  const rel = relative(options.results, homePath);
+  if (rel.startsWith('..') || rel.startsWith('/')) {
+    return { skip: { runId, reason: 'refusing: path escapes --results' } };
+  }
+  if (!existsSync(join(runDir, 'verdict.json'))) {
+    return {
+      skip: { runId, reason: 'no verdict.json (crashed run — home is its only record)' },
+    };
+  }
+  const files = manifestFiles.get(runId);
+  if (files === undefined) {
+    return { skip: { runId, reason: 'not present in the bundle manifest' } };
+  }
+  if (!options.skipVerify) {
+    const problem = payloadIntact(options.bundle, runId, files);
+    if (problem !== null) {
+      return { skip: { runId, reason: problem } };
+    }
+  }
+  return { candidate: { runId, homePath, bytes: dirBytes(homePath) } };
+}
+
+function runDirs(resultsDir: string): string[] {
+  const out: string[] = [];
+  for (const label of readdirSync(resultsDir, { withFileTypes: true })) {
+    if (!label.isDirectory()) {
+      continue;
+    }
+    const labelDir = join(resultsDir, label.name);
+    for (const run of readdirSync(labelDir, { withFileTypes: true })) {
+      if (run.isDirectory()) {
+        out.push(join(labelDir, run.name));
+      }
+    }
+  }
+  return out.sort();
+}
+
+function main(): void {
+  const options = parseArgs(process.argv.slice(2));
+
+  const manifest = BundleManifestSchema.parse(
+    JSON.parse(readFileSync(join(options.bundle, 'manifest.json'), 'utf8')),
+  );
+  const manifestFiles = new Map(
+    manifest.entries.map((entry) => [entry.run_id, entry.files]),
+  );
+
+  const candidates: Candidate[] = [];
+  const skips: Skip[] = [];
+  for (const runDir of runDirs(options.results)) {
+    const verdict = classify(options, runDir, manifestFiles);
+    if ('candidate' in verdict) {
+      candidates.push(verdict.candidate);
+    } else if (verdict.skip.reason !== 'no home/ dir') {
+      // "no home" is the steady state after a previous pass; not worth reporting.
+      skips.push(verdict.skip);
+    }
+  }
+
+  const total = candidates.reduce((sum, c) => sum + c.bytes, 0);
+  let freed = 0;
+  const failures: Skip[] = [];
+
+  if (options.yes) {
+    for (const candidate of candidates) {
+      try {
+        rmSync(candidate.homePath, { recursive: true, force: true });
+        freed += candidate.bytes;
+      } catch (error) {
+        failures.push({
+          runId: candidate.runId,
+          reason: `delete failed: ${error instanceof Error ? error.message : String(error)}`,
+        });
+      }
+    }
+  }
+
+  if (options.json) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          dry_run: !options.yes,
+          results_dir: options.results,
+          bundle_dir: options.bundle,
+          verified_checksums: !options.skipVerify,
+          candidates: candidates.length,
+          bytes: total,
+          freed_bytes: freed,
+          skipped: [...skips, ...failures],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  } else {
+    const mode = options.yes ? 'DELETED' : 'would delete';
+    process.stdout.write(
+      `${mode} ${candidates.length} run home(s), ${gb(options.yes ? freed : total)}\n` +
+        `  results: ${options.results}\n` +
+        `  bundle:  ${options.bundle}${options.skipVerify ? ' (checksums NOT verified)' : ' (checksums verified)'}\n`,
+    );
+    if (skips.length > 0) {
+      process.stdout.write(`\nkept ${skips.length} home(s):\n`);
+      for (const skip of skips.slice(0, 20)) {
+        process.stdout.write(`  ${skip.runId}\n    ${skip.reason}\n`);
+      }
+      if (skips.length > 20) {
+        process.stdout.write(`  ... and ${skips.length - 20} more\n`);
+      }
+    }
+    for (const failure of failures) {
+      process.stderr.write(`FAILED ${failure.runId}: ${failure.reason}\n`);
+    }
+    if (!options.yes) {
+      process.stdout.write('\ndry run — re-run with --yes to delete\n');
+    }
+  }
+
+  process.exit(skips.length > 0 || failures.length > 0 ? 2 : 0);
+}
+
+main();

--- a/scripts/thin-run-homes.ts
+++ b/scripts/thin-run-homes.ts
@@ -42,6 +42,7 @@ import {
   statSync,
 } from 'node:fs';
 import { basename, join, relative, resolve } from 'node:path';
+import { findRunDirs } from '../src/export-runs/index.ts';
 import { BundleManifestSchema } from '../src/export-runs/manifest.ts';
 
 interface Options {
@@ -207,22 +208,6 @@ function classify(
   return { candidate: { runId, homePath, bytes: dirBytes(homePath) } };
 }
 
-function runDirs(resultsDir: string): string[] {
-  const out: string[] = [];
-  for (const label of readdirSync(resultsDir, { withFileTypes: true })) {
-    if (!label.isDirectory()) {
-      continue;
-    }
-    const labelDir = join(resultsDir, label.name);
-    for (const run of readdirSync(labelDir, { withFileTypes: true })) {
-      if (run.isDirectory()) {
-        out.push(join(labelDir, run.name));
-      }
-    }
-  }
-  return out.sort();
-}
-
 function main(): void {
   const options = parseArgs(process.argv.slice(2));
 
@@ -235,7 +220,7 @@ function main(): void {
 
   const candidates: Candidate[] = [];
   const skips: Skip[] = [];
-  for (const runDir of runDirs(options.results)) {
+  for (const runDir of findRunDirs(options.results)) {
     const verdict = classify(options, runDir, manifestFiles);
     if ('candidate' in verdict) {
       candidates.push(verdict.candidate);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,6 +15,7 @@ import { FinalVerdictSchema } from '../contracts/verdict.ts';
 import { checkCredentials } from '../credentials/check.ts';
 import { getEnv } from '../env.ts';
 import { exportRuns } from '../export-runs/index.ts';
+import { BundleManifestSchema } from '../export-runs/manifest.ts';
 import { runBatch } from '../run-all/index.ts';
 import { writeGridManifest } from '../run-all/write-grid-manifest.ts';
 import {
@@ -383,6 +384,7 @@ program
 interface ExportRunsOptions {
   readonly out: string;
   readonly superpowersRepo: string | undefined;
+  readonly excludeManifest: readonly string[] | undefined;
 }
 
 program
@@ -396,6 +398,10 @@ program
     '--superpowers-repo <path>',
     'superpowers checkout used to resolve archived skill trees to commits',
   )
+  .option(
+    '--exclude-manifest <path...>',
+    'manifest.json of a previous bundle; its runs are left out of this one',
+  )
   .action((resultsDir: string, opts: ExportRunsOptions) => {
     const source = resolve(resultsDir);
     if (!existsSync(source) || !statSync(source).isDirectory()) {
@@ -408,11 +414,22 @@ program
       opts.superpowersRepo ?? getEnv('SUPERPOWERS_ROOT') ?? '.',
     );
 
+    const excludeRunIds = new Set<string>();
+    for (const path of opts.excludeManifest ?? []) {
+      const prior = BundleManifestSchema.parse(
+        JSON.parse(readFileSync(resolve(path), 'utf8')),
+      );
+      for (const entry of prior.entries) {
+        excludeRunIds.add(entry.run_id);
+      }
+    }
+
     let last = 0;
     const summary = exportRuns({
       resultsDir: source,
       outDir: resolve(opts.out),
       superpowersRepo,
+      excludeRunIds,
       runner: new SpawnCommandRunner(),
       sourceHost: hostname(),
       now: new Date().toISOString(),
@@ -431,7 +448,8 @@ program
       .join(' ');
     process.stdout.write(
       `bundle written to ${summary.bundleDir}\n` +
-        `  exported ${summary.exported}, skipped ${summary.skipped}\n` +
+        `  exported ${summary.exported}, skipped ${summary.skipped}` +
+        `${summary.excluded > 0 ? `, already exported ${summary.excluded}` : ''}\n` +
         `  superpowers rev: ${recovery}\n`,
     );
     process.exit(0);

--- a/src/export-runs/index.ts
+++ b/src/export-runs/index.ts
@@ -58,11 +58,16 @@ export interface ExportArgs {
   readonly sourceHost: string;
   readonly now: string;
   readonly onProgress?: (done: number, total: number) => void;
+  // Runs a previous bundle already captured. Re-exporting one is worse than
+  // useless: thinning deletes the home the rev recovery reads, so a second pass
+  // over an already-exported run yields a strictly weaker provenance record.
+  readonly excludeRunIds?: ReadonlySet<string>;
 }
 
 export interface ExportSummary {
   readonly exported: number;
   readonly skipped: number;
+  readonly excluded: number;
   readonly byRecovery: Record<string, number>;
   readonly bundleDir: string;
 }
@@ -76,28 +81,52 @@ function sha256(path: string): string {
   return Bun.SHA256.hash(readFileSync(path), 'hex');
 }
 
-// Every run directory under results/<label>/<run-id>/ that has a verdict.
-function discoverRunDirs(resultsDir: string): string[] {
+// A run's own payload can contain a nested results tree — a scenario that
+// exercises quorum itself leaves verdicts under coding-agent-workdir/. Finding
+// a verdict marks a run and stops the descent, and these names are never
+// searched at all.
+const NON_RUN_DIRS = new Set([...PAYLOAD_DIRS, 'home', 'raw-sessions', '.git']);
+
+// Depth is bounded so a stray symlink or a deep fixture tree cannot turn a
+// scan into a full-disk walk.
+const MAX_DISCOVERY_DEPTH = 6;
+
+// Every run directory at any depth. The canonical layout is
+// results/<label>/<run-id>/, but quarantine sweeps move a whole label tree
+// under a holding directory, putting its runs one level deeper.
+//
+// A run is a directory holding a verdict.json or a home/ — the latter marks a
+// run that crashed before it could reach a verdict, which callers thinning
+// disk still need to see. Either marker ends the descent.
+export function findRunDirs(resultsDir: string): string[] {
   const runs: string[] = [];
-  if (!existsSync(resultsDir)) {
-    return runs;
-  }
-  for (const label of readdirSync(resultsDir, { withFileTypes: true })) {
-    if (!label.isDirectory()) {
-      continue;
+  const visit = (dir: string, depth: number): void => {
+    if (
+      existsSync(join(dir, 'verdict.json')) ||
+      existsSync(join(dir, 'home'))
+    ) {
+      runs.push(dir);
+      return;
     }
-    const labelDir = join(resultsDir, label.name);
-    for (const run of readdirSync(labelDir, { withFileTypes: true })) {
-      if (!run.isDirectory()) {
-        continue;
-      }
-      const runDir = join(labelDir, run.name);
-      if (existsSync(join(runDir, 'verdict.json'))) {
-        runs.push(runDir);
+    if (depth >= MAX_DISCOVERY_DEPTH) {
+      return;
+    }
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory() && !NON_RUN_DIRS.has(entry.name)) {
+        visit(join(dir, entry.name), depth + 1);
       }
     }
+  };
+  if (existsSync(resultsDir)) {
+    visit(resultsDir, 0);
   }
   return runs.sort();
+}
+
+function discoverRunDirs(resultsDir: string): string[] {
+  return findRunDirs(resultsDir).filter((dir) =>
+    existsSync(join(dir, 'verdict.json')),
+  );
 }
 
 function copyTree(
@@ -231,11 +260,30 @@ export function exportRuns(args: ExportArgs): ExportSummary {
 
   let entries: BundleEntry[] = [];
   const skipped: BundleSkip[] = [];
+  const claimedRunIds = new Map<string, string>();
+  let excluded = 0;
 
   let done = 0;
   for (const runDir of runDirs) {
     done += 1;
     args.onProgress?.(done, runDirs.length);
+
+    const runId = basename(runDir);
+    if (args.excludeRunIds?.has(runId) === true) {
+      excluded += 1;
+      continue;
+    }
+    // Bundle layout is keyed on the run id alone, so a collision would merge
+    // two runs' payloads into one directory and corrupt both.
+    const claimed = claimedRunIds.get(runId);
+    if (claimed !== undefined) {
+      skipped.push({
+        source_path: runDir,
+        reason: `duplicate run id, already exported from ${claimed}`,
+      });
+      continue;
+    }
+    claimedRunIds.set(runId, runDir);
 
     let parsed: ReturnType<typeof FinalVerdictSchema.parse>;
     try {
@@ -268,7 +316,6 @@ export function exportRuns(args: ExportArgs): ExportSummary {
       };
     }
 
-    const runId = basename(runDir);
     const destRun = join(args.outDir, 'runs', runId);
     let files: Record<string, string>;
     try {
@@ -332,6 +379,7 @@ export function exportRuns(args: ExportArgs): ExportSummary {
   return {
     exported: entries.length,
     skipped: skipped.length,
+    excluded,
     byRecovery,
     bundleDir: args.outDir,
   };

--- a/test/export-runs.test.ts
+++ b/test/export-runs.test.ts
@@ -317,6 +317,115 @@ test('a run whose verdict will not parse is skipped, not fatal', () => {
   expect(manifest.skipped[0]?.reason).toContain('verdict');
 });
 
+test('a run nested below the usual two levels is still found', () => {
+  const { root } = resultsTree();
+  // Quarantine dirs hold a whole label tree, putting the run one level deeper.
+  const run = join(
+    root,
+    '.quarantine-quota-20260806',
+    'cx-eff-demo-rep9',
+    'quar-run',
+  );
+  write(join(run, 'verdict.json'), verdict());
+  write(join(run, 'trajectory.json'), '{"steps":[]}');
+
+  const entries = exportCorpus(root);
+
+  expect(entries.map((e) => e.run_id).sort()).toEqual([
+    'demo-codex-codex_sub-linux-20260730T201515Z-a325',
+    'quar-run',
+  ]);
+});
+
+test('a verdict inside a payload dir is not mistaken for a run', () => {
+  const { root, runId } = resultsTree();
+  // A scenario that exercises quorum itself leaves a verdict in the workdir.
+  write(
+    join(
+      root,
+      'cx-eff-demo-rep1',
+      runId,
+      'coding-agent-workdir/results/x/y/verdict.json',
+    ),
+    verdict(),
+  );
+  write(
+    join(root, 'cx-eff-demo-rep1', runId, 'home/nested/verdict.json'),
+    verdict(),
+  );
+
+  const entries = exportCorpus(root);
+
+  expect(entries).toHaveLength(1);
+  expect(entries[0]?.run_id).toBe(runId);
+});
+
+test('a colliding run id is skipped rather than overwriting the first', () => {
+  const { root, runId } = resultsTree();
+  const clash = join(
+    root,
+    '.quarantine-quota-20260806',
+    'cx-eff-demo-rep1',
+    runId,
+  );
+  write(join(clash, 'verdict.json'), verdict());
+
+  const bundle = join(mkdtempSync(join(tmpdir(), 'bundle-')), 'out');
+  const summary = exportRuns({
+    resultsDir: root,
+    outDir: bundle,
+    superpowersRepo: superpowersRepo(),
+    runner,
+    sourceHost: 'test-host',
+    now: '2026-08-09T00:00:00.000Z',
+  });
+
+  expect(summary.exported).toBe(1);
+  expect(summary.skipped).toBe(1);
+  const manifest = BundleManifestSchema.parse(
+    JSON.parse(readFileSync(join(bundle, 'manifest.json'), 'utf8')),
+  );
+  // One copy wins by sort order; the skip names both paths so the collision is
+  // diagnosable rather than silent.
+  expect(manifest.skipped[0]?.reason).toContain('duplicate run id');
+  expect(manifest.skipped[0]?.source_path).toBe(
+    join(root, 'cx-eff-demo-rep1', runId),
+  );
+  expect(manifest.skipped[0]?.reason).toContain(clash);
+  expect(manifest.entries[0]?.source_path).toBe(clash);
+});
+
+test('an already-exported run is left out of an incremental bundle', () => {
+  const { root, runId } = resultsTree();
+  const run = join(
+    root,
+    '.quarantine-quota-20260806',
+    'cx-eff-demo-rep9',
+    'new-run',
+  );
+  write(join(run, 'verdict.json'), verdict());
+
+  const bundle = join(mkdtempSync(join(tmpdir(), 'bundle-')), 'out');
+  const summary = exportRuns({
+    resultsDir: root,
+    outDir: bundle,
+    superpowersRepo: superpowersRepo(),
+    runner,
+    sourceHost: 'test-host',
+    now: '2026-08-09T00:00:00.000Z',
+    excludeRunIds: new Set([runId]),
+  });
+
+  // Excluded is not skipped: nothing failed, it is simply already captured.
+  expect(summary.exported).toBe(1);
+  expect(summary.skipped).toBe(0);
+  expect(summary.excluded).toBe(1);
+  expect(existsSync(join(bundle, 'runs', runId))).toBe(false);
+  expect(existsSync(join(bundle, 'runs', 'new-run', 'verdict.json'))).toBe(
+    true,
+  );
+});
+
 test('bundle files are written private', () => {
   const { bundle } = runExport();
   const mode = statSync(join(bundle, 'manifest.json')).mode & 0o777;


### PR DESCRIPTION
Companion to `quorum export-runs`. A finished run keeps the whole disposable `$HOME` the coding agent ran in — npm/bun caches, sqlite logs, archived plugin trees, and a live `auth.json`. Across the two laptop corpora that was 54.9 GB and 506 files holding OAuth tokens.

Deleting a home is only safe once the payload is captured, so the script proves that per run before touching anything:

- `verdict.json` present
- run present in the bundle manifest
- every bundle file re-hashed against its recorded sha-256

Dry run by default; `--yes` to delete. Verified against a deliberately corrupted bundle — the affected run is kept with `bundle checksum mismatch`.

It also keeps the home of any run with no verdict: those crashed mid-flight and the home is the only record of why. The two corpora have 2 and 3 such runs respectively.

Measured dry runs: 346 homes / 18.34 GB and 280 homes / 30.76 GB, checksums verified in ~30s each.