### PR TITLE
Rebase container on shared everyharness-container image

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ evals checkout, the Superpowers checkout under test, credentials, auth sources,
 and all run artifacts on the host while quorum runs inside a rich Ubuntu
 workspace container.
 
+The eval image builds `FROM` the shared base image
+[`ghcr.io/prime-radiant-inc/everyharness-container`](https://github.com/prime-radiant-inc/everyharness-container),
+which owns the harness-CLI install layer (every agent CLI plus the base
+toolchains); this repo layers only the evals-specific pieces (serf, gauntlet,
+the quorum shims) on top. See [container/README.md](container/README.md) for the
+base-image relationship and how to bump the pin.
+
 Create `.env.container` or pass an explicit env file to `up`:
 
 ```dotenv

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,167 +1,25 @@
 # syntax=docker/dockerfile:1.7
-FROM ubuntu:26.04
+# The harness-CLI install layer (23 coding-agent CLIs + base toolchains: Node,
+# bun, uv, Rust, mise, Python, Go, Ruby) lives in the shared base image
+# everyharness-container. That layer was extracted verbatim from this repo's
+# container/ directory, so both consumers share one proven image instead of
+# maintaining near-duplicates. This Dockerfile keeps ONLY the evals-specific
+# layers (serf, gauntlet, the quorum + evals-tool-versions shims, the evals
+# workspace) on top of that base.
+#
+# Pinned by digest per everyharness-container's version-pin policy (`latest`
+# moves; pin by sha tag or digest for reproducibility). This digest is the
+# first published build — human-readable tag
+# ghcr.io/prime-radiant-inc/everyharness-container:8034359 (commit 8034359,
+# 2026-08-11). To bump: pull the newer base, then replace the digest below and
+# update this comment's tag/commit to match.
+FROM ghcr.io/prime-radiant-inc/everyharness-container@sha256:de1026a0580ce2956ab4b181407110f2cbc37660c7bf0f3d5a0a1d3cc6051d7f
 
-ARG GOOSE_VERSION=1.41.0
+# The base image already sets the toolchain env vars (BUN_INSTALL, CARGO_HOME,
+# UV_TOOL_*, PATH, AGY_OAUTH_HOME, KIMI_OAUTH_HOME) and puts go, bun, and the
+# harness CLIs on PATH; the evals layers below rely on that inherited state.
+
 ARG SERF_REF=0a459b633629cd034aa8a800c77bcd75a76496e8
-ARG TARGETARCH
-
-ENV DEBIAN_FRONTEND=noninteractive
-ENV BUN_INSTALL=/usr/local/bun
-ENV RUSTUP_HOME=/usr/local/rustup
-ENV CARGO_HOME=/usr/local/cargo
-ENV UV_TOOL_DIR=/opt/uv-tools
-ENV UV_TOOL_BIN_DIR=/usr/local/bin
-ENV UV_PYTHON_INSTALL_DIR=/opt/uv-python
-ENV AGY_OAUTH_HOME=/auth/gemini
-ENV KIMI_OAUTH_HOME=/auth/kimi-code
-ENV PATH="/usr/local/bun/bin:/usr/local/cargo/bin:/opt/uv-tools:${PATH}"
-
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
-    bash \
-    zsh \
-    git \
-    gh \
-    curl \
-    wget \
-    ca-certificates \
-    gnupg \
-    jq \
-    yq \
-    ripgrep \
-    fd-find \
-    shellcheck \
-    tmux \
-    less \
-    unzip \
-    zip \
-    xz-utils \
-    file \
-    sudo \
-    openssh-client \
-    procps \
-    lsof \
-    tree \
-    rsync \
-    build-essential \
-    pkg-config \
-    libssl-dev \
-    libsqlite3-dev \
-    zlib1g-dev \
-    libbz2-dev \
-    libreadline-dev \
-    libffi-dev \
-    liblzma-dev \
-    libncurses-dev \
-    libxml2-dev \
-    libxmlsec1-dev \
-    python3 \
-    python3-pip \
-    python3-venv \
-    ruby-full \
-    golang-go \
-  && ln -sf /usr/bin/fdfind /usr/local/bin/fd \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
-  && apt-get update \
-  && apt-get install -y --no-install-recommends nodejs \
-  && node --version \
-  && npm --version \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN curl -fsSL https://bun.sh/install | bash \
-  && ln -sf /usr/local/bun/bin/bun /usr/local/bin/bun \
-  && bun --version
-
-RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh \
-  && uv --version
-
-RUN curl -fsSL https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal \
-  && rustc --version \
-  && cargo --version
-
-RUN curl -fsSL https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise sh \
-  && mise --version
-
-RUN npm install -g \
-    @anthropic-ai/claude-code@2.1.209 \
-    @openai/codex@0.146.0 \
-    @google/gemini-cli@0.50.0 \
-    opencode-ai@1.18.1 \
-    @github/copilot@1.0.78 \
-    @factory/cli@0.171.0 \
-    @qwen-code/qwen-code@0.19.10 \
-    @moonshot-ai/kimi-code@0.24.1 \
-    @kilocode/cli@7.4.7 \
-    openclaw@2026.7.1 \
-    @sourcegraph/amp@0.0.1784060561-g91077d \
-    cline@3.0.40 \
-    @earendil-works/pi-coding-agent@0.80.7 \
-    pi-subagents@0.34.0 \
-    @xai-official/grok@0.2.101 \
-  && if command -v kilocode >/dev/null 2>&1 && ! command -v kilo >/dev/null 2>&1; then ln -s "$(command -v kilocode)" /usr/local/bin/kilo; fi \
-  && if command -v factory >/dev/null 2>&1 && ! command -v droid >/dev/null 2>&1; then ln -s "$(command -v factory)" /usr/local/bin/droid; fi \
-  && if command -v kimi >/dev/null 2>&1 && [ "$(command -v kimi)" != /usr/local/bin/kimi ]; then ln -s "$(command -v kimi)" /usr/local/bin/kimi; fi
-
-RUN mkdir -p /opt/cursor-agent \
-  && curl -fsSL https://cursor.com/install | HOME=/opt/cursor-agent bash \
-  && test -x /opt/cursor-agent/.local/bin/agent \
-  && test -x /opt/cursor-agent/.local/bin/cursor-agent \
-  && ln -sf /opt/cursor-agent/.local/bin/agent /usr/local/bin/agent \
-  && ln -sf /opt/cursor-agent/.local/bin/cursor-agent /usr/local/bin/cursor-agent \
-  && agent --version
-
-# Both tools pin Python 3.12: litellm builds a pyo3 extension whose maximum
-# supported interpreter is 3.13, and unpinned uv resolves to CPython 3.14.
-RUN uv tool install --python 3.12 mini-swe-agent \
-  && uv tool install --python 3.12 "trae-agent[test,evaluation] @ git+https://github.com/bytedance/trae-agent.git" \
-  && chmod -R a+rX "$UV_TOOL_DIR" "$UV_PYTHON_INSTALL_DIR" \
-  && mini-swe-agent --help >/dev/null \
-  && trae-cli --version
-
-# Editable install: SWE-agent resolves CONFIG_DIR relative to its package and
-# asserts it exists; a non-editable install leaves config/ behind in the repo,
-# so install -e to keep the package pointed at /opt/sweagent-repo (which has config/).
-RUN uv venv /opt/sweagent-venv --python 3.12 \
-  && git clone --depth 1 https://github.com/SWE-agent/SWE-agent.git /opt/sweagent-repo \
-  && uv pip install --python /opt/sweagent-venv -e /opt/sweagent-repo \
-  && printf '%s\n' \
-    '#!/usr/bin/env bash' \
-    'source /opt/sweagent-venv/bin/activate' \
-    'exec python -m sweagent.run.run "$@"' \
-    > /usr/local/bin/sweagent \
-  && chmod +x /usr/local/bin/sweagent \
-  && sweagent --help >/dev/null
-
-RUN case "$TARGETARCH" in \
-      amd64) goose_arch=x86_64 ;; \
-      arm64) goose_arch=aarch64 ;; \
-      *) echo "unsupported TARGETARCH for goose: $TARGETARCH" >&2; exit 1 ;; \
-    esac \
-  && curl -fsSL -o /tmp/goose.tar.gz "https://github.com/aaif-goose/goose/releases/download/v${GOOSE_VERSION}/goose-${goose_arch}-unknown-linux-gnu.tar.gz" \
-  && tar -xzf /tmp/goose.tar.gz -C /tmp ./goose \
-  && install -m 0755 /tmp/goose /usr/local/bin/goose \
-  && rm -f /tmp/goose /tmp/goose.tar.gz \
-  && goose --version
-
-# Run as root, the hermes installer uses the FHS layout: code at
-# /usr/local/lib/hermes-agent, command at /usr/local/bin/hermes (already on PATH).
-# HERMES_COMMIT pins the installed revision: the installer defaults to main
-# HEAD, which BuildKit's layer cache would otherwise freeze invisibly — a bare
-# rebuild is a cache no-op. Bump the default to move hermes.
-ARG HERMES_COMMIT=9ea01979dc00d3ed0b08977c28325e6c3ed592d0
-RUN curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-setup --commit "$HERMES_COMMIT" \
-  && hermes version
-
-RUN curl -fsSL https://mimo.xiaomi.com/install | bash \
-  && ln -sf /root/.mimocode/bin/mimo /usr/local/bin/mimo \
-  && mimo --version
-
-# Google Antigravity CLI (binary: agy, installs to $HOME/.local/bin/agy).
-RUN curl -fsSL https://antigravity.google/cli/install.sh | bash \
-  && ln -sf /root/.local/bin/agy /usr/local/bin/agy \
-  && agy --version
 
 RUN git clone https://github.com/prime-radiant-inc/serf.git /opt/serf-repo \
   && cd /opt/serf-repo \

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -9,10 +9,11 @@
 #
 # Pinned by digest per everyharness-container's version-pin policy (`latest`
 # moves; pin by sha tag or digest for reproducibility). This digest is the
-# first published build — human-readable tag
-# ghcr.io/prime-radiant-inc/everyharness-container:8034359 (commit 8034359,
-# 2026-08-11). To bump: pull the newer base, then replace the digest below and
-# update this comment's tag/commit to match.
+# first published build (commit 8034359, 2026-08-11), also pullable as the
+# full-commit-SHA tag
+# ghcr.io/prime-radiant-inc/everyharness-container:80343595da91f739fb1042a817a49519ab301d6a
+# (the registry has no short-SHA tags). To bump: pull the newer base, then
+# replace the digest below and update this comment's commit/tag to match.
 FROM ghcr.io/prime-radiant-inc/everyharness-container@sha256:de1026a0580ce2956ab4b181407110f2cbc37660c7bf0f3d5a0a1d3cc6051d7f
 
 # The base image already sets the toolchain env vars (BUN_INSTALL, CARGO_HOME,

--- a/container/README.md
+++ b/container/README.md
@@ -1,0 +1,83 @@
+# Eval Container
+
+The eval image is the primary recipe for real suite runs: quorum runs inside it
+while the evals checkout, the Superpowers checkout under test, credentials, and
+run artifacts stay on the host. Build and run it with
+[`scripts/evals-container`](../scripts/evals-container); see the README's
+[Container Runtime](../README.md#container-runtime) section for the operator
+workflow.
+
+## Base image
+
+`Dockerfile` builds `FROM
+ghcr.io/prime-radiant-inc/everyharness-container`, the shared base image that
+owns the **harness-CLI install layer**: every coding-agent CLI quorum can launch
+(Claude Code, Codex, Gemini CLI, and the rest) plus the base toolchains they
+need (Node, bun, uv, Rust, mise, Python, Go, Ruby). That layer was extracted
+verbatim from this repo's `container/` directory, so both consumers share one
+proven image instead of maintaining near-duplicate install steps.
+
+This repo's `Dockerfile` keeps **only the evals-specific layers** on top of the
+base:
+
+- **serf** — cloned and `go install`ed, pinned by `ARG SERF_REF`, with its
+  source revision recorded at `/usr/local/share/serf-source-rev`.
+- **gauntlet** — installed from the `gauntlet` build-context (a local checkout
+  the wrapper resolves via `GAUNTLET_ROOT`/`--gauntlet-root`) and wrapped as
+  `/usr/local/bin/gauntlet`.
+- **quorum** and **evals-tool-versions** shims copied to `/usr/local/bin`.
+- `WORKDIR /workspace/evals`.
+
+Base-image concerns — the harness CLIs, their version pins, and the base
+toolchains — live in
+[everyharness-container](https://github.com/prime-radiant-inc/everyharness-container).
+Adding or bumping a harness CLI happens there, not here (see
+[docs/adding-a-coding-agent.md](../docs/adding-a-coding-agent.md)).
+
+## Version reporting
+
+The base image ships `harness-versions` on `PATH`, which reports the harness
+CLIs and base toolchains. This repo's `bin/evals-tool-versions` delegates to it
+for that shared inventory, then reports the evals-specific tools (`quorum`,
+`serf`, `gauntlet`):
+
+```bash
+scripts/evals-container exec evals-tool-versions
+```
+
+## Bumping the base-image pin
+
+`Dockerfile` pins the base by **digest**, per everyharness-container's
+version-pin policy (`latest` moves; pin by sha tag or digest for
+reproducibility). The `FROM` line carries a comment naming the human-readable
+tag/commit the digest corresponds to.
+
+To move to a newer base:
+
+1. Find the new build's digest and commit — from
+   [everyharness-container's packages page](https://github.com/prime-radiant-inc/everyharness-container/pkgs/container/everyharness-container),
+   or:
+
+   ```bash
+   docker pull ghcr.io/prime-radiant-inc/everyharness-container:latest
+   docker image inspect ghcr.io/prime-radiant-inc/everyharness-container:latest \
+     --format '{{index .RepoDigests 0}}'
+   ```
+
+2. Replace the `sha256:…` digest in the `FROM` line and update the adjacent
+   comment's tag/commit to match.
+3. Rebuild and smoke-test:
+
+   ```bash
+   scripts/evals-container build
+   docker run --rm superpowers-evals:local evals-tool-versions
+   ```
+
+## `Dockerfile.claude-slim`
+
+A standalone, Claude-only slim variant used for a resource-constrained host that
+cannot afford the full base image's ~15 GB footprint. It deliberately does **not**
+build on everyharness-container — building on the full base would defeat its
+purpose — so it still carries its own minimal base + Claude install inline. See
+the header comment in that file and
+[docs/experiments/2026-07-sdd-fix-loop-redesign.md](../docs/experiments/2026-07-sdd-fix-loop-redesign.md).

--- a/container/README.md
+++ b/container/README.md
@@ -34,6 +34,17 @@ toolchains — live in
 Adding or bumping a harness CLI happens there, not here (see
 [docs/adding-a-coding-agent.md](../docs/adding-a-coding-agent.md)).
 
+## Architecture
+
+The base image is published for **`linux/amd64` only** (consistent with
+everyharness-container's own documented design), so the eval image is amd64-only
+too. On an arm64 host (Apple Silicon) it builds and runs under emulation rather
+than natively. This is a change from the previous `FROM ubuntu:26.04`, which was
+multi-arch and built natively on arm64. If a native arm64 eval image is ever
+needed, everyharness-container has to publish an arm64 variant first — the
+`TARGETARCH` plumbing (e.g. goose's architecture-specific download) already
+lives in its Dockerfile.
+
 ## Version reporting
 
 The base image ships `harness-versions` on `PATH`, which reports the harness
@@ -44,6 +55,13 @@ for that shared inventory, then reports the evals-specific tools (`quorum`,
 ```bash
 scripts/evals-container exec evals-tool-versions
 ```
+
+Because the shared inventory is delegated, `evals-tool-versions` only produces a
+full report when run on an image that carries the base's `harness-versions`
+(i.e. the main image). On an image without it, the harness/toolchain section
+collapses to a single `harness-versions: missing (base image not detected)` line
+and only the evals-specific tools are reported — see the `Dockerfile.claude-slim`
+note below.
 
 ## Bumping the base-image pin
 
@@ -81,3 +99,13 @@ build on everyharness-container — building on the full base would defeat its
 purpose — so it still carries its own minimal base + Claude install inline. See
 the header comment in that file and
 [docs/experiments/2026-07-sdd-fix-loop-redesign.md](../docs/experiments/2026-07-sdd-fix-loop-redesign.md).
+
+**Version report on the slim image is evals-only.** The slim image copies the
+same `bin/evals-tool-versions`, but it has no `harness-versions` (that ships with
+the base image, which slim does not use). So on slim the report is
+`harness-versions: missing (base image not detected)` followed by just the evals
+tools (`quorum`, `serf`, `gauntlet`) — the claude/node/bun/python inventory the
+old inline script printed is not reported. This is an accepted limitation of the
+throwaway slim variant; use the full image when a complete harness inventory is
+needed. Re-adding an inventory to slim is intentionally avoided because it would
+reintroduce exactly the duplication this base-image split removes.

--- a/container/bin/evals-tool-versions
+++ b/container/bin/evals-tool-versions
@@ -1,48 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-core_tools=(
-  bash
-  zsh
-  git
-  gh
-  node
-  npm
-  bun
-  python3
-  uv
-  go
-  rustc
-  cargo
-  ruby
-  mise
-  quorum
-)
+# The base image (everyharness-container) owns the harness CLIs and base
+# toolchains and ships `harness-versions` to report them. This script defers to
+# that for the shared inventory, then reports the evals-specific tools layered
+# on top by this repo's Dockerfile.
 
-agent_tools=(
-  claude
-  codex
-  gemini
-  opencode
-  pi
-  copilot
-  grok
-  droid
-  qwen
-  kilo
-  openclaw
-  amp
-  cline
-  cursor-agent
-  goose
-  agy
-  kimi
-  mini-swe-agent
-  sweagent
-  trae-cli
-  hermes
-  mimo
+evals_tools=(
+  quorum
   serf
+  gauntlet
 )
 
 print_version() {
@@ -55,11 +22,16 @@ print_version() {
     return 0
   fi
 
-  case "$tool" in
-    go)
-      args=(version)
-      ;;
-  esac
+  # gauntlet has no --version flag; confirm it runs via `config` instead so we
+  # report presence cleanly rather than dumping its usage text.
+  if [[ "$tool" == 'gauntlet' ]]; then
+    if "$tool" config --json >/dev/null 2>&1; then
+      printf '%s: present\n' "$tool"
+    else
+      printf '%s: present (config check failed)\n' "$tool"
+    fi
+    return 0
+  fi
 
   if output=$("$tool" "${args[@]}" 2>&1); then
     first_line=${output%%$'\n'*}
@@ -85,12 +57,13 @@ print_version() {
   fi
 }
 
-printf 'Core tools:\n'
-for tool in "${core_tools[@]}"; do
-  print_version "$tool"
-done
+if command -v harness-versions >/dev/null 2>&1; then
+  harness-versions
+else
+  printf 'harness-versions: missing (base image not detected)\n'
+fi
 
-printf '\nAgent CLIs:\n'
-for tool in "${agent_tools[@]}"; do
+printf '\nEvals tools:\n'
+for tool in "${evals_tools[@]}"; do
   print_version "$tool"
 done

--- a/docs/adding-a-coding-agent.md
+++ b/docs/adding-a-coding-agent.md
@@ -25,12 +25,23 @@ Do not add public-CI live runs. Live evals are trusted-maintainer operations.
 
 ## Step 0 — Install The CLI In The Eval Container
 
-The eval container (`container/Dockerfile`, `ubuntu:26.04`) bundles every
-agent CLI so quorum can launch the target headlessly. A new target's CLI must
-be installed here before any live run. (A desktop-only IDE integration with no
-headless CLI cannot be containerized and cannot be a quorum target.)
+The eval container bundles every agent CLI so quorum can launch the target
+headlessly. A new target's CLI must be installed before any live run. (A
+desktop-only IDE integration with no headless CLI cannot be containerized and
+cannot be a quorum target.)
 
-**Source the install recipe, don't guess one.** In priority order:
+**The harness CLIs live in the shared base image, not this repo.** The eval
+image (`container/Dockerfile`) now builds `FROM
+ghcr.io/prime-radiant-inc/everyharness-container`, which owns the harness-CLI
+install layer (every agent CLI plus the base toolchains: Node, bun, uv, Rust,
+mise, Python, Go, Ruby). This repo's Dockerfile keeps only the evals-specific
+layers (serf, gauntlet, the quorum/`evals-tool-versions` shims, the workspace).
+See [container/README.md](../container/README.md) for the base-image
+relationship and how to bump the pin.
+
+**So a new harness CLI is added in
+[everyharness-container](https://github.com/prime-radiant-inc/everyharness-container),
+not here.** Source the install recipe, don't guess one. In priority order:
 
 1. **Harbor** (`/tmp/harbor-inspect/src/harbor/agents/installed/<agent>.py`,
    pinned — see `docs/superpowers/reference/porting-harbor-converters.md`): its
@@ -42,7 +53,7 @@ headless CLI cannot be containerized and cannot be a quorum target.)
 Verify the package/URL actually exists before editing (`npm view <pkg> version`,
 `curl -fsSIL <url> | head -1`) — never commit an unverified install.
 
-**Match the existing Dockerfile patterns:**
+**Match the existing base-image Dockerfile patterns** (in everyharness-container):
 
 - npm-distributed CLI → add the package to the existing `npm install -g` block.
 - Python CLI → `uv tool install <pkg>` (grouped with the other uv-tool installs),
@@ -53,18 +64,20 @@ Verify the package/URL actually exists before editing (`npm view <pkg> version`,
 
 End every install block with a `--version`/`--help` check so a bad recipe fails
 the build, and symlink the entrypoint into `/usr/local/bin` if the install dir
-isn't already on `PATH`. Then update:
+isn't already on `PATH`. Then, in everyharness-container, add the CLI's command
+name to its `bin/harness-versions` script. (`evals-tool-versions` in this repo
+delegates the harness inventory to `harness-versions`, so it needs no change for
+a new harness CLI — it only lists the evals-specific tools.)
 
-- `test/container-dockerfile.test.ts` — add the install-intent token(s).
-- `container/bin/evals-tool-versions` — add the CLI's command name.
+Once the base image ships the new CLI, bump this repo's base-image pin (see
+[container/README.md](../container/README.md)) so the eval image picks it up.
 
-**Build and smoke it locally** (the build is the real gate; the static test only
-checks the Dockerfile *mentions* the install):
+**Build and smoke it locally** (the build is the real gate). Smoke the base
+image directly in everyharness-container:
 
 ```bash
-orb start                       # ensure the OrbStack docker daemon is up
-scripts/evals-container build    # multi-stage; resolves the gauntlet build-context
-docker run --rm superpowers-evals:local bash -lc '<cmd> --version'
+docker build -t everyharness-container:local .
+docker run --rm everyharness-container:local bash -lc '<cmd> --version'
 ```
 
 **Gotchas (each cost a failed build — watch for them):**

--- a/test/container-dockerfile.test.ts
+++ b/test/container-dockerfile.test.ts
@@ -10,153 +10,58 @@ function dockerfileSource(): string {
   return readFileSync(DOCKERFILE, 'utf8');
 }
 
-function expectInstallIntent(source: string, token: string): void {
-  expect(source).toContain(token);
-}
-
-test('container Dockerfile uses the official Ubuntu 26.04 LTS base', () => {
+test('container Dockerfile builds on the shared everyharness-container base', () => {
   const source = dockerfileSource();
 
   expect(source).toMatch(/^# syntax=docker\/dockerfile:/m);
-  expect(source).toMatch(/^FROM ubuntu:26\.04$/m);
-  expect(source).not.toContain('mcr.microsoft.com/devcontainers');
-  expect(source).not.toContain('ubuntu24.04');
+  // The harness-CLI install layer (agent CLIs + base toolchains) lives in the
+  // shared base image, pinned by digest per its version-pin policy. It must not
+  // be duplicated here.
+  expect(source).toMatch(
+    /^FROM ghcr\.io\/prime-radiant-inc\/everyharness-container@sha256:[0-9a-f]{64}$/m,
+  );
+  expect(source).not.toContain('FROM ubuntu:');
 });
 
-test('container Dockerfile installs the core development toolchain families', () => {
+test('container Dockerfile does not duplicate the base image harness layer', () => {
   const source = dockerfileSource();
 
-  for (const packageName of [
-    'git',
-    'gh',
-    'curl',
-    'jq',
-    'ripgrep',
-    'fd-find',
-    'shellcheck',
-    'build-essential',
-    'python3-pip',
-    'python3-venv',
-    'ruby-full',
-    'golang-go',
-  ]) {
-    expectInstallIntent(source, packageName);
-  }
-
-  for (const toolIntent of [
+  // These installs now belong to everyharness-container. Keeping them here
+  // would reintroduce the duplicate-maintenance problem this base image solves.
+  for (const baseOwned of [
     'deb.nodesource.com',
     'bun.sh/install',
     'astral.sh/uv/install.sh',
     'sh.rustup.rs',
     'mise.run',
-  ]) {
-    expectInstallIntent(source, toolIntent);
-  }
-});
-
-test('container Dockerfile installs headless agent CLIs without desktop IDE sprawl', () => {
-  const source = dockerfileSource();
-
-  for (const npmPackage of [
     '@anthropic-ai/claude-code',
     '@openai/codex',
     '@google/gemini-cli',
-    'opencode-ai',
-    '@github/copilot',
-    '@factory/cli',
-    '@qwen-code/qwen-code',
-    '@moonshot-ai/kimi-code',
-    '@kilocode/cli',
-    'openclaw',
-    '@sourcegraph/amp',
-    'cline',
-    '@earendil-works/pi-coding-agent',
-    'pi-subagents',
-    '@xai-official/grok',
-  ]) {
-    expectInstallIntent(source, npmPackage);
-  }
-
-  for (const externalInstall of [
     'cursor.com/install',
-    'AGY_OAUTH_HOME',
-    'KIMI_OAUTH_HOME',
-    'mini-swe-agent',
-    'git+https://github.com/bytedance/trae-agent.git',
-    'SWE-agent/SWE-agent',
-    '/opt/sweagent-venv',
     'NousResearch/hermes-agent',
-    'mimo.xiaomi.com/install',
     'antigravity.google/cli/install.sh',
-    'prime-radiant-inc/serf',
+    'goose-${goose_arch}-unknown-linux-gnu.tar.gz',
   ]) {
-    expectInstallIntent(source, externalInstall);
+    expect(source).not.toContain(baseOwned);
   }
+});
 
-  for (const commandIntent of [
-    '/usr/local/bin/kilo',
-    '/usr/local/bin/droid',
-    '/usr/local/bin/kimi',
-    '/usr/local/bin/cursor-agent',
-    '/usr/local/bin/sweagent',
-    '/usr/local/bin/hermes',
-    '/usr/local/bin/mimo',
-    '/usr/local/bin/agy',
-    '/usr/local/bin/serf',
-  ]) {
-    expectInstallIntent(source, commandIntent);
-  }
+test('container Dockerfile keeps the serf build pinned by SERF_REF', () => {
+  const source = dockerfileSource();
 
-  expect(source).toContain(
-    'curl -fsSL https://cursor.com/install | HOME=/opt/cursor-agent bash',
-  );
-  expect(source).toContain('test -x /opt/cursor-agent/.local/bin/agent');
-  expect(source).not.toContain('find /opt/cursor-agent -type f -name agent');
-  expect(source).not.toContain(
-    'HOME=/opt/cursor-agent curl -fsSL https://cursor.com/install | bash',
-  );
-  expect(source).toContain('UV_TOOL_BIN_DIR=/usr/local/bin');
-  expect(source).toContain('UV_PYTHON_INSTALL_DIR=/opt/uv-python');
-  expect(source).toContain(
-    'chmod -R a+rX "$UV_TOOL_DIR" "$UV_PYTHON_INSTALL_DIR"',
-  );
-  expect(source).toContain('mini-swe-agent --help');
-  expect(source).toContain('trae-cli --version');
-  expect(source).toContain('sweagent --help');
-  expect(source).toContain('hermes version');
-  expect(source).toContain('mimo --version');
-  expect(source).toContain('agy --version');
   expect(source).toContain(
     'ARG SERF_REF=0a459b633629cd034aa8a800c77bcd75a76496e8',
   );
+  expect(source).toContain('prime-radiant-inc/serf');
   expect(source).toContain('git checkout "$SERF_REF"');
   expect(source).toContain(
     'git rev-parse HEAD > /usr/local/share/serf-source-rev',
   );
   expect(source).toContain('test -x /usr/local/bin/serf');
   expect(source).toContain('serf --version');
-  expect(source).not.toContain('[[');
-  expect(source).not.toContain('uv tool install --tool-dir');
-  expect(source).toContain('ARG TARGETARCH');
-  expect(source).toContain('amd64) goose_arch=x86_64');
-  expect(source).toContain('arm64) goose_arch=aarch64');
-  expect(source).toContain('goose-${goose_arch}-unknown-linux-gnu.tar.gz');
-  expect(source).not.toContain('goose_1.31.1_amd64.deb');
-
-  for (const forbidden of [
-    '.devcontainer/devcontainer.json',
-    '/var/run/docker.sock',
-    'xvfb',
-    'vnc',
-    'novnc',
-    'cursor.deb',
-    'kiro',
-  ]) {
-    expect(source.toLowerCase()).not.toContain(forbidden);
-  }
 });
 
-test('container Dockerfile exposes quorum shims and stable workspace entrypoint', () => {
+test('container Dockerfile exposes gauntlet, quorum shims and stable workspace entrypoint', () => {
   const source = dockerfileSource();
 
   expect(source).toContain('COPY --from=gauntlet /package.json /opt/gauntlet/');
@@ -173,13 +78,4 @@ test('container Dockerfile exposes quorum shims and stable workspace entrypoint'
   );
   expect(source).toMatch(/^WORKDIR \/workspace\/evals$/m);
   expect(source).toMatch(/^CMD \["sleep", "infinity"\]$/m);
-});
-
-test('hermes install is commit-pinned via HERMES_COMMIT', () => {
-  const source = dockerfileSource();
-  // The installer defaults to main HEAD, which BuildKit's layer cache freezes
-  // invisibly — a bare rebuild is a cache no-op. The ARG default is the pin;
-  // bumping it busts exactly the hermes layer.
-  expect(source).toContain('ARG HERMES_COMMIT=');
-  expect(source).toContain('--commit "$HERMES_COMMIT"');
 });

--- a/test/container-shims.test.ts
+++ b/test/container-shims.test.ts
@@ -141,3 +141,79 @@ test('evals-tool-versions reports the real exit status for failing evals-tool ve
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test('evals-tool-versions probes gauntlet via config since it has no --version flag', () => {
+  const root = mkdtempSync(join(tmpdir(), 'evals-tool-versions-'));
+  const bin = join(root, 'bin');
+  mkdirSync(bin);
+
+  try {
+    writeFakeTool(bin, 'harness-versions', 'claude: claude 2.0.0');
+    // A working gauntlet: `config --json` exits 0.
+    writeFakeTool(bin, 'gauntlet', '{}');
+
+    const proc = spawnSync('/bin/bash', [TOOL_VERSIONS], {
+      env: { PATH: bin },
+      encoding: 'utf8',
+    });
+
+    expect(proc.status).toBe(0);
+    expect(proc.stderr).toBe('');
+    // Reported as present without dumping gauntlet's usage text.
+    expect(proc.stdout).toContain('gauntlet: present');
+    expect(proc.stdout).not.toContain('gauntlet: present (config check failed)');
+    expect(proc.stdout).not.toContain('Unknown command');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('evals-tool-versions flags gauntlet when its config probe fails', () => {
+  const root = mkdtempSync(join(tmpdir(), 'evals-tool-versions-'));
+  const bin = join(root, 'bin');
+  mkdirSync(bin);
+
+  try {
+    writeFakeTool(bin, 'harness-versions', 'claude: claude 2.0.0');
+    // A broken gauntlet: present on PATH but `config --json` exits nonzero.
+    const gauntlet = join(bin, 'gauntlet');
+    writeFileSync(gauntlet, ['#!/bin/sh', 'exit 1', ''].join('\n'));
+    chmodSync(gauntlet, 0o755);
+
+    const proc = spawnSync('/bin/bash', [TOOL_VERSIONS], {
+      env: { PATH: bin },
+      encoding: 'utf8',
+    });
+
+    expect(proc.status).toBe(0);
+    expect(proc.stderr).toBe('');
+    expect(proc.stdout).toContain('gauntlet: present (config check failed)');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('evals-tool-versions reports a clear diagnostic when the base image harness-versions is absent', () => {
+  const root = mkdtempSync(join(tmpdir(), 'evals-tool-versions-'));
+  const bin = join(root, 'bin');
+  mkdirSync(bin);
+
+  try {
+    // No harness-versions on PATH — the eval image is expected to inherit it
+    // from the base image, so its absence is a meaningful diagnostic.
+    const proc = spawnSync('/bin/bash', [TOOL_VERSIONS], {
+      env: { PATH: bin },
+      encoding: 'utf8',
+    });
+
+    expect(proc.status).toBe(0);
+    expect(proc.stderr).toBe('');
+    expect(proc.stdout).toContain(
+      'harness-versions: missing (base image not detected)',
+    );
+    // Evals-specific tools are still reported.
+    expect(proc.stdout).toContain('quorum: missing');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/container-shims.test.ts
+++ b/test/container-shims.test.ts
@@ -161,7 +161,9 @@ test('evals-tool-versions probes gauntlet via config since it has no --version f
     expect(proc.stderr).toBe('');
     // Reported as present without dumping gauntlet's usage text.
     expect(proc.stdout).toContain('gauntlet: present');
-    expect(proc.stdout).not.toContain('gauntlet: present (config check failed)');
+    expect(proc.stdout).not.toContain(
+      'gauntlet: present (config check failed)',
+    );
     expect(proc.stdout).not.toContain('Unknown command');
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/test/container-shims.test.ts
+++ b/test/container-shims.test.ts
@@ -86,14 +86,16 @@ test('container/bin/quorum tightens umask for live run artifacts', () => {
   expect(execIndex).toBeGreaterThan(umaskIndex);
 });
 
-test('evals-tool-versions reports available tools without failing on missing optional agents', () => {
+test('evals-tool-versions delegates the base inventory to harness-versions and reports evals tools', () => {
   const root = mkdtempSync(join(tmpdir(), 'evals-tool-versions-'));
   const bin = join(root, 'bin');
   mkdirSync(bin);
 
   try {
-    writeFakeTool(bin, 'bun', 'bun 1.3.13');
-    writeFakeTool(bin, 'claude', 'claude 2.0.0');
+    // The base image ships harness-versions; the shared harness/toolchain
+    // inventory is its responsibility, not this script's.
+    writeFakeTool(bin, 'harness-versions', 'claude: claude 2.0.0');
+    writeFakeTool(bin, 'quorum', 'quorum 1.0.0');
 
     const proc = spawnSync('/bin/bash', [TOOL_VERSIONS], {
       env: { PATH: bin },
@@ -102,22 +104,25 @@ test('evals-tool-versions reports available tools without failing on missing opt
 
     expect(proc.status).toBe(0);
     expect(proc.stderr).toBe('');
-    expect(proc.stdout).toContain('bun: bun 1.3.13');
+    // Delegated base inventory passes straight through.
     expect(proc.stdout).toContain('claude: claude 2.0.0');
-    expect(proc.stdout).toContain('codex: missing');
-    expect(proc.stdout).toContain('kimi: missing');
+    // Evals-specific tools are reported by this script.
+    expect(proc.stdout).toContain('quorum: quorum 1.0.0');
+    expect(proc.stdout).toContain('serf: missing');
+    expect(proc.stdout).toContain('gauntlet: missing');
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
 });
 
-test('evals-tool-versions reports the real exit status for failing version checks', () => {
+test('evals-tool-versions reports the real exit status for failing evals-tool version checks', () => {
   const root = mkdtempSync(join(tmpdir(), 'evals-tool-versions-'));
   const bin = join(root, 'bin');
   mkdirSync(bin);
 
   try {
-    writeFailingVersionTool(bin, 'claude', 'claude version probe failed', 42);
+    writeFakeTool(bin, 'harness-versions', 'claude: claude 2.0.0');
+    writeFailingVersionTool(bin, 'serf', 'serf version probe failed', 42);
 
     const proc = spawnSync('/bin/bash', [TOOL_VERSIONS], {
       env: { PATH: bin },
@@ -127,10 +132,10 @@ test('evals-tool-versions reports the real exit status for failing version check
     expect(proc.status).toBe(0);
     expect(proc.stderr).toBe('');
     expect(proc.stdout).toContain(
-      'claude: present (version check failed with exit 42): claude version probe failed',
+      'serf: present (version check failed with exit 42): serf version probe failed',
     );
     expect(proc.stdout).not.toContain(
-      'claude: present (version check failed with exit 0)',
+      'serf: present (version check failed with exit 0)',
     );
   } finally {
     rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## What problem are you trying to solve?

The eval image's harness-CLI install layer — 23 coding-agent CLIs (Claude Code,
Codex, Gemini CLI, …) plus the base toolchains they need (Node, bun, uv, Rust,
mise, Python, Go, Ruby), with all their version pins — was duplicated between
this repo's `container/Dockerfile` and
[`prime-radiant-inc/everyharness-container`](https://github.com/prime-radiant-inc/everyharness-container),
which was extracted verbatim from this repo's `container/` directory on
2026-08-11. Two copies means every CLI bump (and every `harness-versions`
change) has to be made and re-tested in both places, and they will drift. The
`everyharness-container` README and this repo's own README already record this
migration as planned work.

## What does this PR change?

`container/Dockerfile` now builds `FROM
ghcr.io/prime-radiant-inc/everyharness-container` (digest-pinned) and keeps only
the evals-specific layers on top: serf, gauntlet, the `quorum` /
`evals-tool-versions` shims, and the `/workspace/evals` workspace. The redundant
harness-CLI install steps and their pins are deleted — the base image owns them.
`bin/evals-tool-versions` now delegates the shared harness/toolchain inventory to
the base image's `harness-versions` and reports only the evals-specific tools
(`quorum`, `serf`, `gauntlet`) instead of re-listing everything.

### What moved to the base image vs what stayed

- **Moved to the base image** (deleted here): the Ubuntu base, the apt toolchain
  block, Node 22, bun, uv, Rust, mise; the `npm install -g` block for all 15
  npm-distributed CLIs; cursor-agent, mini-swe-agent, trae-agent, SWE-agent,
  goose (incl. the `TARGETARCH` plumbing and `GOOSE_VERSION`), hermes (incl.
  `HERMES_COMMIT`), mimo, agy; and all their env vars (`BUN_INSTALL`,
  `CARGO_HOME`, `UV_TOOL_*`, `AGY_OAUTH_HOME`, `KIMI_OAUTH_HOME`, `PATH`, …),
  which the child image inherits.
- **Stayed here** (evals-specific): the serf clone/`go install` pinned by
  `ARG SERF_REF` (with its source-rev recording), the gauntlet build-context
  block and wrapper, the `quorum` and `evals-tool-versions` shims, and
  `WORKDIR /workspace/evals`.

### Drift found and replicated

None. Diffing this repo's harness install layer (lines 1–164 of the old
Dockerfile) against the corresponding install layer of `everyharness-container`'s
Dockerfile shows the only difference is the evals-only `ARG SERF_REF` line (the
base's own trailing `COPY harness-versions`/`WORKDIR`/`CMD` tail is base-specific
and not part of the comparison). The harness-CLI installs,
version pins, env vars, and `TARGETARCH` plumbing are byte-for-byte identical, so
nothing had to be replicated as an override layer on top of the base.

### Base-image pin

Pinned by digest per `everyharness-container`'s version-pin policy (`latest`
moves; pin by sha tag or digest):
`sha256:de1026a0580ce2956ab4b181407110f2cbc37660c7bf0f3d5a0a1d3cc6051d7f` — the
first published build (commit 8034359, 2026-08-11; also pullable as the
full-commit-SHA tag `…:80343595da91f739fb1042a817a49519ab301d6a` — the registry
has no short-SHA tags). The `FROM` line carries a comment naming that commit/tag
so bumps are mechanical;
`container/README.md` documents the bump procedure.

### Architecture regression (amd64-only)

**The eval image is now `linux/amd64`-only.** The old `FROM ubuntu:26.04` was
multi-arch and built natively on arm64; the pinned base digest publishes only
`linux/amd64` (verified with `docker buildx imagetools inspect` — the index
carries a single `linux/amd64` manifest plus the `unknown/unknown` attestation
manifest, no arm64). So on Apple Silicon the eval image now builds and runs under
emulation instead of natively. This is consistent with everyharness-container's
own documented amd64-only design; a native arm64 eval image would require the
base image to publish an arm64 variant first (its `TARGETARCH` plumbing already
supports this). Documented in `container/README.md`'s new Architecture section.

### `Dockerfile.claude-slim` version-report limitation

`Dockerfile.claude-slim` copies the rewritten `evals-tool-versions` but builds on
bare `ubuntu:26.04`, which has no `harness-versions`. So its report now degrades
to `harness-versions: missing (base image not detected)` plus only the evals
tools (`quorum`/`serf`/`gauntlet`) — it no longer prints the claude/node/bun/…
inventory the old inline script did. I chose to **document** this rather than
restore an inventory: slim is a throwaway, resource-constrained variant, and
re-adding even a small inventory there would reintroduce the exact duplication
this PR removes. Anyone needing a full harness inventory uses the main image.
Documented in `container/README.md`.

### Out of scope

- `container/Dockerfile.claude-slim` is deliberately **not** rebased. It exists
  precisely because one host cannot afford the full image's ~15 GB footprint;
  building it on the full base would defeat its purpose. Left as a standalone
  minimal build and documented as such in `container/README.md` (see the
  version-report limitation above).
- Historical experiment logs and design specs under `docs/experiments/` and
  `docs/superpowers/` that mention `container/Dockerfile` are dated records and
  were left untouched.

## Relationship to superpowers

This is eval-lab infrastructure only — no skill behavior, harness loading, or
eval methodology changes. It reduces maintenance so the container the quorum
suite runs in stays in lockstep with the shared image, and removes a whole class
of "the two copies drifted" failures.

## Security and eval-lab checklist
- [x] This PR does not commit API keys, `.env` files, session logs, `results/`, or other run artifacts
- [x] This PR does not cause CI to run live agent evals, call model APIs, or require `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`
- [x] If this touches dangerous-mode backend flags, shell execution, environment inheritance, or log collection, the risk is explained below
- [x] If this adds or changes a scenario, setup helper, or assertion command, I considered how untrusted input could affect shell execution

Risk notes: The base image is pinned by immutable digest (not a moving tag), so
what the eval image builds on cannot change out from under us without a
deliberate pin bump. No secrets are baked into any image. The base image is
anonymously pullable from ghcr.io.

## CI / runner-disk notes

No workflow in this repo builds the container image — `.github/workflows/test.yml`
only runs `bun run check` and `bun run quorum check`, both of which read
`container/Dockerfile`/scripts as files and never invoke Docker. So this change
adds no CI build cost and no GitHub-runner disk pressure here; CI stays green
without pulling the ~15 GB base.

For reference, if an image-build job is ever added: the base is ~15 GB
uncompressed and a stock `ubuntu-latest` runner has limited free disk.
`everyharness-container`'s own `build.yml` handles this with
`docker/setup-buildx-action` + `docker/build-push-action` and `type=gha`
build-cache, which is the approach to copy.

## Existing work
- [x] I searched for related open and closed PRs/issues/tickets
- Related work: No prior PR attempts this migration. The closest merged
  container work is #31 (agent-CLI refresh), #29 (container build fixes), and #24
  (add serf harness) — all bumps/additions to the (then-inline) harness layer,
  none about moving to a shared base image.

## Tests

Run against the reworked image built locally (`scripts/evals-container build`,
base pulled by the pinned digest):

- `bun run check` — the container test files pass:
  `bun test test/container-dockerfile.test.ts test/container-shims.test.ts` →
  **13 pass, 0 fail** (includes new coverage for the gauntlet `config` presence
  probe, the gauntlet `config`-check-failed path, and the
  `harness-versions: missing (base image not detected)` fallback).
  `shellcheck container/bin/evals-tool-versions` → clean.
  (Three failures elsewhere in the full `check` — `setup-helpers-git`,
  `runner-guards`, and a `runPhase` scenario-dir test — reproduce on the
  pristine branch before my changes; they are environmental on this host: git
  date-format and no `claude`/scenario deps on PATH. They are unrelated to this
  PR.)
- `docker run --rm superpowers-evals:local evals-tool-versions` — sample harness
  CLIs resolve to real versions: `claude: 2.1.209 (Claude Code)`,
  `codex: codex-cli 0.146.0`, `gemini: 0.50.0`; base toolchains resolve
  (node v22.23.2, bun 1.3.14, go go1.26.0, rustc 1.97.1, uv 0.12.3, …); and the
  evals tools resolve: `serf: serf dev (source 0a459b63…)`, `gauntlet: present`,
  `quorum: present` (its `--version` probe fails only because no repo is mounted
  in a bare `docker run` — expected; see below).
- `docker run --rm -v "$PWD:/workspace/evals" superpowers-evals:local quorum check`
  runs the quorum shim end-to-end in the new image. It reports one failing
  scenario (`serf-builder-fractals`), which fails identically with host-side
  `bun run quorum check` — a pre-existing scenario-validation issue, not caused
  by the container change.

## Human review
- [ ] A maintainer has reviewed the complete proposed diff before merge

## Parent submodule follow-up
- [x] If this PR merges to `main`, a parent `superpowers` submodule bump PR into `dev` will be opened

---

**Authoring disclosure:** This PR was authored by a Claude Opus subagent
(`claude-opus-4-8`) dispatched from a Claude Code session (harness: Claude Code
CLI) run by Jesse Vincent, who requested this PR explicitly. The build and all
verification commands above were executed for real against a locally built image
on Jesse's machine.

