### PR TITLE
Portability fixes surfaced by the drew-devbox bring-up (git 2.43 / umask 002)

### DIFF
--- a/src/scenario-manifest.ts
+++ b/src/scenario-manifest.ts
@@ -244,7 +244,10 @@ function digestAt(rootDir: string, relativePath: string): string {
 }
 
 function gitMode(stat: Stats): string {
-  return `100${(stat.mode & 0o7777).toString(8).padStart(3, '0')}`;
+  // git records only 100644/100755 for regular files; permission bits beyond
+  // the exec bit follow the host umask at checkout (0664 under Ubuntu's
+  // default 002) and must not count as drift.
+  return (stat.mode & 0o111) !== 0 ? '100755' : '100644';
 }
 
 function comparePaths(left: string, right: string): number {

--- a/test/scenario-manifest.test.ts
+++ b/test/scenario-manifest.test.ts
@@ -144,6 +144,27 @@ test('reports content and mode drift from the declared baseline', () => {
   }
 });
 
+test('accepts umask-driven group-write bits as git-normalized modes', () => {
+  const scenarioDir = tempDir();
+  const files: FixtureFile[] = [
+    { path: PLAN, content: 'PLAN\n' },
+    { path: SPEC, content: 'SPEC\n' },
+    { path: 'tools/run.sh', content: '#!/bin/sh\n', mode: '100755' },
+  ];
+  for (const file of files) writeFixture(scenarioDir, file);
+  writeManifest(scenarioDir, files);
+  try {
+    // git records only 100644/100755; checkout permission bits follow the
+    // host umask (0664/0775 under Ubuntu's default 002), so verification
+    // must compare git-normalized modes, not raw bits.
+    chmodSync(join(scenarioDir, 'fixtures', PLAN), 0o664);
+    chmodSync(join(scenarioDir, 'fixtures', 'tools/run.sh'), 0o775);
+    expect(validateBaselineManifest(scenarioDir)).toEqual([]);
+  } finally {
+    rmSync(scenarioDir, { recursive: true, force: true });
+  }
+});
+
 test('rejects unsafe, duplicate, and unsorted manifest file paths', () => {
   const { scenarioDir } = validScenario();
   try {

--- a/test/setup-helpers-git.test.ts
+++ b/test/setup-helpers-git.test.ts
@@ -70,12 +70,15 @@ describe('runGit extraEnv', () => {
       // made in the same wall-clock second collide on hash even WITHOUT
       // injection, so a hash-equality assertion is vacuously green. The
       // committed date is wall-clock pre-fix, the injected value post-fix.
+      // --date=unix because iso-strict renders UTC as +00:00 on git <2.45
+      // and Z on >=2.45; the epoch rendering is version-stable.
+      // 1783684800 = 2026-07-10T12:00:00Z.
       expect(
-        runGit(['log', '-1', '--format=%cd', '--date=iso-strict'], dir).trim(),
-      ).toBe('2026-07-10T12:00:00Z');
+        runGit(['log', '-1', '--format=%cd', '--date=unix'], dir).trim(),
+      ).toBe('1783684800');
       expect(
-        runGit(['log', '-1', '--format=%ad', '--date=iso-strict'], dir).trim(),
-      ).toBe('2026-07-10T12:00:00Z');
+        runGit(['log', '-1', '--format=%ad', '--date=unix'], dir).trim(),
+      ).toBe('1783684800');
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
Two environment-portability bugs found while standing up superpowers-evals on drew-devbox (stock Ubuntu 24.04: git 2.43, umask 002). Both false-fail identical trees on hosts that differ only in git version or umask.

1. **test: assert injected commit dates via `--date=unix`** — `iso-strict` renders UTC as `+00:00` on git <2.45 and `Z` on >=2.45; the literal `Z` assertion false-fails on git 2.43. The unix rendering is version-stable and still proves the injected date reached the commit.

2. **fix: git-normalize modes in baseline-manifest verification** — `gitMode()` compared raw permission bits, so umask-002 checkouts (0664) tripped `quorum check` and the pre-launch `baseline-manifest` verb with `mode mismatch: expected 100644, got 100664` on git-identical fixtures. Verification now normalizes the way git records regular files (exec bit → 100755, else 100644), which is all the manifest schema admits. TDD: new red test for 0664/0775 acceptance; existing 644-vs-755 drift test still passes.

Verified: `bun run check` exit 0 on macOS (git 2.50.1, umask 022) and drew-devbox (git 2.43.0, umask 002); `bun run quorum check` exit 0 on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)