### PR TITLE
docs: default claude credential is opus_bedrock, not opus

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,10 @@ bun run quorum run scenarios/<name> --coding-agent claude --credential sonnet
 bun run quorum run scenarios/<name> --coding-agent claude --credential haiku
 ```
 
-The `claude` agent's default credential is `opus`.
+The `claude` agent's default credential is `opus_bedrock`, which authenticates
+with `AWS_BEARER_TOKEN_BEDROCK`. Pass `--credential opus` for the direct
+Anthropic API path (`ANTHROPIC_API_KEY`), or `--credential opus5_sub` to drive
+it from a Claude subscription with `CLAUDE_CODE_OAUTH_TOKEN`.
 
 ## Shared Eval Appliance
 


### PR DESCRIPTION
## What problem are you trying to solve?

`README.md` states the `claude` agent's default credential is `opus`. It has
been `opus_bedrock` since a5f4e76 (`feat(claude): default to opus_bedrock
(Mantle); opus is the direct opt-out`, 2026-07-08). The README line was last
touched in 418194f (2026-06-22), so it was correct when written and has been
stale since the default moved.

The failure this produces is confusing rather than obvious. The README's
"Quick Start" tells a subscription user to set `CLAUDE_CODE_OAUTH_TOKEN` and
run a scenario. Doing exactly that, with no `--credential`, fails at setup
with:

```
final     indeterminate
reason    quorum error (setup): bedrock bearer env var AWS_BEARER_TOKEN_BEDROCK is unset/empty
```

Nothing in that message points at credential selection, and the README two
paragraphs earlier has just said the default is `opus` — which would have
worked with an `ANTHROPIC_API_KEY`. I lost a run to it before reading
`coding-agents/claude.yaml:13`.

The same stale phrasing appears in the body of #27 ("The default claude
credential is unchanged (still `opus`)"), which predates a5f4e76 — so this is
a doc lagging a config change, not an error by either author.

## What does this PR change?

One paragraph in `README.md`: names `opus_bedrock` as the default and the env
var it needs, and points at the two opt-outs (`opus` for the direct API path,
`opus5_sub` for subscription auth). No behavior change.

## Relationship to superpowers

Contributors running `superpowers` skill evals locally hit this on their first
command. The fix removes a setup failure that reads as a broken harness rather
than a missing flag, on the path the README itself recommends.

## Security and eval-lab checklist
- [x] This PR does not commit API keys, `.env` files, session logs, `results/`, or other run artifacts
- [x] This PR does not cause CI to run live agent evals, call model APIs, or require `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`
- [x] If this touches dangerous-mode backend flags, shell execution, environment inheritance, or log collection, the risk is explained below
- [x] If this adds or changes a scenario, setup helper, or assertion command, I considered how untrusted input could affect shell execution

Risk notes: N/A — documentation only, no executable paths touched.

## Existing work
- [x] I searched for related open and closed PRs/issues/tickets
- Related work: #27 (merged) added the `sonnet5` credential and repeats the
  same "default is `opus`" phrasing in its body; it predates a5f4e76, which is
  the commit that actually moved the default. No open issue tracks this.

## Tests

```
bun run check          # 2096 pass, 1 skip, 0 fail (161 files); tsc --noEmit clean
bun run quorum check   # all scenarios ok, credentials ok
```

Verified the claim against source rather than by running: `coding-agents/claude.yaml:13`
reads `default_credential: opus_bedrock`. Separately confirmed empirically —
omitting `--credential` produced the Bedrock error quoted above, and
`--credential opus5_sub` then ran to completion.

No live eval is needed to validate a documentation string, and none is added
to CI.

## Human review
- [ ] A maintainer has reviewed the complete proposed diff before merge

## Parent submodule follow-up
- [x] If this PR merges to `main`, a parent `superpowers` submodule bump PR into `dev` will be opened
