### PR TITLE
feat(credential): subscription-auth sonnet5_sub and haiku_sub

### DIFF
--- a/credentials.yaml
+++ b/credentials.yaml
@@ -60,6 +60,22 @@ opus5_sub:
   auth: oauth
   harnesses: [claude]
 
+sonnet5_sub:
+  # Subscription-auth counterpart to sonnet5, same oauth route as opus5_sub.
+  # Lets a subscription-only contributor run the cheaper-reviewer arms; without
+  # it every non-opus Claude credential needs ANTHROPIC_API_KEY.
+  model: claude-sonnet-5
+  api: anthropic
+  auth: oauth
+  harnesses: [claude]
+
+haiku_sub:
+  # Subscription-auth counterpart to haiku. Same rationale as sonnet5_sub.
+  model: claude-haiku-4-5-20251001
+  api: anthropic
+  auth: oauth
+  harnesses: [claude]
+
 sonnet:
   model: sonnet
   api: anthropic


### PR DESCRIPTION
## What problem are you trying to solve?

`opus5_sub` is the only credential in the `claude` harness that authenticates
with a subscription token. Every other Claude credential — `opus`, `opus5`,
`sonnet`, `sonnet5`, `sonnet46`, `haiku` — declares
`api_key_env: ANTHROPIC_API_KEY`, and the two Bedrock entries need
`AWS_BEARER_TOKEN_BEDROCK`.

The effect is that a contributor holding only a Claude subscription can run
exactly one model. The README recommends that path — "To drive it from a
logged-in Claude subscription instead, set `CLAUDE_CODE_OAUTH_TOKEN` (from
`claude setup-token`)" — and the credential axis it documents immediately
afterwards (`--credential sonnet`, `--credential haiku`) is unreachable from
it. Any comparison that varies model strength is therefore closed to
subscription-only contributors, including the cheaper arms the README suggests
for exactly that purpose.

I hit this measuring whether a review-prompt change helps weaker reviewer
models. The Opus arms ran; the Sonnet and Haiku arms could not, for want of
four lines of YAML.

## What does this PR change?

Adds `sonnet5_sub` and `haiku_sub` to `credentials.yaml`: subscription-auth
counterparts to the existing `sonnet5` and `haiku` entries, pinned to the same
model ids, differing only in `auth: oauth` instead of `api_key_env`. This is
the same relationship `opus5_sub` already has to `opus5`.

No existing entry is modified and no default changes.

- Pinned ids (`claude-sonnet-5`, `claude-haiku-4-5-20251001`) rather than
  floating aliases, matching the precedent set in #27 for longitudinal
  comparability.
- Naming follows `opus5_sub`, so the subscription variants sort next to their
  API-key twins and the suffix means one thing throughout the file.

## Relationship to superpowers

The `superpowers` review stack is tuned per model tier — `SKILL.md`'s Model
Selection section instructs controllers to run cheaper reviewers where the
diff allows, and the strict-cost work (L2, `2026-06-10-strict-cost-sdd-design.md`)
turns on measured differences between tiers. Validating any of that requires
running the cheaper tiers. Today only maintainers with API keys can. This
opens the same measurements to anyone with a subscription.

## Security and eval-lab checklist
- [x] This PR does not commit API keys, `.env` files, session logs, `results/`, or other run artifacts
- [x] This PR does not cause CI to run live agent evals, call model APIs, or require `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`
- [x] If this touches dangerous-mode backend flags, shell execution, environment inheritance, or log collection, the risk is explained below
- [x] If this adds or changes a scenario, setup helper, or assertion command, I considered how untrusted input could affect shell execution

Risk notes: The new entries reuse the existing oauth provisioning path that
`opus5_sub` already exercises — no new auth mechanism, no new env var, no
change to how tokens are seeded into the run-scoped `.claude-env`. They are
opt-in: nothing selects them unless `--credential` names them. No shell
execution or verifier input is touched.

## Existing work
- [x] I searched for related open and closed PRs/issues/tickets
- Related work: #27 (merged) added the pinned `sonnet5` credential and
  established the pinned-id convention this follows. No open issue or PR
  requests subscription variants.

## Tests

```
bun run check          # 2096 pass, 1 skip, 0 fail (161 files); tsc --noEmit clean
bun run quorum check   # all scenarios ok, credentials ok
```

Both entries were exercised live against a real subscription token, on the
`code-review-catches-planted-migration` scenario:

```
--credential sonnet5_sub   -> completed; economics reports "sonnet  524K  $0.33"
--credential haiku_sub     -> completed; economics reports "haiku"
```

The reported model line confirms the run used the pinned model rather than
falling back to the harness default.

## Human review
- [ ] A maintainer has reviewed the complete proposed diff before merge

## Parent submodule follow-up
- [x] If this PR merges to `main`, a parent `superpowers` submodule bump PR into `dev` will be opened
