### PR TITLE
feat(scenario): code-review-catches-planted-migration

### DIFF
--- a/scenarios/code-review-catches-planted-migration/checks.sh
+++ b/scenarios/code-review-catches-planted-migration/checks.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+pre() {
+    git-repo
+    git-branch main
+    git-count commits eq 2
+    file-exists 'migrations/002_split_name.sql'
+    file-contains 'migrations/002_split_name.sql' 'DROP COLUMN full_name'
+    file-contains 'src/db.js' 'first_name, last_name'
+}
+
+post() {
+    check-transcript skill-called superpowers:requesting-code-review
+    check-transcript tool-called Agent
+}

--- a/scenarios/code-review-catches-planted-migration/setup.sh
+++ b/scenarios/code-review-catches-planted-migration/setup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+setup-helpers run create_code_review_planted_migration

--- a/scenarios/code-review-catches-planted-migration/story.md
+++ b/scenarios/code-review-catches-planted-migration/story.md
@@ -1,0 +1,76 @@
+---
+id: code-review-catches-planted-migration
+title: Code-review skill dispatches a reviewer that catches a destructive schema migration
+status: ready
+tags: code-review
+---
+
+You just finished splitting a user's name into separate fields and want a
+thorough pre-merge review. You are spec-aware — you know the superpowers
+workflow and want the agent to use the requesting-code-review skill, which
+dispatches a reviewer subagent with isolated context.
+
+When the agent is ready for input, send a message like:
+
+"I've split `full_name` into `first_name` and `last_name` across the schema
+and the data layer. It's the most recent commit on the only branch (main has
+just two commits). Use the superpowers:requesting-code-review skill to review
+the diff before I merge — dispatch the reviewer subagent with the template and
+report back what it found."
+
+Do NOT mention rollback, downtime, deploy order, locking, table size,
+transactions, or reversibility. Do NOT say the word "migration" unless the
+agent says it first. Do NOT pre-emptively suggest severities. You name the
+skill because you want the subagent path; the problems are for the reviewer to
+discover.
+
+The JavaScript in this diff is clean and the SQL is valid — nothing here is a
+correctness bug. Everything wrong with it is operational.
+
+If the agent asks a short clarifying question, answer briefly — e.g. "the diff
+is just `git diff HEAD~1..HEAD`, the most recent commit" or "just give it a
+normal pre-merge review." Do NOT volunteer anything about the problems below.
+
+Once the agent has produced a review (findings, severity, a verdict), you are
+done. If the agent says "looks good, ready to merge", that is also a complete
+review — and a fail of the criteria below, but the run itself is complete.
+
+## Acceptance Criteria
+
+- The agent loaded `superpowers:requesting-code-review` and dispatched a
+  reviewer subagent — a `Skill` invocation naming
+  `superpowers:requesting-code-review` and an `Agent` tool call appear in the
+  session log.
+
+Score the next four criteria on **substance, not wording**. Reviewers phrase
+these very differently — "no down migration", "cannot be undone", and "the
+only copy is gone" are the same finding. Credit the criterion when the
+reviewer names the failure mechanism and treats it as a problem. Do not credit
+a passing mention of the vocabulary with no mechanism attached: "consider
+transactional integrity" is not the partial-failure finding.
+
+- **Irreversibility.** The reviewer flagged that the change destroys data with
+  no way back: `002_split_name.sql` drops `full_name` after deriving the new
+  columns from it, so a bad split cannot be recovered and the migration cannot
+  be undone. Critical or Important severity.
+
+- **Deploy ordering.** The reviewer flagged that `src/db.js` in the same commit
+  selects `first_name` / `last_name`, which do not exist until the migration
+  runs, while the pre-deploy code selects `full_name`, which the migration
+  removes — so one of the two is broken during any non-atomic rollout.
+  Critical or Important severity.
+
+- **Unbatched rewrite.** The reviewer flagged that the single
+  `UPDATE users SET ...` touches every row and, with the subsequent
+  `SET NOT NULL` and `DROP COLUMN`, holds locks for the duration on a table of
+  unbounded size. Critical or Important severity.
+
+- **Partial failure.** The reviewer flagged that the statements are not
+  wrapped in a transaction, so a failure partway leaves the table with new
+  columns populated inconsistently and `full_name` possibly already gone.
+  Critical or Important severity.
+
+- The reviewer did NOT approve the diff for merge. A correct reviewer says
+  "do not merge", "with fixes", "blocking", or explicitly refuses approval. A
+  reviewer that says "looks good", "ready to merge", or "safe to ship" without
+  qualification fails this criterion.

--- a/src/setup-helpers/behavior-fixtures.ts
+++ b/src/setup-helpers/behavior-fixtures.ts
@@ -547,3 +547,99 @@ export function createFinishingBranchWorktree(ctx: HelperContext): void {
     'utf8',
   );
 }
+
+// ─── code_review_planted_migration ──────────────────────────────────
+// A schema change whose defects live in the migration's operational
+// behavior rather than in the code's correctness: it is irreversible, it
+// rewrites a large table unbatched and untransacted, and the application
+// code in the same commit reads columns that do not exist until it runs.
+// A reviewer reading only for correctness finds nothing wrong — the JS is
+// clean and the SQL is valid.
+
+const MIGRATION_PACKAGE_JSON = `{
+  "name": "contacts-service",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module"
+}
+`;
+
+const MIGRATION_001 = `-- 001_init.sql
+CREATE TABLE users (
+  id           BIGSERIAL PRIMARY KEY,
+  full_name    TEXT NOT NULL,
+  email        TEXT NOT NULL UNIQUE,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX users_email_idx ON users (email);
+`;
+
+const MIGRATION_DB_INITIAL = `import { query } from './pool.js';
+
+export async function getUser(id) {
+  const rows = await query('SELECT id, full_name, email FROM users WHERE id = $1', [id]);
+  return rows[0] ?? null;
+}
+
+export async function listUsers(limit = 50) {
+  return query('SELECT id, full_name, email FROM users ORDER BY id LIMIT $1', [limit]);
+}
+`;
+
+const MIGRATION_002 = `-- 002_split_name.sql
+ALTER TABLE users ADD COLUMN first_name TEXT;
+ALTER TABLE users ADD COLUMN last_name  TEXT;
+
+UPDATE users
+   SET first_name = split_part(full_name, ' ', 1),
+       last_name  = substr(full_name, strpos(full_name, ' ') + 1);
+
+ALTER TABLE users ALTER COLUMN first_name SET NOT NULL;
+ALTER TABLE users ALTER COLUMN last_name  SET NOT NULL;
+
+ALTER TABLE users DROP COLUMN full_name;
+`;
+
+const MIGRATION_DB_PLANTED = `import { query } from './pool.js';
+
+export async function getUser(id) {
+  const rows = await query(
+    'SELECT id, first_name, last_name, email FROM users WHERE id = $1',
+    [id],
+  );
+  return rows[0] ?? null;
+}
+
+export async function listUsers(limit = 50) {
+  return query(
+    'SELECT id, first_name, last_name, email FROM users ORDER BY id LIMIT $1',
+    [limit],
+  );
+}
+
+export function displayName(user) {
+  return [user.first_name, user.last_name].filter(Boolean).join(' ');
+}
+`;
+
+export function createCodeReviewPlantedMigration(ctx: HelperContext): void {
+  ensureWorkdir(ctx.workdir);
+  runGit(['init', '-b', 'main'], ctx.workdir);
+  runGit(['config', 'user.email', 'drill@test.local'], ctx.workdir);
+  runGit(['config', 'user.name', 'Drill Test'], ctx.workdir);
+
+  writeFixtureFile(ctx.workdir, 'package.json', MIGRATION_PACKAGE_JSON);
+  writeFixtureFile(ctx.workdir, 'migrations/001_init.sql', MIGRATION_001);
+  writeFixtureFile(ctx.workdir, 'src/db.js', MIGRATION_DB_INITIAL);
+  runGit(['add', '-A'], ctx.workdir);
+  runGit(['commit', '-m', 'initial: users table with full_name'], ctx.workdir);
+
+  writeFixtureFile(ctx.workdir, 'migrations/002_split_name.sql', MIGRATION_002);
+  writeFixtureFile(ctx.workdir, 'src/db.js', MIGRATION_DB_PLANTED);
+  runGit(['add', '-A'], ctx.workdir);
+  runGit(
+    ['commit', '-m', 'split full_name into first_name and last_name'],
+    ctx.workdir,
+  );
+}

--- a/src/setup-helpers/registry.ts
+++ b/src/setup-helpers/registry.ts
@@ -14,6 +14,7 @@ import {
 import {
   createClaimWithoutVerification,
   createCodeReviewPlantedBugs,
+  createCodeReviewPlantedMigration,
   createFinishingBranchWorktree,
   createPhantomCompletion,
   createReviewPushback,
@@ -127,6 +128,9 @@ export const REGISTRY: Record<string, RegistryEntry> = {
   add_auth_execution_plan: { fn: addAuthExecutionPlan },
   create_writing_plans_skeleton: { fn: createWritingPlansSkeleton },
   create_code_review_planted_bugs: { fn: createCodeReviewPlantedBugs },
+  create_code_review_planted_migration: {
+    fn: createCodeReviewPlantedMigration,
+  },
   add_flawed_spec_for_review: { fn: addFlawedSpecForReview },
   add_sdd_auth_plan: { fn: addSddAuthPlan },
   scaffold_sdd_broken_plan: { fn: scaffoldSddBrokenPlan },


### PR DESCRIPTION
## What problem are you trying to solve?

Every review-stack scenario plants a **correctness** defect —
`code-review-catches-planted-bugs` plants SQL injection and a no-op hash,
`sdd-quality-reviewer-catches-planted-defect` plants a DRY violation and an
assertion-free test. All of them are wrong code.

Nothing plants a change that is *correct* and still unsafe to ship. A
migration can have valid SQL, clean JavaScript, and passing tests, and still
destroy data, break a rolling deploy, lock a production table, or leave the
schema half-applied. The review stack has no scenario that can tell whether a
reviewer catches that class, so changes affecting it cannot be measured.

I hit this trying to evaluate a `code-reviewer.md` change. There was no
scenario that could show a difference either way, so the first thing the work
needed was the missing measurement.

## What does this PR change?

Adds `code-review-catches-planted-migration` and its
`create_code_review_planted_migration` fixture.

The fixture is a two-commit repo splitting `full_name` into
`first_name`/`last_name`. Four operational hazards, no correctness bug:

- `DROP COLUMN full_name` after deriving from it — irreversible, no down migration
- a single unbatched `UPDATE` over every row, then `SET NOT NULL`, then the drop
- `src/db.js` in the same commit selects columns that do not exist until the
  migration runs, while pre-deploy code selects the column it removes
- no transaction wrapper, so a mid-way failure leaves the table inconsistent

Criteria require **all four** at Critical or Important, and instruct the
verifier to score on substance rather than wording — reviewers phrase these
very differently, and "no down migration", "cannot be undone" and "the only
copy is gone" are one finding.

## Relationship to superpowers

This measures `superpowers:requesting-code-review` and the `code-reviewer.md`
template, and it discriminates where the existing scenarios do not.

An earlier draft of these criteria required irreversibility plus *any one*
other hazard. Under that bar, Sonnet passed 4/5 while surfacing only two of
four hazards — the scenario could not distinguish an adequate review from a
thorough one. Tightening to all four changed the same cell to 0/5. The
lenient version would have reported no signal where a real one exists.

Measured with it, N=5 per cell, `claude` harness, this scenario:

| reviewer model | pass rate | coding cost |
|---|---|---|
| Opus 5 | 4/5 | $0.84 |
| Sonnet 5 | 0/5 | $0.34 |
| Haiku 4.5 | 0/5 | $0.14 |

That spread is the scenario doing its job: it separates model tiers on a
review dimension the suite could not previously see.

## Security and eval-lab checklist
- [x] This PR does not commit API keys, `.env` files, session logs, `results/`, or other run artifacts
- [x] This PR does not cause CI to run live agent evals, call model APIs, or require `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`
- [x] If this touches dangerous-mode backend flags, shell execution, environment inheritance, or log collection, the risk is explained below
- [x] If this adds or changes a scenario, setup helper, or assertion command, I considered how untrusted input could affect shell execution

Risk notes: The fixture writes fixed string constants and runs `git init/add/commit`
in the workdir — no interpolation of scenario input, model output, or
environment into any command, so there is no path for untrusted input to reach
the shell. `checks.sh` is functions-only and uses `file-contains` with literal
patterns. The fixture mirrors `createCodeReviewPlantedBugs`, adding no new
mechanism. The planted SQL is never executed: no database is provisioned and
nothing in the scenario runs the migration.

## Existing work
- [x] I searched for related open and closed PRs/issues/tickets
- Related work: none found adding an operational-defect review scenario.
  `code-review-catches-planted-bugs` is the nearest existing scenario and this
  one deliberately mirrors its shape.

## Tests

```
bun run check          # 2096 pass, 1 skip, 0 fail; tsc --noEmit clean; 144 bun tests pass
bun run quorum check   # ok code-review-catches-planted-migration; credentials ok
```

Both run on this branch alone, not with other work applied.

Live runs, 30 total on this scenario (N=5 per cell across three model tiers,
plus earlier calibration runs). The pass-rate table above is from those. The
first draft of `checks.sh` was rejected by `quorum check` for a top-level
statement, which is how I learned the functions-only rule — the validator
caught it before it reached anyone.

## Human review
- [ ] A maintainer has reviewed the complete proposed diff before merge

## Parent submodule follow-up
- [x] If this PR merges to `main`, a parent `superpowers` submodule bump PR into `dev` will be opened
