### PR TITLE
Key the Pi placeholder-zero pricing policy on the provisioning route

### DIFF
--- a/src/agents/pi.ts
+++ b/src/agents/pi.ts
@@ -13,6 +13,10 @@ import type { Credential } from '../contracts/credential.ts';
 import type { ApiKeyResolution } from '../credentials/resolve.ts';
 import { resolveApiKey } from '../credentials/resolve.ts';
 import { envSnapshot, getEnv } from '../env.ts';
+import {
+  type AtifNormalizationContext,
+  PI_ZERO_COST_NORMALIZATION_POLICY,
+} from '../normalize/context.ts';
 import type { CommandRunner } from './command-runner.ts';
 import { type CodingAgent, ProvisionError, type RunHome } from './index.ts';
 import { writePrivateFileNoFollow } from './private-file.ts';
@@ -26,6 +30,31 @@ const CREDENTIAL_API_TO_PI_API: Readonly<Record<string, string>> = {
   'openai-chat': 'openai-completions',
   'openai-responses': 'openai-responses',
 };
+
+// The fixed provider name api-key provisioning registers in models.json (not
+// the credential name) so pi's internal routing always points at the same slot.
+const PI_CUSTOM_PROVIDER = 'quorum';
+
+/** The normalization context capture needs for an api-key Pi credential.
+ * Pi has no native rates for a model served through the custom provider, so
+ * it records a placeholder zero cost on every message; naming the exact
+ * provider/model pair lets the normalizer omit that zero and let obol price
+ * the token buckets. An OAuth login runs on pi's own providers and gets no
+ * policy. */
+export function piCustomProviderContext(
+  credential: Credential | undefined,
+): AtifNormalizationContext | undefined {
+  if (credential?.auth !== 'api-key') return undefined;
+  return {
+    pi: {
+      placeholderZeroCost: {
+        provider: PI_CUSTOM_PROVIDER,
+        model: credential.model,
+        policy: PI_ZERO_COST_NORMALIZATION_POLICY,
+      },
+    },
+  };
+}
 
 // Characters shlex.quote treats as safe (its unsafe-char regex is
 // [^\w@%+=:,./-]). A value built only from these is emitted bare; anything else
@@ -257,7 +286,7 @@ function writePiModelsJson(
 
   const body = {
     providers: {
-      quorum: {
+      [PI_CUSTOM_PROVIDER]: {
         baseUrl,
         api: piApi,
         apiKey,

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -50,6 +50,7 @@ import {
   OpenCodeCaptureError,
   snapshotOpencodeSessions,
 } from '../agents/opencode-capture.ts';
+import { piCustomProviderContext } from '../agents/pi.ts';
 import { writePrivateFileNoFollow } from '../agents/private-file.ts';
 import { SERF_API_ENV_FILE_NAME } from '../agents/serf.ts';
 import {
@@ -110,10 +111,6 @@ import {
 import { isSerfOpenRouterCampaignCredentialV1 } from '../credentials/serf-openrouter-profile.ts';
 import { buildRunEconomics } from '../economics.ts';
 import { envSnapshot, getEnv } from '../env.ts';
-import {
-  type AtifNormalizationContext,
-  PI_ZERO_COST_NORMALIZATION_POLICY,
-} from '../normalize/context.ts';
 import { kimiLogsHaveSuperpowersSessionStart } from '../normalize/kimi.ts';
 import {
   captureOpenRouterGenerations,
@@ -1900,22 +1897,8 @@ async function runInnerBody(
   // strips arbitrary env from new sessions, so the QA agent reads concrete
   // paths from the substituted files rather than from env inheritance.
   const family = cfg.runtime_family ?? cfg.name;
-  const normalizationContext: AtifNormalizationContext | undefined =
-    family === 'pi' &&
-    resolvedCredential?.auth === 'api-key' &&
-    resolvedCredential.api === 'openai-responses' &&
-    resolvedCredential.base_url !== undefined &&
-    resolvedCredential.model === 'gpt-5.6-sol'
-      ? {
-          pi: {
-            placeholderZeroCost: {
-              provider: 'quorum',
-              model: resolvedCredential.model,
-              policy: PI_ZERO_COST_NORMALIZATION_POLICY,
-            },
-          },
-        }
-      : undefined;
+  const normalizationContext =
+    family === 'pi' ? piCustomProviderContext(resolvedCredential) : undefined;
   const isRemote = os !== 'linux';
   const launchAgentPath = join(
     runDir,

--- a/test/agent-pi.test.ts
+++ b/test/agent-pi.test.ts
@@ -12,7 +12,7 @@ import {
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { ProvisionError } from '../src/agents/index.ts';
-import { PiAgent } from '../src/agents/pi.ts';
+import { PiAgent, piCustomProviderContext } from '../src/agents/pi.ts';
 import type { AgentConfig } from '../src/contracts/agent-config.ts';
 import type { Credential } from '../src/contracts/credential.ts';
 import { makeTempHome } from './provision-helpers.ts';
@@ -905,4 +905,27 @@ test('superpowers undefined spec keeps the legacy missing-root ProvisionError', 
   } finally {
     cleanup();
   }
+});
+
+// Pi records a placeholder zero cost for every model served through the custom
+// provider that api-key provisioning registers, whatever the endpoint. Capture
+// needs that provider/model pair to reprice from token buckets; an OAuth login
+// uses pi's own provider rates and gets no policy.
+test('piCustomProviderContext names the quorum provider for every api-key route and nothing for oauth', () => {
+  expect(piCustomProviderContext(makeApiKeyCredential())).toEqual({
+    pi: {
+      placeholderZeroCost: {
+        provider: 'quorum',
+        model: 'glm-5.2-fp8',
+        policy: 'unconfigured-provider-model-rates',
+      },
+    },
+  });
+  expect(
+    piCustomProviderContext(
+      makeApiKeyCredential({ model: 'gpt-5.6-sol', api: 'openai-responses' }),
+    )?.pi?.placeholderZeroCost?.model,
+  ).toBe('gpt-5.6-sol');
+  expect(piCustomProviderContext(makeOauthCredential())).toBeUndefined();
+  expect(piCustomProviderContext(undefined)).toBeUndefined();
 });

--- a/test/runner-credential.test.ts
+++ b/test/runner-credential.test.ts
@@ -827,7 +827,7 @@ function makePiCaptureScenario(root: string): string {
   return scenario;
 }
 
-function makePiCaptureGauntlet(root: string): string {
+function makePiCaptureGauntlet(root: string, model: string): string {
   const script = join(root, 'gauntlet-pi-capture.ts');
   writeFileSync(
     script,
@@ -858,7 +858,7 @@ function log(id: string, input: number, output: number, cacheRead: number) {
     JSON.stringify({
       type: 'message',
       message: {
-        role: 'assistant', provider: 'quorum', model: 'gpt-5.6-sol',
+        role: 'assistant', provider: 'quorum', model: '${model}',
         usage: { input, output, cacheRead, cacheWrite: 0, cost: { total: 0 } },
         content: [{ type: 'toolCall', id: 'call-' + id, name: 'read', arguments: {} }],
       },
@@ -873,93 +873,109 @@ writeFileSync(join(sessions, 'children', 'child.jsonl'), log('child', 200, 20, 4
   return script;
 }
 
-test('runner threads Pi custom-route zero normalization through root and child capture exactly once', async () => {
-  const root = mkdtempSync(join(tmpdir(), 'runner-pi-zero-cost-'));
-  const binDir = join(root, 'bin');
-  const credentialsPath = join(root, 'credentials.yaml');
-  const previousPath = Bun.env['PATH'];
-  const previousRoot = Bun.env['SUPERPOWERS_ROOT'];
-  const previousKey = Bun.env['PI_CAPTURE_KEY'];
-  mkdirSync(binDir);
-  const pi = join(binDir, 'pi');
-  writeFileSync(pi, '#!/bin/sh\nexit 0\n');
-  chmodSync(pi, 0o755);
-  writeFileSync(
-    credentialsPath,
-    [
-      'subject:',
-      '  model: gpt-5.6-sol',
-      '  harnesses: [pi]',
-      '  api: openai-responses',
-      '  base_url: https://api.openai.com/v1',
-      '  auth: api-key',
-      '  api_key_env: PI_CAPTURE_KEY',
-      '',
-    ].join('\n'),
-  );
-  Bun.env['PATH'] = `${binDir}:${previousPath ?? ''}`;
-  Bun.env['SUPERPOWERS_ROOT'] = makePiCaptureSuperpowersRoot(root);
-  Bun.env['PI_CAPTURE_KEY'] = 'test-key';
-
-  try {
-    const { runDir } = await runScenario({
-      scenarioDir: makePiCaptureScenario(root),
-      codingAgent: 'pi',
-      codingAgentsDir: REAL_CODING_AGENTS,
-      outRoot: join(root, 'results'),
-      credential: 'subject',
+// Every api-key Pi credential is served through the custom provider that
+// provisioning registers, and pi records a placeholder zero for all of them.
+// The policy must therefore follow the provisioning route, not one model name.
+for (const route of [
+  {
+    name: 'openai-responses sol',
+    model: 'gpt-5.6-sol',
+    api: 'openai-responses',
+    baseUrl: 'https://api.openai.com/v1',
+    expectedCost: 0.00243,
+  },
+  {
+    name: 'openai-chat custom endpoint',
+    model: 'custom-chat-model',
+    api: 'openai-chat',
+    baseUrl: 'https://example.com/v1',
+    expectedCost: undefined,
+  },
+] as const)
+  test(`runner threads Pi custom-route zero normalization through root and child capture exactly once (${route.name})`, async () => {
+    const root = mkdtempSync(join(tmpdir(), 'runner-pi-zero-cost-'));
+    const binDir = join(root, 'bin');
+    const credentialsPath = join(root, 'credentials.yaml');
+    const previousPath = Bun.env['PATH'];
+    const previousRoot = Bun.env['SUPERPOWERS_ROOT'];
+    const previousKey = Bun.env['PI_CAPTURE_KEY'];
+    mkdirSync(binDir);
+    const pi = join(binDir, 'pi');
+    writeFileSync(pi, '#!/bin/sh\nexit 0\n');
+    chmodSync(pi, 0o755);
+    writeFileSync(
       credentialsPath,
-      gauntletBin: makePiCaptureGauntlet(root),
-    });
-    const trajectory = JSON.parse(
-      readFileSync(join(runDir, 'trajectory.json'), 'utf8'),
-    ) as AtifTrajectory;
-    const usage = JSON.parse(
-      readFileSync(join(runDir, 'coding-agent-token-usage.json'), 'utf8'),
-    ) as {
-      total_input: number;
-      total_output: number;
-      total_cache_read: number;
-      total_tokens: number;
-      est_cost_usd: number | null;
-    };
+      [
+        'subject:',
+        `  model: ${route.model}`,
+        '  harnesses: [pi]',
+        `  api: ${route.api}`,
+        `  base_url: ${route.baseUrl}`,
+        '  auth: api-key',
+        '  api_key_env: PI_CAPTURE_KEY',
+        '',
+      ].join('\n'),
+    );
+    Bun.env['PATH'] = `${binDir}:${previousPath ?? ''}`;
+    Bun.env['SUPERPOWERS_ROOT'] = makePiCaptureSuperpowersRoot(root);
+    Bun.env['PI_CAPTURE_KEY'] = 'test-key';
 
-    expect(trajectory.steps).toHaveLength(2);
-    expect(
-      trajectory.steps.every((step) => step.metrics?.cost_usd === undefined),
-    ).toBe(true);
-    expect(
-      trajectory.steps.map((step) => step.extra?.['cost_normalization']),
-    ).toEqual([
-      {
+    try {
+      const { runDir } = await runScenario({
+        scenarioDir: makePiCaptureScenario(root),
+        codingAgent: 'pi',
+        codingAgentsDir: REAL_CODING_AGENTS,
+        outRoot: join(root, 'results'),
+        credential: 'subject',
+        credentialsPath,
+        gauntletBin: makePiCaptureGauntlet(root, route.model),
+      });
+      const trajectory = JSON.parse(
+        readFileSync(join(runDir, 'trajectory.json'), 'utf8'),
+      ) as AtifTrajectory;
+      const usage = JSON.parse(
+        readFileSync(join(runDir, 'coding-agent-token-usage.json'), 'utf8'),
+      ) as {
+        total_input: number;
+        total_output: number;
+        total_cache_read: number;
+        total_tokens: number;
+        est_cost_usd: number | null;
+      };
+
+      expect(trajectory.steps).toHaveLength(2);
+      expect(
+        trajectory.steps.every((step) => step.metrics?.cost_usd === undefined),
+      ).toBe(true);
+      const normalization = {
         policy: 'unconfigured-provider-model-rates',
         recorded_cost_usd: 0,
         provider: 'quorum',
-        model: 'gpt-5.6-sol',
-      },
-      {
-        policy: 'unconfigured-provider-model-rates',
-        recorded_cost_usd: 0,
-        provider: 'quorum',
-        model: 'gpt-5.6-sol',
-      },
-    ]);
-    expect(usage).toMatchObject({
-      total_input: 300,
-      total_output: 30,
-      total_cache_read: 60,
-      total_tokens: 390,
-    });
-    expect(usage.est_cost_usd).toBeCloseTo(0.00243, 10);
-  } finally {
-    if (previousPath === undefined) delete Bun.env['PATH'];
-    else Bun.env['PATH'] = previousPath;
-    if (previousRoot === undefined) delete Bun.env['SUPERPOWERS_ROOT'];
-    else Bun.env['SUPERPOWERS_ROOT'] = previousRoot;
-    if (previousKey === undefined) delete Bun.env['PI_CAPTURE_KEY'];
-    else Bun.env['PI_CAPTURE_KEY'] = previousKey;
-  }
-}, 10_000);
+        model: route.model,
+      };
+      expect(
+        trajectory.steps.map((step) => step.extra?.['cost_normalization']),
+      ).toEqual([normalization, normalization]);
+      expect(usage).toMatchObject({
+        total_input: 300,
+        total_output: 30,
+        total_cache_read: 60,
+        total_tokens: 390,
+      });
+      // A placeholder zero must never become the priced total: either obol
+      // has rates for the model or the cost is honestly unknown.
+      expect(usage.est_cost_usd).not.toBe(0);
+      if (route.expectedCost !== undefined)
+        expect(usage.est_cost_usd).toBeCloseTo(route.expectedCost, 10);
+    } finally {
+      if (previousPath === undefined) delete Bun.env['PATH'];
+      else Bun.env['PATH'] = previousPath;
+      if (previousRoot === undefined) delete Bun.env['SUPERPOWERS_ROOT'];
+      else Bun.env['SUPERPOWERS_ROOT'] = previousRoot;
+      if (previousKey === undefined) delete Bun.env['PI_CAPTURE_KEY'];
+      else Bun.env['PI_CAPTURE_KEY'] = previousKey;
+    }
+  }, 10_000);
 
 // --- $COPILOT_MODEL_SH sourced from credential ---
 


### PR DESCRIPTION
Fixes a pricing regression introduced by #50. Pi records a zero cost on every message served through the custom provider that api-key provisioning registers (it has no native rates for the model). The policy that omits that placeholder so obol prices the token buckets was keyed on one credential shape (`openai-responses` + `gpt-5.6-sol`), so every other api-key Pi route, including the appliance's default OpenRouter credential, kept the zero as authoritative and priced the run at $0. Confirmed on a retained OpenRouter run: every assistant message carries `provider=quorum, cost.total=0`.

The Pi adapter now owns the rule: `piCustomProviderContext` returns the provider/model pair for any api-key credential and nothing for an OAuth login, and the runner asks the adapter instead of matching credential fields. Tests: adapter unit test for api-key vs. OAuth; the runner regression now runs a second, non-sol api-key route next to the sol route and asserts the placeholder is repriced rather than honored.

Validation: `bun run check` green (3,930 pass, 34 platform skips, 0 fail; dashboard 144/144), lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)