### PR TITLE
Declare the conversation code-review smoke suite

### DIFF
--- a/docs/experiments/2026-09-10-conversation-code-review-smoke.md
+++ b/docs/experiments/2026-09-10-conversation-code-review-smoke.md
@@ -1,0 +1,56 @@
+# Conversation code-review smoke — 2026-09-10
+
+**Status:** Declared. Not yet registered or run.
+**Suite:** `suites/conversation_code_review_smoke.yaml` (12 attempts).
+**Purpose:** First live pass through main after the 2026-09-10 consolidation
+(#50, #51, #52), and the first measurement of Gauntlet assessor reliability
+since the completion contract and malformed-call correction landed.
+
+## Questions
+
+1. **Platform.** Do all twelve attempts complete through `evals-appliance
+   campaign` on main: conversation role, capture, assessment role, completion
+   record, publication, seal? Is every Pi attempt priced above zero?
+2. **Judge, mechanical.** Per assessment: was the first submitted report
+   accepted, how many physical requests were needed, and for every rejection,
+   what did the model actually emit?
+3. **Judge, semantic.** Per assessment and per criterion, does an independent
+   reading of the retained transcript agree with the assessor's verdict?
+
+The treatment-versus-stock effect on code review is recorded but is not a
+question this run can answer at n=2; it seeds the full routine-use suite.
+
+## Frozen configuration
+
+One scenario, `conversation-code-review`, on the committed arms:
+Claude (`opus5_bedrock`, effort high), Codex (`openai_responses_56sol`, effort
+high), Pi (`pi_gpt56_sol`); treatment pins superpowers
+`b36e0829c6d0140e93cfef2ca599b1b07d4a7797`, stock is `superpowers: none`.
+Grader `sonnet5_bedrock` / `anthropic.claude-sonnet-5`. Two repetitions per
+arm, one attempt each, 900-second bound, no reserve, global cap four. Evals
+source is whatever main resolves to at registration; the campaign report
+records the exact commit. Expected cost about $25 (six assessments at roughly
+$0.20 each; six conversations per harness pair at roughly $1 to $3).
+
+## Readout method
+
+- Platform: the campaign report and each attempt's `verdict.json`,
+  `assessment-completion.json`, and `coding-agent-token-usage.json`.
+- Judge, mechanical: `assessment-attempts.jsonl` and the Gauntlet event stream
+  (`run.jsonl`) for each assessment role; rejected submissions are quoted in
+  this record with provider content redacted to structure only.
+- Judge, semantic: the operator reads each retained conversation transcript and
+  the assessor's `result.md`, and records agree / disagree per criterion with
+  the transcript line that decides it. Twelve assessments, six criteria each.
+
+## Stop rules
+
+Any attempt that fails at setup, capture, or publication stops the campaign
+readout at the platform question; the defect is fixed on main before any
+further spend. If two or more of the twelve assessments end without an
+accepted report, the judge question is answered "still failing" and the next
+step is root cause from the retained model output, not the full suite.
+
+## Result
+
+_Pending._

--- a/suites/conversation_code_review_smoke.yaml
+++ b/suites/conversation_code_review_smoke.yaml
@@ -1,0 +1,30 @@
+# Stage-one smoke of the routine-use comparison: the one scenario every
+# conversation harness supports, treatment versus stock, two repetitions.
+# A strict subset of conversation_routine_use.yaml; same arms, grader, bounds,
+# and pricing snapshot. Record: docs/experiments/2026-09-10-conversation-code-review-smoke.md
+schema_version: 2
+name: conversation_code_review_smoke
+reserve: 0
+max_exposure_skew: 60
+attempt_bounds:
+  max_attempts: 1
+  max_time_s: 900
+grader:
+  credential: sonnet5_bedrock
+  model: anthropic.claude-sonnet-5
+pricing_snapshot:
+  path: docs/experiments/2026-09-06-pr2258-pricing/current.json
+  sha256: 6423a36bd98e01653824967834f114c71a1f4f03eeab595e511ad91a1ec37d8b
+comparisons:
+  - baseline: conversation_claude_stock
+    treatment: conversation_claude
+    scenarios: [conversation-code-review]
+    n: 2
+  - baseline: conversation_codex_stock
+    treatment: conversation_codex
+    scenarios: [conversation-code-review]
+    n: 2
+  - baseline: conversation_pi_stock
+    treatment: conversation_pi
+    scenarios: [conversation-code-review]
+    n: 2


### PR DESCRIPTION
Twelve-attempt subset of `conversation_routine_use`: `conversation-code-review` on Claude, Codex, and Pi, treatment versus stock, n=2. Same arms, grader, bounds, and pricing snapshot. First live pass through main after #50, #51, #52, and the first assessor-reliability measurement since the completion contract landed. The experiment record declares questions, frozen configuration, readout method, and stop rules before any spend. No source changes; `bun run quorum check` validates the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)