### PR TITLE
Reduce initial validation to one paired repetition

### DIFF
--- a/docs/experiments/2026-09-10-repeatable-pr-release-validation.md
+++ b/docs/experiments/2026-09-10-repeatable-pr-release-validation.md
@@ -1,9 +1,30 @@
 # Repeatable PR and release validation — 2026-09-10
 
-Status: declarations and fixture freeze complete; Task 9 capacity/pricing data
-preflight recorded below. Final implementation verification, grading qualification
-and live acceptance **pending**. No model calls, deployment or live workload was
-performed by this data preflight.
+Status: implementation is merged at Evals `1aca1214` and Gauntlet `9e5511e7`.
+Drew amended live validation to one repetition per declared cell: focused F28 and
+release R118, with qualification24 unchanged and an approximately $500 planning
+budget. Final implementation verification, grading qualification and live
+acceptance **pending**. No model calls, deployment or live workload was performed
+by this data preflight.
+
+## Current reduced execution amendment — 2026-09-10
+
+The current templates use F28/R118 (seven focused scenarios and 22 release
+scenarios, Claude/Codex/Pi eligibility unchanged, both arms, one repetition
+everywhere). The four-hour and 24-hour outer targets, per-role allowances,
+scenario selection, frozen refs, prices, exclusions and qualification24 remain
+unchanged. The retained forecast is $40.11/$55.62 standard/upper mean for F and
+$193.44/$295.83 for R; summed-cell p90 is $52.58/$73.35 and $248.65/$378.18.
+With qualification's $1–$10 allowance, combined planning arithmetic is
+$234.55–$461.53 (approximately $235–$462), not a spending ceiling or guaranteed
+final cost. Historical cohort proxies, unknown physical usage/retries and the
+one-repetition design limit interpretation.
+
+The original 84/366 declaration is a dated superseded full-scale proposal. It is
+deferred and is not satisfied by this reduced workflow validation; n=1 supplies
+initial behavioral observations and cannot establish equivalence or run-to-run
+variability. The current templates and this amendment are data-only; no Gauntlet
+or product behavior changed.
 
 ## Questions and frozen declarations
 
@@ -20,10 +41,11 @@ Versioned declarations: [workloads and constraints](../../examples/campaigns/val
 [focused](../../examples/campaigns/validation/focused.yaml),
 [release](../../examples/campaigns/validation/release.yaml), and
 [per-criterion requirements](../../examples/campaigns/validation/requirements.json).
-Focused: seven scenarios, Claude/Codex, two revisions, three repetitions,
-84 samples, four-hour target. Release: 22 scenarios, Claude/Codex/Pi, two
-revisions, three repetitions except five fractals repetitions, 366 samples,
-24-hour target. The seven existing Pi exclusions are declared in the README.
+Focused: seven scenarios, Claude/Codex, two revisions, one repetition, 28
+samples, four-hour target. Release: 22 scenarios, Claude/Codex/Pi, two
+revisions, one repetition everywhere, 118 samples, 24-hour target. The seven
+existing Pi exclusions are declared in the README. The earlier 84/366 counts
+remain below as a dated superseded proposal.
 Both use the frozen direct Anthropic Sonnet 5 grader and retain the committed
 acceptance-specific pricing snapshot described below. Eight-way capacity is a
 quota-supported configuration proposal, not a throughput result.
@@ -38,8 +60,8 @@ criteria 3 and 5 in its three assessments. No disputed label is counted as gold.
 
 Case-manifest SHA-256: `11b273a535f878a12ed1b075949b4e4f353b625636144b533b7f12a351782459`.
 Requirements SHA-256: `4bef2871b9890dbc5246bdb2e30607522975ff00b4631ea17daf25af0a856af1`.
-Focused-template SHA-256: `2bd7ce9b5b19738ceca9aaa8535588e52feef6b7ce1636860a95bb6bb132dc61`.
-Release-template SHA-256: `fae792e3d7249c6b5173850a8e9238ebb4a52a5751206f2e1e3767d598ea1f67`.
+Focused-template SHA-256: `9c72e7e8b0e5f6dfa04af9741a6d4914b4bdc204559b068bb4fc220397b0becd`.
+Release-template SHA-256: `fb956890b0946512ef5a34e91bd431f080d9524170b82ca05f1ca855cd651032`.
 
 The requirements digest includes explicit assessment-qualification scope metadata
 for the six conversation-code-review obligations; the rubric and case-manifest
@@ -70,9 +92,11 @@ Report workload dispositions, all declared repetitions, native/visible
 capture, trusted executable-check dispositions, every applicable rubric row,
 qualification scope, actor-specific known costs and missingness, full turnaround
 and coverage. Cost unknown is not zero and does not discard behavioral evidence.
-No detected difference at n=3/5 establishes equivalence. No automatic release
-decision follows. Model assessments, paid runs, operational capacity, four-hour
-and 24-hour targets, and live comparison results remain pending.
+The superseded n=3/5 proposal's “no detected difference” condition would not
+establish equivalence. The current n=1 amendment supplies initial observations
+only. No automatic release decision follows. Model assessments, paid runs,
+operational capacity, four-hour and 24-hour targets, and live comparison results
+remain pending.
 
 ## Independent-measurement integration boundary
 
@@ -205,7 +229,17 @@ also confirmed the existing Terra, Luna and Astra standard/long-context rates.
 Retained forecasting cohorts include 97 Codex Terra, 40 Luna, one Astra and
 90 Claude Haiku model records. No OpenAI rate correction is made.
 
-### Planning forecast, not spending limits
+### Current reduced planning forecast, not spending limits
+
+The reduced forecast reweights the existing per-cell cohorts to one repetition
+per declared cell. It is $40.11/$55.62 standard/upper mean for focused and
+$193.44/$295.83 for release; summed-cell p90 estimates are $52.58/$73.35 and
+$248.65/$378.18. With the unchanged qualification24 allowance of $1–$10, the
+combined planning arithmetic is $234.55–$461.53. It is neither a spending
+ceiling nor a confidence interval, and does not account for unknown physical
+usage or retries.
+
+### Superseded full-scale planning forecast, not current authorization
 
 The forecast selects each quantity's first populated cohort: exact scenario,
 harness and primary model; then the same scenario/harness with another model
@@ -246,8 +280,9 @@ drift and actual overlap still constrain delivery. Preserve this negative
 capacity evidence without promising the proposed cap will meet either target.
 
 Before any deployment/live authorization, present the final tested evals and
-Gauntlet heads, unchanged 84/366 declarations, these estimates and limitations,
-and the exact 24-assessment sequence. Then qualify the frozen grading gate,
+Gauntlet heads, the current F28/R118 declarations, these estimates and
+limitations, and the exact 24-assessment sequence. The original 84/366 counts
+remain deferred historical scope. Then qualify the frozen grading gate,
 freeze its data and instrument identity, register both comparisons plus the
 registration-only alternate candidate demonstration, and measure both ordinary
 reports against their turnaround and completeness obligations. This preflight

--- a/docs/superpowers/plans/2026-09-10-repeatable-pr-release-validation.md
+++ b/docs/superpowers/plans/2026-09-10-repeatable-pr-release-validation.md
@@ -4,6 +4,16 @@
 
 **Goal:** Compare Superpowers dev with v6.3.0 through reusable appliance inputs and deliver trustworthy focused and release reports within four and 24 hours, respectively.
 
+### Dated execution amendment — 2026-09-10
+
+Drew amended the execution counts after implementation merged. The current
+data-only validation is F28/R118 with n=1 for every eligible scenario, harness
+and arm; qualification24, scenario selection, exclusions, frozen refs, prices,
+role allowances and outer time budgets remain unchanged. Plan approximately
+$500. The original 84/366 live acceptance and statistical/scale claims are
+deferred and are not satisfied by the reduced workflow validation. No software
+behavior, Gauntlet change or appliance change is authorized by this amendment.
+
 **Architecture:** Extend ordinary campaign registration, role execution and report publication. Preserve the controller, isolated workers, immutable evidence and separate simulated-user/assessor histories. Measurement availability is derived from authenticated artifacts; it is not inherited from the aggregate verdict.
 
 **Tech Stack:** Bun (evals requires ≥1.3.13; Gauntlet requires ≥1.3.14), TypeScript, existing Zod/YAML contracts, Gauntlet's existing Anthropic client, Linux appliance containers. No new dependencies.

--- a/docs/superpowers/specs/2026-09-10-repeatable-pr-release-validation-design.md
+++ b/docs/superpowers/specs/2026-09-10-repeatable-pr-release-validation-design.md
@@ -4,6 +4,16 @@ Status: written design for Drew's review. The operator, execution, grading and
 reporting contracts were agreed in conversation. Implementation and live
 acceptance have not started under this design.
 
+### Dated execution amendment — 2026-09-10
+
+Drew amended the live validation execution counts after implementation merged:
+the current data-only templates use F28/R118, n=1 for every eligible scenario,
+harness and arm, while qualification24 and all scenario selection, exclusions,
+refs, prices and time budgets remain unchanged. The planning budget is
+approximately $500. The original 84/366 live acceptance and its statistical or
+scale claims are deferred; a reduced result supplies initial observations and
+does not satisfy those claims. No software behavior or Gauntlet contract changes.
+
 ## Purpose and success
 
 Given a Superpowers baseline and candidate, run a declared comparison across

--- a/examples/campaigns/validation/README.md
+++ b/examples/campaigns/validation/README.md
@@ -20,12 +20,13 @@ registration; no comparison-specific arm files belong here.
 | Implementation identity | Freeze final evals/Gauntlet commits and image digest at registration |
 
 `focused.yaml` covers the first seven declared scenarios on Claude and Codex,
-three repetitions on both revisions: **84 primary samples**, a **four-hour**
+one repetition on both revisions: **28 primary samples**, a **four-hour**
 target from durable execution acceptance to a usable report, and a 5400-second
 outer attempt bound. `release.yaml` covers all 22 scenarios on the three
-pairings, with three repetitions except five for `sdd-go-fractals-opus48`:
-**366 primary samples** (Claude 136, Codex 136, Pi 94), a **24-hour** target,
-and a 10800-second outer bound. These are targets, not measured throughput.
+pairings, one repetition everywhere: **118 primary samples** (Claude 44,
+Codex 44, Pi 30), a **24-hour** target, and a 10800-second outer bound. These
+are reduced workflow-validation counts, not measured throughput or the original
+full-scale acceptance.
 
 Pi is excluded from exactly these seven release scenarios by their existing
 eligibility: `user-pref-no-brainstorm`, `conversation-design`,
@@ -65,14 +66,16 @@ load reached 24.98, exceeding the current 16 guard: sustainable eight-way
 throughput and the four/24-hour targets remain unproven. Quotas and retained
 returned-usage samples do not measure active request concurrency or retries.
 
-Planning means are $120.34 standard / $166.87 upper for focused and $705.79 /
-$1,096.23 for release; summed cell p90 estimates are $157.74 / $220.05 and
-$890.70 / $1,374.44. These use 78/84 and 272/366 exact primary slots, respectively,
-with six and 94 explicit model/harness proxy slots. The separate 24-assessment
-qualification has a $1–$10 planning allowance. These are neither spending ceilings
-nor measured final costs; see the record for role subtotals, proxy selection,
-rate sources and uncertainty. No qualification is attached, and this data
-preflight does not authorize deployment or live acceptance.
+The reduced forecast is $40.11 standard / $55.62 upper mean for focused and
+$193.44 / $295.83 for release; summed cell p90 estimates are $52.58 / $73.35
+and $248.65 / $378.18. The separate 24-assessment qualification has a $1–$10
+planning allowance. Combined planning arithmetic is approximately $235–$462
+(exactly $234.55–$461.53), neither a spending ceiling nor a guaranteed final
+cost. These reweight retained per-cell cohorts; unknown physical usage, retries,
+proxy-filled historical samples and the reduced n=1 design remain limitations.
+The original 84/366 full-scale proposal is deferred and is not satisfied by this
+reduced validation. No qualification is attached, and this data preflight does
+not authorize deployment or live acceptance.
 
 ## Requirements data contract
 
@@ -139,10 +142,12 @@ change requires explicit re-freezing of affected inputs, not silent refresh.
 The YAML's `grader` is parsed separately using the existing `GraderSchema`, as
 registration already does, and the remaining fields use `SuiteSchema`.
 
-Require truthful dispositions for all 84/366 primary samples, every declared
+Require truthful dispositions for all 28/118 primary samples, every declared
 repetition, required judgments/checks/capture and authenticated source identity.
-Report actor-specific cost coverage separately. Small-sample descriptive deltas
-do not establish equivalence, and these reports make no automatic release decision.
+Report actor-specific cost coverage separately. One repetition per cell provides
+initial behavioral observations only; it does not establish equivalence,
+run-to-run variability or the original full-scale acceptance. These reports make
+no automatic release decision.
 
 ## Qualification and independent measurements
 

--- a/examples/campaigns/validation/focused.yaml
+++ b/examples/campaigns/validation/focused.yaml
@@ -18,4 +18,4 @@ comparisons:
   - baseline: baseline
     treatment: candidate
     scenarios: [brainstorming-todo-purpose-discovery, brainstorming-resists-jump-to-implementation, brainstorming-companion-just-in-time, user-pref-no-brainstorm, writing-plans-no-spec-conversational, cost-spec-plan-duplication, conversation-design]
-    n: 3
+    n: 1

--- a/examples/campaigns/validation/release.yaml
+++ b/examples/campaigns/validation/release.yaml
@@ -18,5 +18,4 @@ comparisons:
   - baseline: baseline
     treatment: candidate
     scenarios: [brainstorming-todo-purpose-discovery, brainstorming-resists-jump-to-implementation, brainstorming-companion-just-in-time, user-pref-no-brainstorm, writing-plans-no-spec-conversational, cost-spec-plan-duplication, conversation-design, superpowers-bootstrap, triggering-test-driven-development, verification-phantom-completion, triggering-finishing-a-development-branch, worktree-no-drift-to-main, sdd-escalates-broken-plan, sdd-breaker-rules-and-continues, sdd-go-fractals-opus48, receiving-code-review-pushback, tdd-holds-under-tests-later-pressure, conversation-code-review, conversation-review-feedback, conversation-config-repair, conversation-pricing, conversation-debugging]
-    n: 3
-    cells: {sdd-go-fractals-opus48: {n: 5}}
+    n: 1

--- a/test/assessment-validation-fixtures.test.ts
+++ b/test/assessment-validation-fixtures.test.ts
@@ -161,8 +161,8 @@ test('qualification denominators separate grounding from omitted findings', () =
 test('workload declarations preserve samples, exclusions and existing suite fields', () => {
   const requirements = json(join(workloads, 'requirements.json'));
   for (const [name, scenarioCount, samples, bound] of [
-    ['focused', 7, 84, 5400],
-    ['release', 22, 366, 10800],
+    ['focused', 7, 28, 5400],
+    ['release', 22, 118, 10800],
   ] as const) {
     const { grader, ...raw } = parse(
       readFileSync(join(workloads, `${name}.yaml`), 'utf8'),
@@ -181,7 +181,7 @@ test('workload declarations preserve samples, exclusions and existing suite fiel
     expect(comparison).toMatchObject({
       baseline: 'baseline',
       treatment: 'candidate',
-      n: 3,
+      n: 1,
     });
     const scenarios = comparison.scenarios as string[];
     expect(scenarios).toHaveLength(scenarioCount);

--- a/test/campaign-comparison-input.test.ts
+++ b/test/campaign-comparison-input.test.ts
@@ -123,8 +123,8 @@ import { SuiteSchema } from '../src/contracts/campaign/suite.ts';
 import { FAKE_PROBE } from './fixtures/core-comparison/registration.ts';
 
 test.each([
-  ['focused', 84, 2],
-  ['release', 366, 3],
+  ['focused', 28, 2],
+  ['release', 118, 3],
 ] as const)('real %s template compiles declared coverage through ordinary preparation', (name, slots, pairCount) => {
   const root = resolve(import.meta.dir, '..');
   const { grader, ...rawSuite } = parseYaml(
@@ -197,8 +197,7 @@ test.each([
   expect(Object.keys(requirements)).toHaveLength(name === 'focused' ? 7 : 22);
   expect(prepared.planned_slots).toHaveLength(slots);
   expect(prepared.reserve_slots).toHaveLength(0);
-  for (const cell of prepared.cells)
-    expect(cell.n).toBe(cell.scenario === 'sdd-go-fractals-opus48' ? 5 : 3);
+  for (const cell of prepared.cells) expect(cell.n).toBe(1);
   expect(prepared.excluded_cells.map((cell) => cell.cell).sort()).toEqual(
     name === 'focused'
       ? []


### PR DESCRIPTION
Reduce the initial dev-versus-v6.3.0 validation toward Drew's roughly $500 budget by using one paired repetition in every declared cell. Focused coverage becomes 28 samples and release coverage 118, including one fractals repetition per arm. All scenarios, eligible harnesses, seven Pi exclusions, frozen refs, role allowances and 24 qualification assessments remain unchanged.

The retained per-cell forecast now gives roughly $235–$462 including qualification. This is planning arithmetic with historical proxies and rate uncertainty, not a guaranteed ceiling. The original 84/366 full-scale acceptance remains explicitly deferred; this reduced workload exercises the real workflow and gives initial behavioral observations.

Only declarations, documentation and existing compilation expectations change. Reviewed with no findings. Validation at `55ab752e`: full `bun run check` passed lint/typecheck, 3,971 runner tests (40 expected skips) and 144 dashboard tests; focused fixture/compiler tests passed 14 tests with 1,498 assertions; `quorum check` passed. No runtime source or Gauntlet changes.

Refs [PRI-2874](https://linear.app/prime-radiant/issue/PRI-2874). Qualification and the reduced live comparisons follow through the existing appliance path.
