### PR TITLE
Allow the focused comparison while code-review qualification remains unresolved

### DIFF
--- a/docs/experiments/2026-09-10-repeatable-pr-release-validation.md
+++ b/docs/experiments/2026-09-10-repeatable-pr-release-validation.md
@@ -8,8 +8,36 @@ required full-review grounding failures; three Opus sessions ended on API errors
 **Grading qualification remains unmet.** No focused or release comparison was
 launched. Implementation verification is complete; live comparison acceptance
 remains unmet. The original failed qualification below is retained unchanged.
-Drew's approximately $500 reduced scope remains F28/R118, conditional on grading
-qualification; original 84/366 full-scale acceptance is deferred.
+Drew's approximately $500 reduced scope remains F28/R118. The September 11
+amendment below authorizes F28 without code-review qualification; R118 remains
+held. Original 84/366 full-scale acceptance is deferred.
+
+## Focused launch amendment — 2026-09-11
+
+Drew approved running the existing 28-sample dev-versus-v6.3.0 focused workload
+and requested a fresh team review before launch. Its seven scenarios do not
+include conversation-code-review, the sole scope of the failed qualification
+pack. The plan's qualification-before-F sequencing is explicitly superseded;
+the failed results, labels, rubric and review-quality requirement remain intact.
+No successful qualification record is created or attached. R118 and the
+alternate-candidate registration demonstration remain deferred.
+
+The six fused-QA scenarios and conversation-design retain their existing paths.
+Conversation-design shares the assessor implementation and prohibits unsupported
+claims, so this is not evidence of independent or calibrated graders. Preserve
+the ordinary report's uncalibrated labels, inspect decisive evidence for
+assessor-derived findings, and distinguish check authority, interaction,
+judgments, actor costs and missingness. A complete publication receipt does not
+prove semantic accuracy or complete release acceptance.
+
+The frozen baseline remains `b36e0829c6d0140e93cfef2ca599b1b07d4a7797`, candidate
+`3a8bdc11e1db42955350d6d6f063f7a8e89aef58`. Keep the seven scenarios, Claude/Codex
+pairings, n=1, zero reserves, role budgets, eight-way target and pricing snapshot.
+The retained focused forecast is $40.11/$55.62 standard/upper mean and
+$52.58/$73.35 summed-cell p90 estimates, not ceilings. The target remains four
+hours to a usable report; descriptive observations cannot establish equivalence
+or the deferred full-scale acceptance. No model calls or campaign launch have
+occurred under this amendment yet.
 
 ## Prompt-first retry — 2026-09-11
 

--- a/docs/superpowers/plans/2026-09-10-repeatable-pr-release-validation.md
+++ b/docs/superpowers/plans/2026-09-10-repeatable-pr-release-validation.md
@@ -14,6 +14,24 @@ $500. The original 84/366 live acceptance and statistical/scale claims are
 deferred and are not satisfied by the reduced workflow validation. No software
 behavior, Gauntlet change or appliance change is authorized by this amendment.
 
+### Focused launch amendment — 2026-09-11
+
+Drew authorized the existing F28 comparison after a bounded team review,
+without successful conversation-code-review qualification. This supersedes
+Task 9's qualification-before-F sequencing. The pack's failed outcomes and
+scope remain unchanged; no successful qualification record is created or
+attached. F28 contains no code-review scenario. Its six fused-QA scenarios and
+conversation-design still use uncalibrated assessment, and conversation-design
+shares the assessor and checks unsupported claims. Inspect decisive evidence
+for assessor-derived findings; do not infer accuracy from a published report.
+
+Record the amendment, prepare and freeze the final source identity, register
+exactly 28 samples, then execute F through the existing helper and read its
+ordinary report. Preserve existing refs, pairings, n=1, budgets, caps, pricing,
+zero reserves and all missing/error outcomes. R118 and its acceptance remain
+held; the alternate-candidate registration demonstration remains deferred.
+No further prompt/model experiment or runtime change is part of this amendment.
+
 **Architecture:** Extend ordinary campaign registration, role execution and report publication. Preserve the controller, isolated workers, immutable evidence and separate simulated-user/assessor histories. Measurement availability is derived from authenticated artifacts; it is not inherited from the aggregate verdict.
 
 **Tech Stack:** Bun (evals requires ≥1.3.13; Gauntlet requires ≥1.3.14), TypeScript, existing Zod/YAML contracts, Gauntlet's existing Anthropic client, Linux appliance containers. No new dependencies.

--- a/docs/superpowers/specs/2026-09-10-repeatable-pr-release-validation-design.md
+++ b/docs/superpowers/specs/2026-09-10-repeatable-pr-release-validation-design.md
@@ -14,6 +14,24 @@ approximately $500. The original 84/366 live acceptance and its statistical or
 scale claims are deferred; a reduced result supplies initial observations and
 does not satisfy those claims. No software behavior or Gauntlet contract changes.
 
+### Focused launch amendment — 2026-09-11
+
+Drew authorized launching F28 without a successful conversation-code-review
+qualification record. F28 selects no code-review scenario; the qualification
+pack covers only that scenario's obligations. Its failed Sonnet and Opus results
+remain unchanged, grounding remains mandatory for review-quality claims, and
+R118 remains held. This amends execution sequencing only.
+
+The six fused-QA scenarios and conversation-design retain their existing
+graders, rubrics and evidence requirements. Conversation-design shares the
+assessor implementation and includes unsupported-claim checks; this amendment
+does not establish independent or calibrated judgments. Report those judgments
+as uncalibrated and inspect decisive evidence before claiming an improvement or
+regression. Executable checks establish only their declared scope. Complete
+publication is not semantic qualification or completed release acceptance.
+Keep all 28 samples, frozen refs, role budgets, eight-way admission target,
+pricing and missingness policy; n=1 supports descriptive observations only.
+
 ## Purpose and success
 
 Given a Superpowers baseline and candidate, run a declared comparison across

--- a/examples/campaigns/validation/README.md
+++ b/examples/campaigns/validation/README.md
@@ -28,6 +28,15 @@ Codex 44, Pi 30), a **24-hour** target, and a 10800-second outer bound. These
 are reduced workflow-validation counts, not measured throughput or the original
 full-scale acceptance.
 
+Drew's September 11 amendment authorizes F28 without successful code-review
+qualification, after a bounded team review. None of its seven scenarios is
+conversation-code-review. The failed qualification is retained, no success
+record is attached, and R118 remains held. This does not calibrate the focused
+graders: conversation-design shares the assessor and checks unsupported claims;
+the other six scenarios use fused QA. Report judgments with their evidence and
+uncalibrated status, checks within their declared authority, and cost/coverage
+separately. Publication completeness does not establish semantic accuracy.
+
 Pi is excluded from exactly these seven release scenarios by their existing
 eligibility: `user-pref-no-brainstorm`, `conversation-design`,
 `worktree-no-drift-to-main`, `tdd-holds-under-tests-later-pressure`,


### PR DESCRIPTION
The focused 28-sample dev-versus-v6.3.0 workload was waiting on a failed qualification pack whose declared scope is conversation-code-review, a scenario it does not select. Drew approved removing that sequencing dependency for F28 and requested an independent team audit before launch.

This documentation amendment preserves the failed qualification, holds R118, and leaves every scenario, source ref, pairing, budget, cap, price snapshot and missingness rule unchanged. Focused judgments remain uncalibrated; conversation-design shares the assessor and checks unsupported claims, so publication completeness is not semantic qualification.

Validation: independent scope and diff review approved; docs fence, lint and diff check passed. Launch/readout audit is in progress. No live comparison has launched. Tracked under PRI-2874.
