### PR TITLE
Fix campaign paths and the no-spec scenario check

### DIFF
--- a/examples/campaigns/validation/focused.yaml
+++ b/examples/campaigns/validation/focused.yaml
@@ -13,7 +13,7 @@ pricing_snapshot:
   sha256: b4f9e5512b4a62adcf2b47bbe96f5972fc9c5d6fdc313f4d95f965f6343be780
 measurement_requirements:
   path: examples/campaigns/validation/requirements.json
-  sha256: 4bef2871b9890dbc5246bdb2e30607522975ff00b4631ea17daf25af0a856af1
+  sha256: f476f4c8004cacfb2c0d4375a62cf7b7a99b7f698c6c73868e41f08e37b998e7
 comparisons:
   - baseline: baseline
     treatment: candidate

--- a/examples/campaigns/validation/release.yaml
+++ b/examples/campaigns/validation/release.yaml
@@ -13,7 +13,7 @@ pricing_snapshot:
   sha256: b4f9e5512b4a62adcf2b47bbe96f5972fc9c5d6fdc313f4d95f965f6343be780
 measurement_requirements:
   path: examples/campaigns/validation/requirements.json
-  sha256: 4bef2871b9890dbc5246bdb2e30607522975ff00b4631ea17daf25af0a856af1
+  sha256: f476f4c8004cacfb2c0d4375a62cf7b7a99b7f698c6c73868e41f08e37b998e7
 comparisons:
   - baseline: baseline
     treatment: candidate

--- a/examples/campaigns/validation/requirements.json
+++ b/examples/campaigns/validation/requirements.json
@@ -672,12 +672,7 @@
             "output",
             "visible_delivery"
           ],
-          "check_refs": [
-            {
-              "ordinal": 5,
-              "scope": "No-spec header text pattern only; not requirement uniqueness or path validity."
-            }
-          ]
+          "check_refs": []
         },
         {
           "id": "writing-plans-no-spec-conversational:3",
@@ -691,7 +686,7 @@
           ],
           "check_refs": [
             {
-              "ordinal": 6,
+              "ordinal": 5,
               "scope": "No spec file at final capture; does not establish earlier writes."
             }
           ]
@@ -718,7 +713,7 @@
         "manifest": "scenarios/writing-plans-no-spec-conversational/checks-manifest.json",
         "independent_oracles": [],
         "scope": "existing deterministic checks only; all acceptance criteria require their applicable evidence",
-        "check_manifest_sha256": "8f6d4274ba1f35c92c9facd83829aa6150871957a565ece40d1fd5831cf70579"
+        "check_manifest_sha256": "bd7d01468dbdf6dcbbaaa8187f116ac6dc87bf3eff14ebb223025b0dec20c6c9"
       },
       "subject_allowance_s": 1200,
       "allowance_source": "scenario",
@@ -807,22 +802,6 @@
         },
         {
           "ordinal": 5,
-          "phase": "post",
-          "check": "command-succeeds",
-          "args": [
-            "grep -qi \"none \u2014 requirements\\|none - requirements\" docs/superpowers/plans/*.md"
-          ],
-          "negated": false,
-          "count": 1,
-          "authority": {
-            "kind": "output_check",
-            "sources": [
-              "scenarios/writing-plans-no-spec-conversational/checks.sh"
-            ]
-          }
-        },
-        {
-          "ordinal": 6,
           "phase": "post",
           "check": "file-exists",
           "args": [

--- a/scenarios/writing-plans-no-spec-conversational/checks-manifest.json
+++ b/scenarios/writing-plans-no-spec-conversational/checks-manifest.json
@@ -46,15 +46,6 @@
     },
     {
       "phase": "post",
-      "check": "command-succeeds",
-      "args": [
-        "grep -qi \"none — requirements\\|none - requirements\" docs/superpowers/plans/*.md"
-      ],
-      "negated": false,
-      "count": 1
-    },
-    {
-      "phase": "post",
       "check": "file-exists",
       "args": [
         "docs/superpowers/specs/*.md"

--- a/scenarios/writing-plans-no-spec-conversational/checks.sh
+++ b/scenarios/writing-plans-no-spec-conversational/checks.sh
@@ -7,6 +7,6 @@ pre() {
 
 post() {
     file-exists 'docs/superpowers/plans/*.md'
-    command-succeeds 'grep -qi "none — requirements\|none - requirements" docs/superpowers/plans/*.md'
+    # QA assesses the Spec header wording and requirements against story.md.
     not file-exists 'docs/superpowers/specs/*.md'
 }

--- a/src/campaign/attempt-projection.ts
+++ b/src/campaign/attempt-projection.ts
@@ -29,8 +29,7 @@ import {
   sharesMantleCredentialSource,
 } from '../credentials/scope.ts';
 
-// passwd fields cannot contain the colons carried in campaign attempt paths.
-// The container binds this home alias to the existing private attempt home.
+// The container binds this fixed home alias to each attempt's private home.
 export const ATTEMPT_PASSWD_HOME = '/home/quorum';
 
 export class AttemptProjectionError extends Error {
@@ -126,6 +125,7 @@ export function prepareAttemptStage(
   args: PrepareAttemptStageArgs,
 ): PreparedAttemptStage {
   assertAttemptId(args.attemptId);
+  const attemptPathComponent = encodeURIComponent(args.attemptId);
 
   const registry =
     args.grader === undefined
@@ -285,7 +285,7 @@ export function prepareAttemptStage(
       safeEnvValue(line.slice(eq + 1), 'grader env value', args.attemptId);
     }
 
-    const attemptDir = join(args.campaignDir, 'attempts', args.attemptId);
+    const attemptDir = join(args.campaignDir, 'attempts', attemptPathComponent);
     const stageDir = join(attemptDir, '.stage');
     const homeDir = join(attemptDir, 'home');
     const stagingDir = join(attemptDir, 'staging');
@@ -306,7 +306,7 @@ export function prepareAttemptStage(
       );
       attemptPin = createAndPinChild(
         attemptsPin,
-        args.attemptId,
+        attemptPathComponent,
         'attempt directory',
       );
       homePin = createAndPinChild(attemptPin, 'home', 'attempt home');

--- a/test/campaign-attempt-projection.test.ts
+++ b/test/campaign-attempt-projection.test.ts
@@ -2,6 +2,7 @@ import { expect, spyOn, test } from 'bun:test';
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import {
+  chmodSync,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -142,6 +143,77 @@ test('projection writes exact private files and synthesized identity files', () 
   ]);
 });
 
+test('colon-bearing attempt paths run local npm binaries and preserve logical ids', () => {
+  const fx = projectionFixture();
+  const attemptIds = ['c1:s', 'c1%3As'];
+  try {
+    const preparedStages = attemptIds.map((attemptId) => stage(fx, attemptId));
+    const prepared = preparedStages[0];
+    const codingAgentWorkdir = join(
+      prepared.stagingDir,
+      'coding-agent-workdir',
+    );
+    const binDir = join(codingAgentWorkdir, 'node_modules', '.bin');
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(
+      join(codingAgentWorkdir, 'package.json'),
+      JSON.stringify({
+        private: true,
+        scripts: { probe: 'f28-local-probe' },
+      }),
+    );
+    const sentinel = join(codingAgentWorkdir, 'npm-sentinel');
+    const localCommand = join(binDir, 'f28-local-probe');
+    writeFileSync(
+      localCommand,
+      '#!/bin/sh\nprintf "local executable ran\\n" > "$PWD/npm-sentinel"\n',
+    );
+    chmodSync(localCommand, 0o755);
+
+    const mounts = buildAttemptMounts({
+      ...prepared,
+      evalsRoot: fx.corpus,
+      gauntletRoot: join(fx.corpus, 'gauntlet'),
+      binRoot: join(fx.corpus, 'bin'),
+      superpowersTree: null,
+    });
+    const npm = spawnSync('npm', ['run', 'probe', '--silent'], {
+      cwd: codingAgentWorkdir,
+      env: {
+        ...Bun.env,
+        HOME: prepared.homeDir,
+        npm_config_audit: 'false',
+        npm_config_cache: join(fx.campaignDir, 'npm-cache'),
+        npm_config_fund: 'false',
+        npm_config_offline: 'true',
+        npm_config_update_notifier: 'false',
+      },
+      encoding: 'utf8',
+    });
+    expect(npm.status).toBe(0);
+    expect(readFileSync(sentinel, 'utf8')).toBe('local executable ran\n');
+    expect(prepared.attemptId).toBe(attemptIds[0]);
+    expect(prepared.attemptDir).toBe(
+      join(fx.campaignDir, 'attempts', encodeURIComponent(attemptIds[0])),
+    );
+    expect(mounts).toContainEqual({
+      source: prepared.attemptDir,
+      target: prepared.attemptDir,
+      mode: 'rw',
+    });
+    expect(
+      new Set(preparedStages.map(({ attemptDir }) => attemptDir)).size,
+    ).toBe(2);
+    expect(readdirSync(join(fx.campaignDir, 'attempts')).sort()).toEqual(
+      attemptIds.map(encodeURIComponent).sort(),
+    );
+  } finally {
+    for (const path of [fx.corpus, fx.campaignDir, fx.bundleDir]) {
+      rmSync(path, { recursive: true, force: true });
+    }
+  }
+});
+
 test('passwd home resolves to each attempt private home through a writable bind', () => {
   const fx = projectionFixture();
   try {
@@ -166,7 +238,7 @@ test('passwd home resolves to each attempt private home through a writable bind'
         { source: prepared.homeDir, target: '/home/quorum', mode: 'rw' },
       ]);
       expect(prepared.homeDir).toBe(
-        join(fx.campaignDir, 'attempts', attemptId, 'home'),
+        join(fx.campaignDir, 'attempts', encodeURIComponent(attemptId), 'home'),
       );
       expect(mounts).toContainEqual({
         source: prepared.attemptDir,

--- a/test/campaign-attempt-projection.test.ts
+++ b/test/campaign-attempt-projection.test.ts
@@ -145,9 +145,12 @@ test('projection writes exact private files and synthesized identity files', () 
 
 test('colon-bearing attempt paths run local npm binaries and preserve logical ids', () => {
   const fx = projectionFixture();
-  const attemptIds = ['c1:s', 'c1%3As'];
+  const attemptIds = ['c1:s', 'c1%3As'] as const;
   try {
-    const preparedStages = attemptIds.map((attemptId) => stage(fx, attemptId));
+    const preparedStages = [
+      stage(fx, attemptIds[0]),
+      stage(fx, attemptIds[1]),
+    ] as const;
     const prepared = preparedStages[0];
     const codingAgentWorkdir = join(
       prepared.stagingDir,

--- a/test/writing-plans-no-spec-checks.test.ts
+++ b/test/writing-plans-no-spec-checks.test.ts
@@ -1,0 +1,92 @@
+import { expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { compareRecords, readManifest } from '../src/check/manifest.ts';
+import { runPhase } from '../src/checks/index.ts';
+import { repoRoot } from '../src/paths.ts';
+
+const scenarioDir = join(
+  repoRoot(),
+  'scenarios',
+  'writing-plans-no-spec-conversational',
+);
+const checksSh = join(scenarioDir, 'checks.sh');
+const planPath = 'docs/superpowers/plans/plan.md';
+const specPath = 'docs/superpowers/specs/design.md';
+
+test('no-spec post checks accept equivalent headers and preserve filesystem authority', async () => {
+  const cases = [
+    {
+      name: 'equivalent header',
+      plan: '**Spec:** no separate specification; requirements are: add a version flag.\n',
+      expected: [true, true],
+    },
+    {
+      name: 'canonical header',
+      plan: '**Spec:** none — requirements: add a version flag.\n',
+      expected: [true, true],
+    },
+    {
+      name: 'missing plan',
+      plan: null,
+      expected: [false, true],
+    },
+    {
+      name: 'fabricated spec',
+      plan: '**Spec:** none — requirements: add a version flag.\n',
+      spec: '# Design\n',
+      expected: [true, false],
+    },
+  ];
+
+  for (const scenario of cases) {
+    const workdir = mkdtempSync(join(tmpdir(), 'writing-plans-no-spec-'));
+    try {
+      if (scenario.plan !== null && scenario.plan !== undefined) {
+        const plan = join(workdir, planPath);
+        mkdirSync(join(plan, '..'), { recursive: true });
+        writeFileSync(plan, `# Implementation plan\n\n${scenario.plan}`);
+      }
+      if ('spec' in scenario && scenario.spec !== undefined) {
+        const spec = join(workdir, specPath);
+        mkdirSync(join(spec, '..'), { recursive: true });
+        writeFileSync(spec, scenario.spec);
+      }
+
+      const result = await runPhase({
+        checksSh,
+        phase: 'post',
+        workdir,
+        repoRoot: repoRoot(),
+        scenarioDir,
+      });
+
+      expect(result.exitCode, scenario.name).toBe(0);
+      expect(
+        result.records.map((record) => record.check),
+        scenario.name,
+      ).toEqual(['file-exists', 'file-exists']);
+      expect(
+        result.records.map((record) => record.passed),
+        scenario.name,
+      ).toEqual(scenario.expected);
+      const manifest = readManifest(scenarioDir);
+      expect(manifest).not.toBeNull();
+      expect(
+        compareRecords(
+          {
+            ...manifest!,
+            entries: manifest!.entries.filter(
+              (entry) => entry.phase === 'post',
+            ),
+          },
+          result.records,
+        ),
+        scenario.name,
+      ).toEqual({ missing: [], unexpected: [] });
+    } finally {
+      rmSync(workdir, { recursive: true, force: true });
+    }
+  }
+}, 60_000);


### PR DESCRIPTION
Campaign attempts used colon-separated logical IDs directly as directory names. npm then split the local node_modules/.bin entry at those colons, so installed commands failed to resolve. Encode the filesystem component at directory creation while keeping logical identities intact; a real npm regression exercises the prepared path and checks that percent-containing IDs stay distinct.

The conversational no-spec scenario also rejected wording its rubric explicitly permits. Remove that lexical post-check and refresh its manifest, measurement references and template hashes, retaining plan-exists and no-spec-created checks. The unchanged rubric still governs header meaning and requirements. Regression tests execute the real scenario checks for equivalent wording, missing plans and fabricated specs.

Validation: targeted RED/GREEN regressions, independent task and final reviews, full local check (3,973 runner tests, 40 platform skips, 144 dashboard tests; lint/typecheck clean) and scenario validation. Original F28 results remain preserved. This patch launches no campaign and does not establish grader calibration or release acceptance.

Tracking: PRI-2874.
